### PR TITLE
Fix "proxy" boot option is printing inst. warning (#2177219)

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -100,6 +100,14 @@ class AnacondaArgumentParser(ArgumentParser):
         self.removed_no_inst_bootargs = []
         self.bootarg_prefix = kwargs.pop("bootarg_prefix", "")
         self.require_prefix = kwargs.pop("require_prefix", True)
+
+        # List of boot options which are correct with and without the inst. prefix
+        # Please add here options which are processed by us but also by someone
+        # else during the boot.
+        # NOTE: Adding this to add_argument() directly could be problematic because just specific
+        # long option variants could be allowed from multiple, so it would have to be list which
+        # somehow kills the benefit.
+        self._require_prefix_ignore_list = ["proxy"]
         ArgumentParser.__init__(self, description=DESCRIPTION,
                                 formatter_class=lambda prog: HelpFormatter(
                                     prog, max_help_position=LEFT_PADDING, width=help_width),
@@ -133,6 +141,7 @@ class AnacondaArgumentParser(ArgumentParser):
                         "conflicting bootopt string: %s" % b, option)
                 else:
                     self._boot_arg[b] = option
+
         return option
 
     def _get_bootarg_option(self, arg):
@@ -153,7 +162,8 @@ class AnacondaArgumentParser(ArgumentParser):
         option = self._boot_arg.get(arg)
 
         if option and self.bootarg_prefix and not prefixed_option:
-            self.removed_no_inst_bootargs.append(arg)
+            if arg not in self._require_prefix_ignore_list:
+                self.removed_no_inst_bootargs.append(arg)
 
         # From Fedora 34 this prefix is required. However, leave the code here for some time to
         # tell users that we are ignoring the old variants.


### PR DESCRIPTION
We warn user that our proxy kernel command line option should be used with the `inst.` prefix. However, it is also processed by Dracut (and maybe others) to set the curl calls correctly.

We are even generating proxy command for Dracut when we download stage2 based on the KS url with `--proxy` parameter.

For this command we should not warn user about the use of the 'inst.' prefix because both variants are correct.

*Related: rhbz#2177219*
(cherry picked from commit e82f6765c299d3a417c9cd27278b7fbd51ae4bb6)

This is additional fix for PR: https://github.com/rhinstaller/anaconda/pull/4794