### PR TITLE
Allow/improve displaying passwords in plain text (#2013190)

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.glade
+++ b/pyanaconda/ui/gui/spokes/installation_source.glade
@@ -467,6 +467,8 @@
                         <property name="invisible-char">●</property>
                         <property name="activates-default">True</property>
                         <signal name="changed" handler="on_proxyPasswordEntry_changed" swapped="no"/>
+                        <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="map" handler="on_password_entry_map" swapped="no"/>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
@@ -1271,6 +1273,8 @@
                                         <property name="visibility">False</property>
                                         <property name="invisible-char">●</property>
                                         <signal name="changed" handler="on_repoProxy_changed" swapped="no"/>
+                                        <signal name="icon-release" handler="on_repoProxyPassword_icon_clicked" swapped="no"/>
+                                        <signal name="map" handler="on_repoProxyPassword_entry_map" swapped="no"/>
                                       </object>
                                       <packing>
                                         <property name="left-attach">1</property>

--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -48,7 +48,8 @@ from pyanaconda.ui.gui.helpers import GUIDialogInputCheckHandler, GUISpokeInputC
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.gui.utils import blockedHandler, fire_gtk_action, find_first_child
-from pyanaconda.ui.gui.utils import gtk_call_once, really_hide, really_show, fancy_set_sensitive
+from pyanaconda.ui.gui.utils import gtk_call_once, really_hide, really_show, fancy_set_sensitive, \
+    set_password_visibility
 from pyanaconda.threading import threadMgr, AnacondaThread
 from pyanaconda.payload import utils as payload_utils
 from pyanaconda.payload.manager import payloadMgr, PayloadState
@@ -190,6 +191,19 @@ class ProxyDialog(GUIObject, GUIDialogInputCheckHandler):
     def on_proxy_auth_toggled(self, button, *args):
         self._proxy_auth_box.set_sensitive(button.get_active())
         self._proxy_validate.update_check_status()
+
+    def on_password_icon_clicked(self, entry, icon_pos, event):
+        """Called by Gtk callback when the icon of a password entry is clicked."""
+        set_password_visibility(entry, not entry.get_visibility())
+
+    def on_password_entry_map(self, entry):
+        """Called when a proxy password entry widget is going to be displayed.
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then closed the dialog.
+        """
+        set_password_visibility(entry, False)
 
     def refresh(self):
         GUIObject.refresh(self)
@@ -1882,6 +1896,19 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             repo.proxy = proxy.url
         except ProxyStringError as e:
             log.error("Failed to parse proxy - %s:%s@%s: %s", username, password, url, e)
+
+    def on_repoProxyPassword_icon_clicked(self, entry, icon_pos, event):
+        """Called by Gtk callback when the icon of a password entry is clicked."""
+        set_password_visibility(entry, not entry.get_visibility())
+
+    def on_repoProxyPassword_entry_map(self, entry):
+        """Called when a repo proxy password entry widget is going to be displayed.
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then closed the dialog.
+        """
+        set_password_visibility(entry, False)
 
     def on_repoStore_row_changed(self, model, path, itr, user_data=None):
         self._duplicate_repo_check.update_check_status()

--- a/pyanaconda/ui/gui/spokes/root_password.glade
+++ b/pyanaconda/ui/gui/spokes/root_password.glade
@@ -82,6 +82,7 @@
                         <property name="invisible_char">●</property>
                         <signal name="changed" handler="on_password_changed" swapped="no"/>
                         <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="map" handler="on_password_entry_map" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
@@ -102,6 +103,7 @@
                         <property name="activates_default">True</property>
                         <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
                         <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="map" handler="on_password_entry_map" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_confirmation_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>

--- a/pyanaconda/ui/gui/spokes/root_password.py
+++ b/pyanaconda/ui/gui/spokes/root_password.py
@@ -142,12 +142,6 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
         self._password_bar.add_offset_value("medium", 3)
         self._password_bar.add_offset_value("high", 4)
 
-        # set visibility of the password entries
-        # - without this the password visibility toggle icon will
-        #   not be shown
-        set_password_visibility(self.password_entry, False)
-        set_password_visibility(self.password_confirmation_entry, False)
-
         # Send ready signal to main event loop
         hubQ.send_ready(self.__class__.__name__)
 
@@ -314,6 +308,16 @@ class PasswordSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler)
     def on_password_icon_clicked(self, entry, icon_pos, event):
         """Called by Gtk callback when the icon of a password entry is clicked."""
         set_password_visibility(entry, not entry.get_visibility())
+
+    def on_password_entry_map(self, entry):
+        """Called when a password entry widget is going to be displayed.
+
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then left the spoke, for example.
+        """
+        set_password_visibility(entry, False)
 
     def on_back_clicked(self, button):
         # the GUI spoke input check handler handles the spoke exit logic for us

--- a/pyanaconda/ui/gui/spokes/subscription.glade
+++ b/pyanaconda/ui/gui/spokes/subscription.glade
@@ -196,6 +196,8 @@
                                                 <property name="visibility">False</property>
                                                 <property name="invisible-char">●</property>
                                                 <signal name="changed" handler="on_password_entry_changed" swapped="no"/>
