### PR TITLE
Fix unit tests for python 3.12

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py
@@ -349,12 +349,12 @@ class FlatpakTest(unittest.TestCase):
         flatpak.replace_installed_refs_remote("cylon_officer")
 
         # test that every file is read and written
-        open_mock.has_calls([
+        open_mock.assert_has_calls([
             call("/path/app/org.test/x86_64/stable/active/deploy", "rb"),
             call("/path/app/org.test/x86_64/stable/active/deploy", "wb"),
             call("/path/runtime/org.run/x86_64/stable/active/deploy", "rb"),
             call("/path/runtime/org.run/x86_64/stable/active/deploy", "wb"),
-        ])
+        ], any_order=True)
 
 
 class OperationMock(object):


### PR DESCRIPTION
This updates the parts of unit tests that get broken by rawhide's update to Python 3.12.

The breakage is not visible on PRs since these run the old container with Python 3.11. The breakage is visible in container daily updates.

Pylint is not included, because that is its own thing. That will likely require using patched pylint and astroid from rawhide rpms.

~~Translation canary needs its own PR and such, see https://github.com/rhinstaller/translation-canary/pull/7~~