### PR TITLE
webui: provide an About screen

### DIFF
--- a/ui/webui/src/components/AnacondaHeader.jsx
+++ b/ui/webui/src/components/AnacondaHeader.jsx
@@ -27,6 +27,8 @@ import {
 } from "@patternfly/react-core";
 import { InfoCircleIcon } from "@patternfly/react-icons";
 
+import { HeaderKebab } from "./HeaderKebab.jsx";
+
 const _ = cockpit.gettext;
 
 export const AnacondaHeader = ({ beta, title }) => {
@@ -66,6 +68,7 @@ export const AnacondaHeader = ({ beta, title }) => {
                     <Text component="h1">{title}</Text>
                 </TextContent>
                 {betanag}
+                <HeaderKebab />
             </Flex>
         </PageSection>
     );

--- a/ui/webui/src/components/HeaderKebab.jsx
+++ b/ui/webui/src/components/HeaderKebab.jsx
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+
+import React, { useState, useEffect } from "react";
+import {
+    AboutModal,
+    Button,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    Dropdown,
+    DropdownItem,
+    DropdownPosition,
+    Flex,
+    KebabToggle,
+    Stack,
+    StackItem,
+} from "@patternfly/react-core";
+import { ExternalLinkAltIcon } from "@patternfly/react-icons";
+
+import { read_os_release as readOsRelease } from "os-release.js";
+import { getAnacondaVersion } from "../helpers/product.js";
+
+import "./HeaderKebab.scss";
+
+const _ = cockpit.gettext;
+
+const AboutModalVersions = () => {
+    const [anacondaVersion, setAnacondaVersion] = useState("");
+
+    useEffect(() => {
+        getAnacondaVersion().then(content => setAnacondaVersion(content));
+    }, []);
+
+    return (
+        <DescriptionList isHorizontal id="about-modal-versions">
+            <DescriptionListGroup>
+                <DescriptionListTerm>Anaconda</DescriptionListTerm>
+                <DescriptionListDescription>{anacondaVersion}</DescriptionListDescription>
+            </DescriptionListGroup>
+        </DescriptionList>
+    );
+};
+
+const ProductName = () => {
+    const [osRelease, setOsRelease] = useState();
+
+    useEffect(() => {
+        readOsRelease().then(setOsRelease);
+    }, []);
+
+    if (!osRelease) {
+        return null;
+    }
+
+    return (
+        <Stack hasGutter>
+            <StackItem id="about-modal-title" className="title">{cockpit.format("$0 installer", osRelease.PRETTY_NAME)}</StackItem>
+            <StackItem id="about-modal-subtitle" className="subtitle">{_("Powered by Anaconda")}</StackItem>
+        </Stack>
+    );
+};
+
+const AnacondaAboutModal = ({ isModalOpen, setIsAboutModalOpen }) => {
+    const toggleModal = () => {
+        setIsAboutModalOpen(!isModalOpen);
+    };
+
+    return (
+        <AboutModal
+          id="about-modal"
+          isOpen={isModalOpen}
+          noAboutModalBoxContentContainer
+          onClose={toggleModal}
+          productName={<ProductName />}
+        >
+            <Flex direction={{ default: "column" }} justifyContent={{ default: "justifyContentSpaceBetween" }}>
+                <AboutModalVersions />
+                <Button
+                  isInline
+                  id="anaconda-page-button"
+                  variant="link"
+                  icon={<ExternalLinkAltIcon />}
+                  href="https://github.com/rhinstaller/anaconda"
+                  target="_blank"
+                  component="a">
+                    {_("Anaconda project page")}
+                </Button>
+            </Flex>
+        </AboutModal>
+    );
+};
+
+export const HeaderKebab = () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
+
+    const onToggle = isOpen => {
+        setIsOpen(isOpen);
+    };
+    const onFocus = () => {
+        const element = document.getElementById("toggle-kebab");
+        element.focus();
+    };
+    const onSelect = () => {
+        setIsOpen(false);
+        onFocus();
+    };
+
+    const handleAboutModal = () => {
+        setIsAboutModalOpen(true);
+    };
+
+    const dropdownItems = [
+        <DropdownItem id="about-modal-dropdown-item" key="separated link" onClick={handleAboutModal}>
+            {_("About")}
+        </DropdownItem>,
+    ];
+    return (
+        <>
+            <Dropdown
+              position={DropdownPosition.right}
+              onSelect={onSelect}
+              toggle={
+                  <KebabToggle
+                    id="toggle-kebab"
+                    onToggle={onToggle}
+                  />
+              }
+              isOpen={isOpen}
+              isPlain
+              dropdownItems={dropdownItems}
+            />
+            {isAboutModalOpen &&
+            <AnacondaAboutModal
+              isModalOpen={isAboutModalOpen}
+              setIsAboutModalOpen={setIsAboutModalOpen}
+            />}
+        </>
+    );
+};

