### PR TITLE
Disable TFT tests until DNF5 breakage is resolved (#infra)

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -40,10 +40,12 @@ jobs:
     trigger: release
     dist_git_branches: main
 
-  - job: tests
-    trigger: pull_request
-    targets:
-      - fedora-rawhide
+# TODO: Return back the test when DNF5 issue is resolved
+# https://gitlab.com/testing-farm/tests/-/merge_requests/24
+#  - job: tests
+#   trigger: pull_request
+#    targets:
+#      - fedora-rawhide
 
   - job: copr_build
     trigger: pull_request

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -34,10 +34,12 @@ jobs:
     trigger: release
     dist_git_branches: main
 
-  - job: tests
-    trigger: pull_request
-    targets:
-      - fedora-rawhide
+# TODO: Return back the test when DNF5 issue is resolved
+# https://gitlab.com/testing-farm/tests/-/merge_requests/24
+#  - job: tests
+#   trigger: pull_request
+#    targets:
+#      - fedora-rawhide
 
   - job: copr_build
     trigger: pull_request


### PR DESCRIPTION
The DNF5 broke TFT tests executed by Packit. Let's disable these tests for two reasons:

- we don't know when this will be resolved and it's making our PRs red
- this is just smoke test (install anaconda) and we already have that in rpm-tests