### PR TITLE
WebUI: Change help drawer width

### DIFF
--- a/ui/webui/src/components/HelpDrawer.jsx
+++ b/ui/webui/src/components/HelpDrawer.jsx
@@ -38,7 +38,7 @@ export const HelpDrawer = ({ isExpanded, setIsExpanded, helpContent, children })
     };
 
     const panelContent = (
-        <DrawerPanelContent isResizable defaultSize="450px" minSize="150px">
+        <DrawerPanelContent isResizable defaultSize="28rem" minSize="185px" maxSize="50vw">
             <DrawerHead>
                 <span tabIndex={isExpanded ? 0 : -1} ref={drawerRef}>
                     {helpContent}


### PR DESCRIPTION
- Set max width to half of viewport,
- increase minimal width to prevent the
  "x" button being pushed by the help title,
- convert default size to rem.