### PR TITLE
webui: Start Web UI when the anaconda-webui package is installed

### DIFF
--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -202,7 +202,7 @@ class Anaconda(object):
 
         # this boot option is meant to be temporary, so just check it directly
         # from kernel boot command line like this
-        if "webui" in kernel_arguments:
+        if "webui" in kernel_arguments or os.path.exists("/usr/share/cockpit/anaconda-webui"):
             from pyanaconda.ui.webui import CockpitUserInterface
             self._intf = CockpitUserInterface(
                 None,


### PR DESCRIPTION
We do this by checking the /usr/share/cockpit/anaconda-webui path exists. If it exists, Web UI will be launched, regardless of the inst.webui option being present.