### PR TITLE
Master fix add label permissions

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,15 +10,14 @@
 
 # Always apply target fedora version to any changes
 f39:
-- '*'
-- '**/*'
+- '**'
 
 webui:
-- ui/webui/*
+- 'ui/webui/**'
 
 documentation:
- - docs/*
+- 'docs/**'
 
 infrastructure:
-- '.github'
-- dockerfile
+- '.github/**'
+- 'dockerfile/**'

--- a/.github/labeler.yml.j2
+++ b/.github/labeler.yml.j2
@@ -7,15 +7,14 @@ f{$ rawhide_fedora_version $}:
 {% else %}
 f{$ branched_fedora_version $}:
 {% endif %}
-- '*'
-- '**/*'
+- '**'
 
 webui:
-- ui/webui/*
+- 'ui/webui/**'
 
 documentation:
- - docs/*
+- 'docs/**'
 
 infrastructure:
-- '.github'
-- dockerfile
+- '.github/**'
+- 'dockerfile/**'

--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -1,9 +1,12 @@
 name: Add PR labels automatically
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
+# Without the check permission we are getting error - see more info Here
+# https://github.com/actions/labeler/issues/12
 permissions:
+  checks: write
   contents: read
   pull-requests: write
 

--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -16,3 +16,5 @@ jobs:
     steps:
       - name: Add labels
         uses: actions/labeler@v4
+        with:
+          dot: true


### PR DESCRIPTION
Fix autolabel workflow we have for adding labels to the PRs automatically. There are two issues with it now:
- permission from fork are not enough for this to work
- The dot directories are excluded by default