### PR TITLE
webui: add expected journal messages coming from cockpit's new python bridge

### DIFF
--- a/ui/webui/test/anacondalib.py
+++ b/ui/webui/test/anacondalib.py
@@ -30,3 +30,8 @@ from testlib import MachineCase  # pylint: disable=import-error
 
 class VirtInstallMachineCase(MachineCase):
     MachineCase.machine_class = VirtInstallMachine
+
+    def setUp(self):
+        super().setUp()
+
+        self.allow_journal_messages('.*cockpit.bridge-WARNING: Could not start ssh-agent.*')


### PR DESCRIPTION
Fixes the currently red CI because of python cockpit-bridge new messages https://cockpit-logs.us-east-1.linodeobjects.com/pull-4837-20230615-124756-1e15ed5b-fedora-rawhide-boot/log.html#1