### PR TITLE
Docs: added to 'Common bugs and issues' workaround for setup on 4K block devices

### DIFF
--- a/docs/common-bugs.rst
+++ b/docs/common-bugs.rst
@@ -285,6 +285,18 @@ Bug in bootloader
     or ``storage.log`` for more information.
 :Solution: Could the bootloader team have a look at this bug, please?
 
+GRUB2 does not detect MD raid (level 1) 1.0 superblocks on 4k block devices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:Issue: Installation failed on ``grub2-mkconfig`` command, with actual error
+    like: ``grub2-probe error disk mduuid/4589a761dde10c78a204bcfd705df061 not found.``
+    on block device with 4096 bytes sector size.
+:Solution: use workaround.
+:Workaround: make your EFI partitions as second disk partitions, i.e.
+  ``nvme0n1p1`` is for ``/`` RAID, and ``nvme0n1p2`` is partition for the
+  ``/boot/efi`` RAID.
+:Example: `rhbz#1443144 <https://bugzilla.redhat.com/show_bug.cgi?id=1443144>`_
+
 Disable ``rhgb quiet``
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -369,7 +381,7 @@ Network issues
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :Issue: Due to systemd update Fedora 35 installation tracebacks with ``dasbus.error.DBusError: [Errno 2] No such file or directory: '/mnt/sysroot/etc/resolv.conf'``.
-Happens since systemd-249.10-1.fc35, present also in systemd-249.11-1.fc35, systemd-249.12-1.fc35, ... ? 
+Happens since systemd-249.10-1.fc35, present also in systemd-249.11-1.fc35, systemd-249.12-1.fc35, ... ?
 
 :Solution: Reassign to systemd https://bugzilla.redhat.com/show_bug.cgi?id=2074083.
 


### PR DESCRIPTION
The bug with grub and 4K LBA NVM'e still exists, at least on CentOS8-Stream After some days of debug and reinstall I find the way how-to workaround this issue https://bugzilla.redhat.com/show_bug.cgi?id=1443144

The trick is: EFI partition should be not first
```
ignoredisk --only-use=nvme0n1,nvme1n1
clearpart --none --initlabel
part raid.149 --fstype="mdmember" --ondisk=nvme1n1 --size=55895
part raid.156 --fstype="mdmember" --ondisk=nvme1n1 --size=250
part raid.142 --fstype="mdmember" --ondisk=nvme0n1 --size=250
part raid.135 --fstype="mdmember" --ondisk=nvme0n1 --size=55895
raid / --device=root --fstype="xfs" --level=RAID1 raid.135 raid.149
raid /boot/efi --device=boot_efi --fstype="efi" --level=RAID1 --fsoptions="umask=0077,shortname=winnt" raid.142 raid.156
```