### PR TITLE
Set the correct permissions for forks (#infra)

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -3,7 +3,10 @@ on:
   pull_request:
     types: [opened]
 
+# Without the check permission we are getting error - see more info Here
+# https://github.com/actions/labeler/issues/12
 permissions:
+  checks: write
   contents: read
   pull-requests: write
 


### PR DESCRIPTION
Fork has lower permissions as external contributor which in this case is an issue because labeler needs to have also the `checks: write` set.

Without this change PRs from forks are getting:
```
Error: HttpError: Resource not accessible by integration
Error: Resource not accessible by integration
```