### PR TITLE
Fix anaconda-rpm container for DNF5 (#infra)

### DIFF
--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
   dnf update -y; \
   # Install dependencies
   dnf install -y \
-  'dnf-command(copr)' \
+  dnf5-plugins \
   npm \
   git \
   curl \


### PR DESCRIPTION
The issue is that 'dnf-command(copr)' installs DNF 4 plugins not DNF 5.

https://github.com/rpm-software-management/dnf5/issues/566