### PR TITLE
Improve btrfs support in tui mountpoint assignment v2

### DIFF
--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -169,8 +169,11 @@ class ManualPartitioningModule(PartitioningModule):
         request.format_type = device.format.type or ""
         request.reformat = False
 
-        if device.format.mountable and device.format.mountpoint:
-            request.mount_point = device.format.mountpoint
+        if device.format.mountable:
+            if device.format.mountpoint:
+                request.mount_point = device.format.mountpoint
+            if device.format.mountopts:
+                request.mount_options = device.format.mountopts
 
         return request
 

--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -131,7 +131,10 @@ class ManualPartitioningModule(PartitioningModule):
         """
         selected_disks = set(self._selected_disks)
 
-        for device in self.storage.devicetree.leaves:
+        for device in self.storage.devicetree.devices:
+            if not device.isleaf and not device.raw_device.type == "btrfs subvolume":
+                continue
+
             # Is the device usable?
             if device.protected or device.size == Size(0):
                 continue

--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -165,7 +165,7 @@ class ManualPartitioningModule(PartitioningModule):
         :return: an instance of MountPointRequest
         """
         request = MountPointRequest()
-        request.device_spec = device.path
+        request.device_spec = device.name
         request.format_type = device.format.type or ""
         request.reformat = False
 

--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -88,6 +88,7 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
             if device.raw_device.type == "btrfs subvolume":
                 # 'Format', or rather clear the device by recreating it
                 device = self._recreate_device(storage, device_spec)
+                mount_data.mount_options = device.format.options
             else:
                 storage.format_device(device, fmt)
 

--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -22,6 +22,9 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.storage.partitioning.automatic.noninteractive_partitioning import \
     NonInteractivePartitioningTask
+from pyanaconda.modules.storage.partitioning.interactive.utils import destroy_device, \
+    generate_device_factory_request
+from pyanaconda.modules.storage.partitioning.interactive.add_device import AddDeviceTask
 
 log = get_module_logger(__name__)
 
@@ -81,7 +84,13 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
                     raise StorageError(_("No format on device '{}'").format(device_spec))
 
                 fmt = get_format(old_fmt.type)
-            storage.format_device(device, fmt)
+
+            if device.raw_device.type == "btrfs subvolume":
+                # 'Format', or rather clear the device by recreating it
+                device = self._recreate_device(storage, device_spec)
+            else:
+                storage.format_device(device, fmt)
+
             # make sure swaps end up in /etc/fstab
             if fmt.type == "swap":
                 storage.add_fstab_swap(device)
@@ -94,3 +103,18 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
 
         device.format.create_options = mount_data.format_options
         device.format.options = mount_data.mount_options
