### PR TITLE
Split write network and hostname configuration

### DIFF
--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -153,9 +153,9 @@ class RunInstallationTask(InstallationTask):
 
         configuration_queue.append(os_config)
 
+        overwrite = payload.type in PAYLOAD_LIVE_TYPES
         # schedule network configuration (if required)
         if conf.target.can_configure_network and conf.system.provides_network_config:
-            overwrite = payload.type in PAYLOAD_LIVE_TYPES
             network_config = TaskQueue(
                 "Network configuration",
                 _("Writing network configuration")
@@ -166,6 +166,18 @@ class RunInstallationTask(InstallationTask):
                 (overwrite, )
             ))
             configuration_queue.append(network_config)
+        # schedule hostname configuration (if required)
+        if conf.system.can_change_hostname:
+            hostname_config = TaskQueue(
+                "Hostname configuration",
+                _("Writing hostname configuration")
+            )
+            hostname_config.append(Task(
+                "Hostname configuration",
+                network.write_configuration_hostname,
+                (overwrite, )
+            ))
+            configuration_queue.append(hostname_config)
 
         # add installation tasks for the Users DBus module
         if is_module_available(USERS):

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -54,7 +54,7 @@ _nm_client = None
 __all__ = ["get_supported_devices", "status_message", "wait_for_connectivity",
            "wait_for_connecting_NM_thread", "wait_for_network_devices", "wait_for_connected_NM",
            "initialize_network", "prefix_to_netmask", "netmask_to_prefix", "get_first_ip_address",
-           "is_valid_hostname", "check_ip_address", "get_nm_client", "write_configuration"]
+           "is_valid_hostname", "check_ip_address", "get_nm_client", "write_configuration", "write_configuration_hostname"]
 
 
 def get_nm_client():
@@ -273,6 +273,10 @@ def write_configuration(overwrite=False):
     task_proxy = NETWORK.get_proxy(task_path)
     sync_run_task(task_proxy)
 
+
+def write_configuration_hostname(overwrite=False):
+    """Install hostname configuration to target system."""
+    network_proxy = NETWORK.get_proxy()
     task_path = network_proxy.ConfigureHostnameWithTask(overwrite)
     task_proxy = NETWORK.get_proxy(task_path)
     sync_run_task(task_proxy)


### PR DESCRIPTION
When the parameter can_configure_network is disabled in the configuration, the file /etc/hostname is not written to the installed system.