### PR TITLE
Revert "WebUI: explicitly specify GITHUB_BASE for pixel test commands"

### DIFF
--- a/ui/webui/test/README.rst
+++ b/ui/webui/test/README.rst
@@ -139,11 +139,11 @@ Locally just copy the broken tests images to the `test/reference` directory. How
 option to deal with this is to use automation which will download all the broken images from
 fail test on PR::
 
-    GITHUB_BASE=rhinstaller/anaconda ./test/common/pixel-tests fetch <link to HTML with failed tests>
+    ./test/common/pixel-tests fetch <link to HTML with failed tests>
 
 Example of such a call::
 
-    GITHUB_BASE=rhinstaller/anaconda ./test/common/pixel-tests fetch https://cockpit-logs.us-east-1.linodeobjects.com/pull-4551-20230322-101308-479c2fc1-fedora-rawhide-boot-rhinstaller-anaconda
+    ./test/common/pixel-tests fetch https://cockpit-logs.us-east-1.linodeobjects.com/pull-4551-20230322-101308-479c2fc1-fedora-rawhide-boot-rhinstaller-anaconda
 
 The link will be link accessible from the `Details` button on GitHub PR with failed tests.
 


### PR DESCRIPTION
This reverts commit dc9b3a5389f70bed4afc55548120741d0507a77a.

When pulling pixel test references with the full link GITHUB_BASE is not needed. This would be needed if we would use only the PR number.
