### PR TITLE
infra: Clone repo for cockpit lib update with token

### DIFF
--- a/.github/workflows/cockpit-lib-update.yml
+++ b/.github/workflows/cockpit-lib-update.yml
@@ -5,6 +5,7 @@ on:
     - cron: '0 2 * * 4'
   # can be run manually on https://github.com/rhinstaller/anaconda/actions
   workflow_dispatch:
+
 jobs:
   cockpit-lib-update:
     permissions:
@@ -24,6 +25,8 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.INSTALLKER_TOKEN }}
 
       - name: Run cockpit-lib-update
         run: |


### PR DESCRIPTION
This addresses https://github.com/rhinstaller/anaconda/pull/4790#issuecomment-1564673883

It's not clear if this solves the problem.

Currently blocked because we can't update.