### PR TITLE
infra: Temporarily use pylint and astroid from RPM

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -85,6 +85,8 @@ def exitHandler(rebootData):
 
         if flags.eject or rebootData.eject:
             for device_path in optical_media:
+                # path is already imported in __main__ as other things used here -> disable pylint
+                # pylint: disable=undefined-loop-variable
                 if path.get_mount_paths(device_path):
                     util.dracut_eject(device_path)
 

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -75,6 +75,10 @@ RUN set -ex; \
 RUN pip install --no-cache-dir --upgrade pip; \
   pip install --no-cache-dir -r /root/requirements.txt
 
+# TODO: Remove once pylint and astroid from pip work on 3.12 in f39
+RUN pip uninstall -y pylint astroid; \
+  dnf install -y pylint python3-astroid; dnf clean all
+
 RUN mkdir /anaconda
 
 WORKDIR /anaconda

--- a/tests/pylint/censorship.py
+++ b/tests/pylint/censorship.py
@@ -35,6 +35,7 @@ import re
 
 from io import StringIO
 
+import astroid
 import pylint.lint
 
 from pylint.reporters.text import TextReporter
@@ -105,6 +106,7 @@ class CensorshipLinter():
         args = self._prepare_args()
 
         print("Pylint version: ", pylint.__version__)
+        print("Astroid version: ", astroid.__version__)
         print("Running pylint with args: ", args)
 
         pylint.lint.Run(args,

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -37,6 +37,22 @@ class AnacondaLintConfig(CensorshipConfig):
             FalsePositive(r"E1101.*: Instance of 'int' has no 'name_from_node' member"),
             FalsePositive(r"E1101.*: Instance of 'int' has no 'generate_backup_passphrase' member"),
             FalsePositive(r"E1101.*: Instance of 'int' has no 'dasd_is_ldl' member"),
+
+            # TODO: Issue with pylint on newest python 3.12
+            # Problem with datetime members
+            FalsePositive(r"E1101.*: Class 'date' has no 'today' member"),
+            FalsePositive(r"E1101.*: Class 'datetime' has no '(now|strptime)' member"),
+            FalsePositive(r"E1101.*: Instance of 'date' has no 'strftime' member"),
+            FalsePositive(r"E1101.*: Instance of 'datetime' has no 'timestamp' member"),
+            # New pylint has an issue to work with unpacked (*) variables in function calls
+            FalsePositive(r"E1120.*test_dnf_initialization\.py.*: "
+                          "No value for argument 'path' in function call"),
+            FalsePositive(r"E1120.*: .*Spoke.__init__: "
+                          "No value for argument '(data|storage|payload)' in method call"),
+            FalsePositive(r"E1120.*: .*Spoke.__init__: "
+                          "No value for argument '(data|storage|payload)' in unbound method call"),
+            # Can't find AnacondaWidgets from gi.repository
+            FalsePositive(r"E0611.*: No name 'AnacondaWidgets' in module 'gi.repository'")
         ]
 
     def _files(self):


### PR DESCRIPTION
Pip has too old versions that don't work with Rawhide Python 3.12.

----

Draft because this is how a potential fix looks like, except the updated packages are not available yet.

There's also some unclear information about the problem (which problem?) being in Python instead of pylint.

PS: As of submitting the PR, pylint is the only thing that fails on a freshly built CI container.