### PR TITLE
Improve btrfs support in tui mountpoint assignment

### DIFF
--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -290,3 +290,24 @@ def find_unconfigured_luks(storage):
         devices.append(device)
 
     return devices
+
+def resolve_device(storage, dev_spec):
+    """Return the device matching the provided device specification.
+
+    A wrapper of Blivet's resolve_device function supporting also
+    resolution of btrfs volumes specified by UUID of the volume
+    and name of the subvolume, as:
+    'UUID=2252ec30-1fce-4f8e-bdef-c50c3a44ede4@root'
+
+    :param storage: an instance of Blivet
+    :param dev_spec: a string describing a block device
+    :returns: the device
+    :rtype: :class:`~.devices.StorageDevice` or None
+    """
+
+    options = None
+    if dev_spec.startswith("UUID") and "@" in dev_spec:
+        dev_spec, _, subvol = dev_spec.partition("@")
+        options = "subvol={}".format(subvol)
+
+    return storage.devicetree.resolve_device(dev_spec, options=options)

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -28,7 +28,7 @@ from pyanaconda.modules.common.errors.storage import UnknownDeviceError
 from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
     DeviceFormatData, OSData
 from pyanaconda.modules.storage.devicetree.utils import get_required_device_size, \
-    get_supported_filesystems
+    get_supported_filesystems, resolve_device
 
 log = get_module_logger(__name__)
 
@@ -347,13 +347,16 @@ class DeviceTreeViewer(ABC):
         The spec can be anything from a device name (eg: 'sda3') to a
         device node path (eg: '/dev/mapper/fedora-root') to something
         like 'UUID=xyz-tuv-qrs' or 'LABEL=rootfs'.
+        For btrfs subvolumes the subvolume can be specified by the UUID of
+        the volume and the name of the subvolume, as:
+        'UUID=2252ec30-1fce-4f8e-bdef-c50c3a44ede4@root'
 
         If no device is found, return an empty string.
 
         :param dev_spec: a string describing a block device
         :return: a device name or an empty string
         """
-        device = self.storage.devicetree.resolve_device(dev_spec)
+        device = resolve_device(self.storage, dev_spec)
 
         if not device:
             return ""

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -107,6 +107,9 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         The spec can be anything from a device name (eg: 'sda3') to a
         device node path (eg: '/dev/mapper/fedora-root') to something
         like 'UUID=xyz-tuv-qrs' or 'LABEL=rootfs'.
+        For btrfs subvolumes the subvolume can be specified by the UUID of
+        the volume and the name of the subvolume, as:
+        'UUID=2252ec30-1fce-4f8e-bdef-c50c3a44ede4@root'
 
         If no device is found, return an empty string.
 

--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -134,7 +134,7 @@ class ManualPartitioningModule(PartitioningModule):
 
         for device in self.storage.devicetree.devices:
 
-            if not device.isleaf and not device.raw_device.type == "btrfs subvolume" and not device.raw_device.type == "btrfs volume":
+            if not device.isleaf and not device.raw_device.type == "btrfs subvolume":
                 continue
 
             # Is the device usable?

--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -170,11 +170,23 @@ class ManualPartitioningModule(PartitioningModule):
         request.device_spec = self._btrfs_device_spec(device) or device.path
         request.format_type = device.format.type or ""
         request.reformat = False
+        request.mount_options += self._btrfs_mount_options(device)
 
         if device.format.mountable and device.format.mountpoint:
             request.mount_point = device.format.mountpoint
 
         return request
+
+    def _btrfs_mount_options(self, device):
+        """Get btrfs subvolume mount options.
+
+        :param device: a Blivet's device object
+        :return: a btrfs subvolume mount options
+        """
+        if device.raw_device.type == "btrfs subvolume":
+            return "subvol={}".format(device.name)
+        else:
+            return ""
 
     def _btrfs_device_spec(self, device):
         """Get btrfs device specification of the device.

--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -22,6 +22,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.storage.partitioning.automatic.noninteractive_partitioning import \
     NonInteractivePartitioningTask
+from pyanaconda.modules.storage.devicetree.utils import resolve_device
 
 log = get_module_logger(__name__)
 
@@ -59,7 +60,7 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
         reformat = mount_data.reformat
         format_type = mount_data.format_type
 
-        device = storage.devicetree.resolve_device(device_spec)
+        device = resolve_device(storage, device_spec)
         if device is None:
             raise StorageError(
                 _("Unknown or invalid device '{}' specified").format(device_spec)

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -714,10 +714,17 @@ class MountPointAssignSpoke(NormalTUISpoke):
         )
 
         # Generate the description.
-        description = "{} ({})".format(request.device_spec, Size(device_data.size))
+        if device_data.type in ("btrfs volume", "btrfs subvolume"):
+            title = device_data.name
+            format_detail = device_data.type
+        else:
+            title = request.device_spec
+            format_detail = request.format_type
+
+        description = "{} ({})".format(title, Size(device_data.size))
 
         if request.format_type:
-            description += "\n {}".format(request.format_type)
+            description += "\n {}".format(format_detail)
 
             if request.reformat:
                 description += "*"


### PR DESCRIPTION
This PR adds support for btrfs subvolumes reformatting/clearing in mount point assignment with the outlook of using mount point assignment for /home reuse use case on Fedora Workstation (would require reformatting of boot partitions and 'reformatting' / clearing of the root btrfs subvolume). The support is added to Anaconda but some bits could be perhaps moved to Blivet. The PR is assuming there will be no substantial update of device abstractions to accomodate for btrfs volume / subvolume characteristics in near future.

Possible issues and follow-ups:
1) The support for btrfs volume/subvolume device specification resolution should be moved to Blivet, and proper specification (currently it is UUID=uuid@subvolume) should be agreed on (it is pretty arbitrary now).
2) Maybe we could have 'clear' action support in blivet which would replace the _recreate_device function.
3) The display of subvolumes could be better (including a volume id?)
4) We may want to handle also volumes:
  - only leaf volumes ? or warning with non-leaf volumes ?
  - allow to change format of reformatted volume ?
  - support handling volumes residing on single / multiple devices ?
5) possible follow up improvements in GUI (allow reformatting of btrfs subvolumes in Custom Partitioning GUI: https://bugzilla.redhat.com/show_bug.cgi?id=2186158
6) using existing mount options, like compression (compress=zstd:1)

Screenshot of mount-point assignment with /home preserved:
![btrfs_tui_reuse_home](https://github.com/rhinstaller/anaconda/assets/1220237/663bde46-d85d-4232-8425-afcf53d46eb3)


