### PR TITLE
Remove unused variable in TUI software selection

### DIFF
--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -85,8 +85,6 @@ class SoftwareSpoke(NormalTUISpoke):
         payloadMgr.add_listener(PayloadState.STARTED, self._payload_start)
         payloadMgr.add_listener(PayloadState.ERROR, self._payload_error)
 
-        self.shown_environment = False
-
     def initialize(self):
         """Initialize the spoke."""
         super().initialize()


### PR DESCRIPTION
Remove unused variable "shown_environment" added in https://github.com/rhinstaller/anaconda/commit/d373958c267ce55c03b3c770ddb64ed3819d5363 from the software selection spoke of the TUI.

I noticed this when it was too late, sorry about it.
