### PR TITLE
Fix inst.proxy configuration in dracut to allow stage2 image download

### DIFF
--- a/docs/release-notes/fix-proxy-for-downloading-installation-image.rst
+++ b/docs/release-notes/fix-proxy-for-downloading-installation-image.rst
@@ -1,0 +1,12 @@
+:Type: Kickstart
+:Summary: The installation program now correctly processes the proxy configuration (#2177219)
+
+:Description:
+    Previously, the installation program did not correctly process the ``--proxy`` option of the
+    ``url`` Kickstart command or ``inst.proxy`` kernel boot parameter. As a consequence, you could
+    not use the specified proxy to fetch the installation image. With this update, the issue
+    is fixed and proxy works as expected.
+
+:Links:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2177219
+    - https://github.com/rhinstaller/anaconda/pull/4828

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -110,6 +110,11 @@ if getargbool 0 inst.noverifyssl; then
     echo "rd.noverifyssl" >> /etc/cmdline.d/75-anaconda-options.conf
 fi
 
+# add proxy= to the dracut so stage1 downloads (stage2,kickstart...) don't ignore inst.proxy
+if proxy=$(getarg inst.proxy); then
+    echo "proxy=$proxy" >> /etc/cmdline.d/75-anaconda-options.conf
+fi
+
 # updates
 check_removed_no_inst_arg "updates" "inst.updates"
 if updates=$(getarg inst.updates); then

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -157,7 +157,7 @@ class DracutURL(Url, DracutArgsMixin):
         if self.noverifyssl:
             args.append("rd.noverifyssl")
         if self.proxy:
-            args.append("inst.proxy=%s" % self.proxy)
+            args.append("proxy=%s" % self.proxy)
 
         return "\n".join(args)
 

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -97,6 +97,14 @@ class AnacondaArgumentParser(ArgumentParser):
         self.removed_no_inst_bootargs = []
         self.bootarg_prefix = kwargs.pop("bootarg_prefix", "")
         self.require_prefix = kwargs.pop("require_prefix", True)
+
+        # List of boot options which are correct with and without the inst. prefix
+        # Please add here options which are processed by us but also by someone
+        # else during the boot.
+        # NOTE: Adding this to add_argument() directly could be problematic because just specific
+        # long option variants could be allowed from multiple, so it would have to be list which
+        # somehow kills the benefit.
+        self._require_prefix_ignore_list = ["proxy"]
         ArgumentParser.__init__(self, description=DESCRIPTION,
                                 formatter_class=lambda prog: HelpFormatter(
                                     prog, max_help_position=LEFT_PADDING, width=help_width),
@@ -130,6 +138,7 @@ class AnacondaArgumentParser(ArgumentParser):
                         "conflicting bootopt string: %s" % b, option)
                 else:
                     self._boot_arg[b] = option
+
         return option
 
     def _get_bootarg_option(self, arg):
@@ -150,7 +159,8 @@ class AnacondaArgumentParser(ArgumentParser):
         option = self._boot_arg.get(arg)
 
         if option and self.bootarg_prefix and not prefixed_option:
-            self.removed_no_inst_bootargs.append(arg)
+            if arg not in self._require_prefix_ignore_list:
+                self.removed_no_inst_bootargs.append(arg)
 
         # From Fedora 34 this prefix is required. However, leave the code here for some time to
         # tell users that we are ignoring the old variants.

--- a/tests/unit_tests/dracut_tests/test_parse_kickstart.py
+++ b/tests/unit_tests/dracut_tests/test_parse_kickstart.py
@@ -94,7 +94,7 @@ class ParseKickstartTestCase(BaseTestCase):
         assert len(lines) == 3, lines
         assert lines[0] == "inst.repo=https://host.at.foo.com/path/to/tree", lines
         assert lines[1] == "rd.noverifyssl", lines
-        assert lines[2] == "inst.proxy=http://localhost:8123", lines
+        assert lines[2] == "proxy=http://localhost:8123", lines
 
     def test_updates(self):
         with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:


### PR DESCRIPTION
Fix proxy is not used when downloading stage2 image.

This fix is handling two cases:

* kickstart has `url --proxy` which should be used also to download stage2 image with proxy
* `inst.proxy` is not used by dracut to download stuff (like stage2 image)
* do not request `inst.` prefix for `proxy` kernel boot argument because that is valid option for Dracut (and maybe others) 

*Resolves: rhbz#2177219*

Backport of: https://github.com/rhinstaller/anaconda/pull/4794