+                                                <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                                                <signal name="map" handler="on_password_entry_map" swapped="no"/>
                                               </object>
                                               <packing>
                                                 <property name="left-attach">1</property>
@@ -697,6 +699,8 @@
                                                     <property name="visibility">False</property>
                                                     <property name="invisible-char">●</property>
                                                     <signal name="changed" handler="on_http_proxy_password_entry_changed" swapped="no"/>
+                                                    <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                                                    <signal name="map" handler="on_password_entry_map" swapped="no"/>
                                                   </object>
                                                   <packing>
                                                     <property name="left-attach">1</property>

--- a/pyanaconda/ui/gui/spokes/subscription.py
+++ b/pyanaconda/ui/gui/spokes/subscription.py
@@ -44,6 +44,7 @@ from pyanaconda.modules.common.task import sync_run_task, async_run_task
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.spokes.lib.subscription import fill_combobox, \
     populate_attached_subscriptions_listbox
+from pyanaconda.ui.gui.utils import set_password_visibility
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.communication import hubQ
 from pyanaconda.ui.lib.subscription import username_password_sufficient, org_keys_sufficient, \
@@ -328,6 +329,20 @@ class SubscriptionSpoke(NormalSpoke):
         self.subscription_request.account_password.set_secret(entered_text)
         self._update_registration_state()
 
+    def on_password_icon_clicked(self, entry, icon_pos, event):
+        """Called by Gtk callback when the icon of a password entry is clicked."""
+        set_password_visibility(entry, not entry.get_visibility())
+
+    def on_password_entry_map(self, entry):
+        """Called when a password entry widget is going to be displayed.
+
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then left the spoke, for example.
+        """
+        set_password_visibility(entry, False)
+
     def on_select_organization_combobox_changed(self, combobox):
         log.debug("Subscription GUI: organization selected for account: %s",
                   combobox.get_active_id())
@@ -466,6 +481,9 @@ class SubscriptionSpoke(NormalSpoke):
 
     def on_register_button_clicked(self, button):
         log.debug("Subscription GUI: register button clicked")
+        # hide the passwords during the registration process
+        set_password_visibility(self._password_entry, False)
+        set_password_visibility(self._http_proxy_password_entry, False)
         self._register()
 
     def on_unregister_button_clicked(self, button):

--- a/pyanaconda/ui/gui/spokes/user.glade
+++ b/pyanaconda/ui/gui/spokes/user.glade
@@ -170,6 +170,7 @@
                         <property name="invisible-char">●</property>
                         <signal name="changed" handler="on_password_changed" swapped="no"/>
                         <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="map" handler="on_password_entry_map" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Password</property>
@@ -189,6 +190,7 @@
                         <property name="invisible-char">●</property>
                         <signal name="changed" handler="on_password_confirmation_changed" swapped="no"/>
                         <signal name="icon-release" handler="on_password_icon_clicked" swapped="no"/>
+                        <signal name="map" handler="on_password_entry_map" swapped="no"/>
                         <child internal-child="accessible">
                           <object class="AtkObject" id="password_confirmation_entry-atkobject">
                             <property name="AtkObject::accessible-name" translatable="yes">Confirm Password</property>

--- a/pyanaconda/ui/gui/spokes/user.py
+++ b/pyanaconda/ui/gui/spokes/user.py
@@ -377,12 +377,6 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
         self._advanced_user_dialog = AdvancedUserDialog(self)
         self._advanced_user_dialog.initialize()
 
-        # set the visibility of the password entries
-        # - without this the password visibility toggle icon will
-        #   not be shown
-        set_password_visibility(self.password_entry, False)
-        set_password_visibility(self.password_confirmation_entry, False)
-
         # report that we are done
         self.initialize_done()
 
@@ -526,6 +520,16 @@ class UserSpoke(FirstbootSpokeMixIn, NormalSpoke, GUISpokeInputCheckHandler):
     def on_password_icon_clicked(self, entry, icon_pos, event):
         """Called by Gtk callback when the icon of a password entry is clicked."""
         set_password_visibility(entry, not entry.get_visibility())
+
+    def on_password_entry_map(self, entry):
+        """Called when a password entry widget is going to be displayed.
+
+        - Without this the password visibility toggle icon would not be shown.
+        - The password should be hidden every time the entry widget is displayed
+          to avoid showing the password in plain text in case the user previously
+          displayed the password and then left the spoke, for example.
+        """
+        set_password_visibility(entry, False)
 
     def on_username_set_by_user(self, editable, data=None):
         """Called by Gtk on user-driven changes to the username field.


### PR DESCRIPTION
The root and user spokes already allowed to display the passwords in plain text, but they stayed displayed in plain text after re-entering the spokes. Fix this by always using the invisible characters by default when the entry widget is displayed.

Also allow to display plain text passwords on the subscription and installation source spokes.

Resolves: rhbz#2013190

Ported from https://github.com/rhinstaller/anaconda/pull/4625. Since the source spoke design is slightly different in RHEL-9, the commit for proxy passwords for repositories on the installation source spoke was not possible to easily cherry-pick and was re-implemented. So that's the biggest change comparing to the original PR.