### PR TITLE
webui: tests: implement a 'reach' helper method

### DIFF
--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -37,14 +37,10 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         )
 
         i.check_prerelease_info()
-
-        current_page = i.get_current_page()
         # Do not start the installation in non-destructive tests as this performs non revertible changes
-        while current_page is not i.steps.REVIEW:
-            # with the pages basically empty of common elements (as those are provided by the top-level installer widget)
-            # we at least iterate over them to check this works as expected
-            i.wait_current_page(current_page)
-            current_page = i.next()
+        # with the pages basically empty of common elements (as those are provided by the top-level installer widget)
+        # we at least iterate over them to check this works as expected
+        i.reach(i.steps.REVIEW)
 
         # Ensure that the 'actual' UI process is running/
         self.assertIn("/usr/libexec/webui-desktop", m.execute("ps aux"))

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -34,14 +34,10 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         r = Review(b)
 
         i.open()
-        i.next()
-        i.next()
-        i.next()
-
         # After clicking 'Next' on the storage step, partitioning is done, thus changing the available space on the disk
         # Since this is a non-destructive test we need to make sure the we reset partitioning to how it was before the test started
         self.addCleanup(s.dbus_reset_partitioning)
-        i.next()
+        i.reach(i.steps.REVIEW)
 
         # check language is shown
         r.check_language("English (United States)")
@@ -74,9 +70,7 @@ class TestReview(anacondalib.VirtInstallMachineCase):
 
         i.open()
 
-        current_page = i.get_current_page()
-        while current_page is not i.steps.REVIEW:
-            current_page = i.next()
+        i.reach(i.steps.REVIEW)
         i.begin_installation(should_fail=True, confirm_erase=False)
 
 if __name__ == '__main__':

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -76,11 +76,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase):
         i.open()
         # Language selection
 
-        i.next()
-        # Storage Devices
-
-        i.next()
-        # Storage Configuration
+        i.reach(i.steps.STORAGE_CONFIGURATION)
 
         # Check the default mode
         s.check_partitioning_selected("erase-all")
@@ -184,11 +180,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase):
         i.open()
         # Language selection
 
-        i.next()
-        # Storage Devices
-
-        i.next()
-        # Storage Configuration
+        i.reach(i.steps.STORAGE_CONFIGURATION)
 
         # Check the default mode
         s.check_partitioning_selected("erase-all")

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -59,6 +59,20 @@ class Installer():
         else:
             self.wait_current_page(self.steps._steps_jump[current_page])
 
+    def reach(self, target_page):
+        path = []
+        page = target_page
+        current_page = self.get_current_page()
+
+        while current_page != page:
+            path.append(page)
+            prev = [k for k, v in self.steps._steps_jump.items() if page in v][0]
+            page = prev
+
+        while self.get_current_page() != target_page:
+            next_page = path.pop()
+            self.next(next_page=next_page)
+
     @log_step()
     def next(self, should_fail=False, subpage=False, next_page=""):
         current_page = self.get_current_page()


### PR DESCRIPTION
This allows us in the tests to reach a desired page with one test function call, instead of calling 'next' all the time.

