### PR TITLE
webui: Disable strict host checking in SSH config snippet

### DIFF
--- a/ui/webui/test/README.rst
+++ b/ui/webui/test/README.rst
@@ -225,6 +225,8 @@ connect to the test VMs by typing `ssh test-updates`::
         Hostname 127.0.0.2
         Port 2201
         User root
+        StrictHostKeyChecking=no
+        UserKnownHostsFile=/dev/null
 
 Cockpit's CI
 ------------


### PR DESCRIPTION
Otherwise it won't be possible to connect to the VM once its restarted & has a different generated SSH key.