+
+    def _recreate_device(self, storage, dev_spec):
+        """Recreate a device by destroying and adding it.
+
+        :param storage: an instance of the Blivet's storage object
+        :param dev_spec: a string describing a block device to be recreated
+        """
+        device = storage.devicetree.resolve_device(dev_spec)
+        request = generate_device_factory_request(storage, device)
+        destroy_device(storage, device)
+        task = AddDeviceTask(storage, request)
+        task.run()
+        device = storage.devicetree.resolve_device(dev_spec)
+
+        return device

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
@@ -170,7 +170,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
         assert self.interface.GatherRequests() == [
             {
-                'device-spec': get_variant(Str, '/dev/dev1'),
+                'device-spec': get_variant(Str, 'dev1'),
                 'format-options': get_variant(Str, ''),
                 'format-type': get_variant(Str, 'ext4'),
                 'mount-options': get_variant(Str, ''),
@@ -178,7 +178,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
                 'reformat': get_variant(Bool, False)
             },
             {
-                'device-spec': get_variant(Str, '/dev/dev2'),
+                'device-spec': get_variant(Str, 'dev2'),
                 'format-options': get_variant(Str, ''),
                 'format-type': get_variant(Str, 'swap'),
                 'mount-options': get_variant(Str, ''),
@@ -206,7 +206,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
         # Add requests for dev1 and dev3.
         req1 = MountPointRequest()
-        req1.device_spec = '/dev/dev1'
+        req1.device_spec = 'dev1'
         req1.format_options = '-L BOOT'
         req1.format_type = 'xfs'
         req1.mount_options = 'user'
@@ -214,7 +214,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
         req1.reformat = True
 
         req3 = MountPointRequest()
-        req3.device_spec = '/dev/dev3'
+        req3.device_spec = 'dev3'
         req3.mount_point = '/'
 
         self.module.set_requests([req1, req3])
@@ -222,7 +222,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
         # Get requests for dev1 and dev2.
         assert self.interface.GatherRequests() == [
             {
-                'device-spec': get_variant(Str, '/dev/dev1'),
+                'device-spec': get_variant(Str, 'dev1'),
                 'format-options': get_variant(Str, '-L BOOT'),
                 'format-type': get_variant(Str, 'xfs'),
                 'mount-options': get_variant(Str, 'user'),
@@ -230,7 +230,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
                 'reformat': get_variant(Bool, True)
             },
             {
-                'device-spec': get_variant(Str, '/dev/dev2'),
+                'device-spec': get_variant(Str, 'dev2'),
                 'format-options': get_variant(Str, ''),
                 'format-type': get_variant(Str, 'swap'),
                 'mount-options': get_variant(Str, ''),

--- a/ui/webui/src/components/review/ReviewConfiguration.jsx
+++ b/ui/webui/src/components/review/ReviewConfiguration.jsx
@@ -102,7 +102,7 @@ const DeviceRow = ({ deviceData, disk, requests }) => {
     };
 
     const partitionRows = requests?.filter(req => {
-        const partitionName = Object.keys(deviceData).find(device => deviceData[device].path.v === req["device-spec"]);
+        const partitionName = Object.keys(deviceData).find(device => deviceData[device].name.v === req["device-spec"]);
         const device = deviceData[partitionName];
 
         return checkDeviceInSubTree(device, name, deviceData);

--- a/ui/webui/src/components/storage/MountPointMapping.jsx
+++ b/ui/webui/src/components/storage/MountPointMapping.jsx
@@ -132,7 +132,7 @@ export const MountPointMapping = ({ deviceData, diskSelection, partitioningData,
 
         return Object.keys(deviceData).filter(d => {
             return (
-                devs.includes(deviceData[d].path.v) &&
+                devs.includes(deviceData[d].name.v) &&
                 deviceData[d].formatData.type.v === "luks" &&
                 deviceData[d].formatData.attrs.v.has_key !== "True"
             );
@@ -152,7 +152,7 @@ export const MountPointMapping = ({ deviceData, diskSelection, partitioningData,
     }, [partitioningData?.requests, setIsFormValid]);
 
     // If device selection changed since the last partitioning request redo the partitioning
-    const selectedDevicesPaths = diskSelection.selectedDisks.map(d => deviceData[d].path.v) || [];
+    const selectedDevicesPaths = diskSelection.selectedDisks.map(d => deviceData[d].name.v) || [];
     const partitioningDevicesPaths = partitioningData?.requests?.map(r => r["device-spec"]) || [];
     const canReusePartitioning = selectedDevicesPaths.length === partitioningDevicesPaths.length && selectedDevicesPaths.every(d => partitioningDevicesPaths.includes(d));
 

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -384,6 +384,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
 
         disk = "/dev/vda"
         dev = "vda"
+        btrfsname = "btrfstest"
         m.execute(f"""
         sgdisk --zap-all {disk}
         sgdisk --new=0:0:+1MiB -t 0:ef02 {disk}
@@ -392,7 +393,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         sgdisk --new=0:0:0 {disk}
         mkfs.ext4 {disk}2
         mkfs.xfs -f {disk}3
-        mkfs.btrfs -f {disk}4
+        mkfs.btrfs -f -L {btrfsname} {disk}4
         """)
 
         self.udevadm_settle()

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -440,20 +440,20 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         r.expand_disk_table(disk)
 
         row = 1
-        r.check_disk_row(disk, row, "Partition", f"/dev/vda{row}")
+        r.check_disk_row(disk, row, "Partition", f"vda{row}")
         r.check_disk_row(disk, row, "Format type", "biosboot")
         row = 2
-        r.check_disk_row(disk, row, "Partition", f"/dev/vda{row}")
+        r.check_disk_row(disk, row, "Partition", f"vda{row}")
         r.check_disk_row(disk, row, "Format type", "ext4")
         r.check_disk_row(disk, row, "Mount point", "/boot")
         r.check_disk_row_reformatted(disk, row, "Reformat")
         row = 3
-        r.check_disk_row(disk, row, "Partition", f"/dev/vda{row}")
+        r.check_disk_row(disk, row, "Partition", f"vda{row}")
         r.check_disk_row(disk, row, "Format type", "xfs")
         r.check_disk_row(disk, row, "Mount point", "/")
         r.check_disk_row_reformatted(disk, row, "Reformat")
         row = 4
-        r.check_disk_row(disk, row, "Partition", f"/dev/vda{row}")
+        r.check_disk_row(disk, row, "Partition", btrfsname)
         r.check_disk_row(disk, row, "Format type", "btrfs")
         r.check_disk_row(disk, row, "Mount point", "/")
 
@@ -547,7 +547,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
 
         self.select_mountpoint(i, s, [(dev1, False), (dev2, True)])
 
-        self.check_partition(1, "/dev/vdb1")
+        self.check_partition(1, "vdb1")
 
         # Go back and change the disk selection. The partitioning should be re-created
         i.back()
@@ -555,19 +555,19 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         self.browser.click(".pf-c-select__toggle-clear")
         self.select_mountpoint(i, s, [(dev1, True), (dev2, True)])
 
-        self.check_partition(1, "/dev/vda1")
+        self.check_partition(1, "vda1")
 
-        self.check_partition(2, "/dev/vda2")
+        self.check_partition(2, "vda2")
         self.check_format_type(2, "xfs")
         self.select_from_dropdown(2, "boot", "/boot")
         self.check_reformat(2, False)
 
-        self.check_partition(3, "/dev/vda3")
+        self.check_partition(3, "vda3")
         self.check_format_type(3, "xfs")
         self.select_from_dropdown(3, "root", "/")
         self.check_reformat(3, True)
 
-        self.check_partition(4, "/dev/vdb1")
+        self.check_partition(4, "vdb1")
         self.check_format_type(4, "xfs")
         self.select_from_dropdown(4, "home", "/home")
         self.check_reformat(4, False)
@@ -580,14 +580,14 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         r.expand_disk_table(disk)
 
         row = 1
-        r.check_disk_row(disk, row, "Partition", f"/dev/vda{row}")
+        r.check_disk_row(disk, row, "Partition", f"vda{row}")
         r.check_disk_row(disk, row, "Format type", "biosboot")
         row = 2
-        r.check_disk_row(disk, row, "Partition", f"/dev/vda{row}")
+        r.check_disk_row(disk, row, "Partition", f"vda{row}")
         r.check_disk_row(disk, row, "Format type", "xfs")
         r.check_disk_row(disk, row, "Mount point", "/boot")
         row = 3
-        r.check_disk_row(disk, row, "Partition", f"/dev/vda{row}")
+        r.check_disk_row(disk, row, "Partition", f"vda{row}")
         r.check_disk_row(disk, row, "Format type", "xfs")
         r.check_disk_row(disk, row, "Mount point", "/")
         r.check_disk_row_reformatted(disk, row, "Reformat")
@@ -597,7 +597,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         r.expand_disk_table(disk)
 
         row = 1
-        r.check_disk_row(disk, row, "Partition", f"/dev/vdb{row}")
+        r.check_disk_row(disk, row, "Partition", f"vdb{row}")
         r.check_disk_row(disk, row, "Format type", "xfs")
         r.check_disk_row(disk, row, "Mount point", "/home")
 
@@ -646,7 +646,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         self.unlock_device("einszweidrei")
         b.wait_not_present("#mount-point-mapping-table tbody tr:nth-child(4) td[data-label='Format type'] #unlock-luks-btn")
 
-        self.check_partition(4, "/dev/mapper/luks")
+        self.check_partition(4, "luks")
         self.check_format_type(4, "xfs")
 
         self.select_from_dropdown(2, "boot", "/boot")
@@ -656,7 +656,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         i.next()
 
         r.expand_disk_table(dev2)
-        r.check_disk_row(dev2, 1, "Partition", "/dev/mapper/luks")
+        r.check_disk_row(dev2, 1, "Partition", "luks")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This is intended as replacement of #4835

The biggest change is we use device name instead of path as a unique identifier, this way we can display btrfs subvolumes without any additional identifier and changes.