### PR TITLE
Add build of anaconda-iso-creator autobuild (#infra)

### DIFF
--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-type: ['ci', 'rpm']
+        container-type: ['ci', 'rpm', 'iso-creator']
     env:
       CI_TAG: '${{ inputs.container-tag }}'
     timeout-minutes: 60

--- a/.github/workflows/container-rebuild-action.yml.j2
+++ b/.github/workflows/container-rebuild-action.yml.j2
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container-type: ['ci', 'rpm']
+        container-type: ['ci', 'rpm', 'iso-creator']
     env:
       CI_TAG: '${{ inputs.container-tag }}'
     timeout-minutes: 60


### PR DESCRIPTION
Autobuild container image for building of the ISO.

This is just a small draft quickly created to find out if we want to have such a thing.

Question to answer **are we fine to have this without tests?** The issue with running the build test is that you need to have KVM access which means not a GH runners.