--- a/ui/webui/src/components/HeaderKebab.scss
+++ b/ui/webui/src/components/HeaderKebab.scss
@@ -1,0 +1,50 @@
+@import "global-variables";
+
+/* Scale down the about box to be a little smaller */
+@media only screen and (min-width: 992px) {
+  .pf-c-about-modal-box {
+    --pf-c-about-modal-box--lg--MaxWidth: 62rem;
+    --pf-c-about-modal-box--lg--MaxHeight: 38rem;
+    grid-template-rows: 3rem max-content auto;
+    grid-template-columns: 1fr 0fr;
+  }
+}
+
+/* Hide the logo and side graphic */
+.pf-c-about-modal-box__brand,
+.pf-c-about-modal-box__strapline,
+.pf-c-about-modal-box__hero {
+    display: none;
+}
+
+/* Make the close button more obvious, since we hide the side graphic*/
+.pf-c-about-modal-box__close .pf-c-button.pf-m-plain {
+  --pf-c-about-modal-box__close--c-button--BackgroundColor: var(--pf-global--BackgroundColor--dark-200);
+  position: absolute;
+}
+.pf-c-about-modal-box__close .pf-c-button.pf-m-plain:hover {
+  --pf-c-about-modal-box__close--c-button--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
+}
+
+.pf-c-about-modal-box {
+  .title {
+      font-size: var(--pf-c-title--m-3xl--FontSize);
+  }
+  .subtitle {
+    font-size: var(--pf-c-title--m-xl--FontSize);
+  }
+
+  .pf-c-about-modal-box__body {
+    height: 100%;
+
+    > .pf-l-flex {
+      height: 100%;
+    }
+
+    #about-modal-versions {
+      dt {
+        font-size: var(--pf-global--FontSize--md);
+      }
+    }
+  }
+}

--- a/ui/webui/src/helpers/product.js
+++ b/ui/webui/src/helpers/product.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+
+export const getAnacondaVersion = () => {
+    return cockpit
+            .spawn(["anaconda", "--version"])
+            .then((content) => content.split(" ").slice(-1)[0].replace("\n", ""));
+};

--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -66,6 +66,48 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         i.reach(i.steps.REVIEW)
         r.check_language("English (United States)")
 
+    def testAboutModal(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+
+        i.open()
+
+        # Obtain pretty name and versions from the CLI
+        pretty_name = m.execute("cat /etc/os-release | grep PRETTY_NAME | cut -d '\"' -f 2 | tr -d '\n'")
+        version = m.execute("anaconda --version | cut -d ' ' -f 2 | tail -1")
+
+        # Click on the kebab
+        b.click("#toggle-kebab")
+
+        # Click on the "About" item from the dropdown
+        b.click("#about-modal-dropdown-item")
+
+        # Expect PRETTY_NAME to be shown in modal title
+        b.wait_in_text("#about-modal-title", pretty_name)
+
+        # Expect "Powered by Anaconda" to be shown in modal subtitle
+        b.wait_in_text("#about-modal-subtitle", "Powered by Anaconda")
+
+        # Expect About modal body to be shown
+        b.wait_in_text("#about-modal-versions dt", "Anaconda")
+        b.wait_in_text("#about-modal-versions dd", version.strip())
+
+        # Expect button link for Anaconda project page to be shown
+        b.wait_in_text("#anaconda-page-button", "Anaconda project page")
+
+        # Pixel test the language step
+        b.assert_pixels(
+            ".pf-c-about-modal-box",
+            "about-modal",
+            ignore=["#about-modal-versions dd"],
+            wait_animations=False,
+        )
+
+        #Close about modal
+        b.click(".pf-c-button[aria-label='Close Dialog']")
+        b.wait_not_present("#about-modal")
+
 class TestQuit(anacondalib.VirtInstallMachineCase):
 
     def testQuitInstallation(self):


### PR DESCRIPTION
[INSTALLER-3489](https://issues.redhat.com/browse/INSTALLER-3489)

Provide an About screen for Anaconda Web UI using `AboutModal` PF component. 
![image](https://github.com/rhinstaller/anaconda/assets/88343229/bf155a6b-f24d-4cec-8f13-d920af50127a)
