### PR TITLE
webui: correct the last partitioning getter

### DIFF
--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -17,6 +17,7 @@
 import cockpit from "cockpit";
 
 import {
+    getDevicesAction,
     getDiskSelectionAction,
     getPartitioningDataAction
 } from "../actions/storage-actions.js";
@@ -492,7 +493,9 @@ export const initDataStorage = ({ dispatch }) => {
                 if (res.v.length !== 0) {
                     return res.v.forEach(path => dispatch(getPartitioningDataAction({ partitioning: path })));
                 }
-            });
+            })
+            .then(() => dispatch(getDevicesAction()))
+            .then(() => dispatch(getDiskSelectionAction()));
 };
 
 export const applyStorage = async ({ partitioning, encrypt, encryptPassword, onFail, onSuccess }) => {

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -56,7 +56,7 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, onAddE
     const [showPassphraseScreen, setShowPassphraseScreen] = useState(false);
     const [storageScenarioId, setStorageScenarioId] = useState(window.sessionStorage.getItem("storage-scenario-id") || getDefaultScenario().id);
     const lastPartitioning = useMemo(() => {
-        const lastPartitioningKey = Object.keys(storageData.partitioning || {}).find(path => parseInt(path[path.length - 1]) === Object.keys(storageData.partitioning).length);
+        const lastPartitioningKey = Object.keys(storageData.partitioning || {}).find(path => parseInt(path.match(/\d+$/)[0]) === Object.keys(storageData.partitioning).length);
 
         return storageData.partitioning?.[lastPartitioningKey];
     }, [storageData.partitioning]);

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -180,6 +180,8 @@ const LocalStandardDisks = ({ deviceData, diskSelection, dispatch, idPrefix, set
     const [equalDisksNotify, setEqualDisksNotify] = useState(false);
     const refUsableDisks = useRef();
 
+    console.debug("LocalStandardDisks: deviceData: ", JSON.stringify(Object.keys(deviceData)), ", diskSelection: ", JSON.stringify(diskSelection));
+
     useEffect(() => {
         if (isRescanningDisks) {
             refUsableDisks.current = diskSelection.usableDisks;

--- a/ui/webui/src/components/storage/InstallationDestination.jsx
+++ b/ui/webui/src/components/storage/InstallationDestination.jsx
@@ -205,11 +205,6 @@ const LocalStandardDisks = ({ deviceData, diskSelection, dispatch, idPrefix, set
         }
     }, [diskSelection]);
 
-    useEffect(() => {
-        dispatch(getDevicesAction());
-        dispatch(getDiskSelectionAction());
-    }, [dispatch]);
-
     const totalDisksCnt = diskSelection.usableDisks.length;
     const selectedDisksCnt = diskSelection.selectedDisks.length;
 

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -226,6 +226,53 @@ class TestStorage(anacondalib.VirtInstallMachineCase):
         # (there is enough free space)
         s.check_partitioning_selected("use-free-space")
 
+    def testPartitioningObject(self):
+        # Test which partitioning object ends up being the AppliedPartitioning
+        # when we go back and forward the storage steps
+
+        b = self.browser
+        i = Installer(b, self.machine)
+        s = Storage(b, self.machine)
+
+        self.addCleanup(s.dbus_reset_partitioning)
+
+        # Read partitioning data before we do anything
+        created_partitioning = s.dbus_get_created_partitioning()
+
+        # Go to Review step
+        i.open()
+        i.next()
+        i.next()
+        i.next()
+        i.next()
+
+        # Read partitioning data after we went to Review step
+        new_applied_partitioning = s.dbus_get_applied_partitioning()
+        new_created_partitioning = s.dbus_get_created_partitioning()
+
+        # A new AUTOMATIC partitioning object should be created each time the user enters the review page
+        self.assertEqual(len(created_partitioning) + 1, len(new_created_partitioning))
+        # The applied partitioning object should be the last one created
+        self.assertEqual(new_applied_partitioning, new_created_partitioning[-1])
+
+        created_partitioning = new_created_partitioning
+
+        # Create a few partitioning objects and ensure that these will not mess up with the user's
+        # configuration
+        for _ in range(10):
+            s.dbus_create_partitioning("AUTOMATIC")
+
+        # Go back to the previous page and re-enter the review screen.
+        # This should create again a new partitioning object and apply it
+        # no matter how many partitioning objects were created before
+        i.back()
+        i.next()
+        new_applied_partitioning = s.dbus_get_applied_partitioning()
+        new_created_partitioning = s.dbus_get_created_partitioning()
+
+        self.assertEqual(len(created_partitioning) + 11, len(new_created_partitioning))
+        self.assertEqual(new_applied_partitioning, new_created_partitioning[-1])
+
 
 # We can't run this test case on an existing machine,
 # with --machine because MachineCase is not aware of add_disk method

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -97,6 +97,31 @@ class Storage():
             {STORAGE_OBJECT_PATH} \
             {STORAGE_INTERFACE}.ResetPartitioning')
 
+    def dbus_create_partitioning(self, method="MANUAL"):
+        return self.machine.execute(f'dbus-send --print-reply --bus="{self._bus_address}" \
+            --dest={STORAGE_SERVICE} \
+            {STORAGE_OBJECT_PATH} \
+            {STORAGE_INTERFACE}.CreatePartitioning string:"{method}"')
+
+    def dbus_get_applied_partitioning(self):
+        ret = self.machine.execute(f'dbus-send --print-reply=literal --bus="{self._bus_address}" \
+            --dest={STORAGE_SERVICE} \
+            {STORAGE_OBJECT_PATH} \
+            org.freedesktop.DBus.Properties.Get \
+            string:{STORAGE_INTERFACE} string:AppliedPartitioning')
+
+        print("ret: ", ret)
+        return ret.split('variant')[1].strip()
+
+    def dbus_get_created_partitioning(self):
+        ret = self.machine.execute(f'dbus-send --print-reply=literal --bus="{self._bus_address}" \
+            --dest={STORAGE_SERVICE} \
+            {STORAGE_OBJECT_PATH} \
+            org.freedesktop.DBus.Properties.Get \
+            string:{STORAGE_INTERFACE} string:CreatedPartitioning')
+
+        return ret[ret.find("[")+1:ret.rfind("]")].split()
+
     def dbus_set_initialization_mode(self, value):
         self.machine.execute(f'dbus-send --print-reply --bus="{self._bus_address}" \
             --dest={STORAGE_SERVICE} \


### PR DESCRIPTION
Previously we would read just the last character of the path, which would give incorrect data if more than 9 partitionings would exist.

Now we parse the digits in the end of the path with a regexp.
