### PR TITLE
webui: replacing Tooltip for HelperText in Storage devices step

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -20,13 +20,14 @@ import React, { useState, useMemo } from "react";
 import {
     ActionList,
     Button,
+    HelperText,
+    HelperTextItem,
     Modal,
     ModalVariant,
     PageSection,
     PageSectionTypes,
     PageSectionVariants,
     Stack,
-    Tooltip,
     Wizard,
     WizardFooter,
     WizardContextConsumer,
@@ -359,6 +360,13 @@ const Footer = ({
                               setQuitWaitsConfirmation={setQuitWaitsConfirmation}
                               isBootIso={isBootIso}
                             />}
+                            {activeStep.id === "storage-devices" && !isFormValid &&
+                                <HelperText id="next-helper-text">
+                                    <HelperTextItem
+                                      variant="indeterminate">
+                                        {_("To continue, select the devices to install to.")}
+                                    </HelperTextItem>
+                                </HelperText>}
                             <ActionList>
                                 <Button
                                   variant="secondary"
@@ -368,7 +376,6 @@ const Footer = ({
                                 </Button>
                                 <Button
                                   id="installation-next-btn"
-                                  aria-describedby="next-tooltip-ref"
                                   variant={nextButtonVariant}
                                   isDisabled={
                                       !isFormValid ||
@@ -377,21 +384,6 @@ const Footer = ({
                                   onClick={() => goToNextStep(activeStep, onNext)}>
                                     {nextButtonText}
                                 </Button>
-                                {activeStep.id === "storage-devices" &&
-                                    <Tooltip
-                                      id="next-tooltip-ref"
-                                      content={
-                                          <div>
-                                              {_("To continue, select the devices to install to.")}
-                                          </div>
-                                      }
-                                      // Only show the tooltip on installation destination spoke that is not valid (no disks selected).
-                                      // NOTE: As PatternFly Button with isDisabled set apprently does not get any mouse events anymore,
-                                      //       we need to manually trigger the tooltip.
-                                      reference={() => document.getElementById("installation-next-btn")}
-                                      trigger="manual"
-                                      isVisible={!isFormValid}
-                                    />}
                                 <Button
                                   id="installation-quit-btn"
                                   style={{ marginLeft: "var(--pf-c-wizard__footer-cancel--MarginLeft)" }}

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -85,7 +85,7 @@ class Storage():
 
     @log_step()
     def wait_no_disks(self):
-        self.browser.wait_in_text("#next-tooltip-ref",
+        self.browser.wait_in_text("#next-helper-text",
                                   "To continue, select the devices to install to.")
 
     @log_step()


### PR DESCRIPTION
[INSTALLER-3418](https://issues.redhat.com/browse/INSTALLER-3418)

When there are no disks selected, the Next button is disabled and a helper text indicates user to make a disk selection in order to continue with installation. 
![image](https://github.com/rhinstaller/anaconda/assets/88343229/8be01c04-2356-4612-8e16-7d4770f2e8bb)
