### PR TITLE
webui: increasing timeout for download cockpit rpms

### DIFF
--- a/ui/webui/test/build-rpms
+++ b/ui/webui/test/build-rpms
@@ -35,7 +35,7 @@ def build_rpms(srpm, image, verbose, quick):
         # FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies
         # This will change once we include this changes upstream and start building boot.iso with the new dependencies
         # Then we can safely remove this workaround
-        machine.execute(f"dnf download --downloaddir /var/tmp/build/ {missing_packages}", stdout=sys.stdout)
+        machine.execute(f"dnf download --downloaddir /var/tmp/build/ {missing_packages}", stdout=sys.stdout, timeout=1800)
 
         # download rpms
         vm_rpms = machine.execute("find /var/tmp/build -name '*.rpm' -not -name '*.src.rpm'").strip().split()


### PR DESCRIPTION
This PR is to increase the timeout for download cockpit rpms to avoid an error like the following example:
```
File "/home/acruzgon/anaconda/anaconda/ui/webui/bots/machine/machine_core/timeout.py", line 41, in handle_timeout
    raise RuntimeError(self.error_message)
RuntimeError: Timed out on 'dnf download --downloaddir /var/tmp/build/ cockpit-ws cockpit-bridge firefox dbus-glib'
make[1]: *** [Makefile:743: ../../updates.img] Error 1
make[1]: Leaving directory '/home/acruzgon/anaconda/anaconda/ui/webui'
make: *** [Makefile:747: create-updates.img] Error 2
```

Also to avoid any inconvenient with contributors with slower network connections. 