### PR TITLE
Enable ruff pylint checks

### DIFF
--- a/pyanaconda/core/startup/dbus_launcher.py
+++ b/pyanaconda/core/startup/dbus_launcher.py
@@ -110,7 +110,7 @@ class AnacondaDBusLauncher(object):
             "--syslog",
             "--config-file={}".format(ANACONDA_BUS_CONF_FILE)
         ]
-        
+
         def dbus_preexec():
             # to set dbus subprocess SIGINT handler
             signal.signal(signal.SIGINT, signal.SIG_IGN)

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -196,7 +196,7 @@ def do_startup_x11_actions():
     def x11_preexec():
         # to set GUI subprocess SIGINT handler
         signal.signal(signal.SIGINT, signal.SIG_IGN)
-        
+
     childproc = util.startProgram(["gnome-kiosk", "--display", ":1", "--sm-disable", "--x11"],
                                   env_add={'XDG_DATA_DIRS': xdg_data_dirs},
                                   preexec_fn=x11_preexec)

--- a/pyanaconda/modules/common/structures/packages.py
+++ b/pyanaconda/modules/common/structures/packages.py
@@ -310,7 +310,7 @@ class PackagesConfigurationData(DBusData):
 
             all     Install all available packages with compatible
                     architectures.
-            best    Prefer packages which best match the system’s
+            best    Prefer packages which best match the system's
                     architecture.
 
         :return: 'all' or 'best'

--- a/pyanaconda/modules/common/structures/user.py
+++ b/pyanaconda/modules/common/structures/user.py
@@ -162,7 +162,7 @@ class UserData(DBusData):
 
     @property
     def gid(self) -> UInt32:
-        """The GID of the user’s primary group.
+        """The GID of the user's primary group.
 
         If ignored due to gid_mode, defaults to the next available non-system GID.
 
@@ -314,7 +314,7 @@ class UserData(DBusData):
         """Provides the GECOS information for the user.
 
         This is a string of various system-specific fields separated by a comma.
-        It is frequently used to specify the user’s full name, office number, and the like.
+        It is frequently used to specify the user's full name, office number, and the like.
         See man 5 passwd for more details.
 
         For examples: "foo"

--- a/pyanaconda/modules/storage/reset.py
+++ b/pyanaconda/modules/storage/reset.py
@@ -37,7 +37,7 @@ __all__ = ["ScanDevicesTask"]
 class ScanDevicesTask(Task):
     """A task for scanning all devices.
 
-    Scan the system’s storage configuration and store it in the tree.
+    Scan the system's storage configuration and store it in the tree.
     This task will reset the given instance of Blivet.
     """
 

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -214,7 +214,7 @@ class StorageService(KickstartService):
         """Set the current storage model.
 
         The current storage is the latest model of
-        the system’s storage configuration created
+        the system's storage configuration created
         by scanning all devices.
 
         :param storage: a storage

--- a/pyanaconda/modules/storage/storage_interface.py
+++ b/pyanaconda/modules/storage/storage_interface.py
@@ -127,7 +127,7 @@ class StorageInterface(KickstartModuleInterface):
         """Reset the scheduled partitioning.
 
         Reset the applied partitioning and reset the storage models of all
-        partitioning modules to the latest model of the system’s storage
+        partitioning modules to the latest model of the system's storage
         configuration.
 
         This method will not rescan the system.

--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -409,7 +409,7 @@ class ParseAttachedSubscriptionsTask(Task):
             pass
         try:
             # The start/end date in GetPools() output seems to be formatted as
-            # "Locale’s appropriate date representation.".
+            # "Locale's appropriate date representation.".
             # See bug 1793501 for possible issues with RHSM provided date parsing.
             date = datetime.datetime.strptime(date_from_json, "%m/%d/%y")
             # get a nice human readable date

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -569,7 +569,7 @@ class FilterSpoke(NormalSpoke):
         super().refresh()
 
         # Reset the scheduled partitioning if any to make sure that we
-        # are working with the current system’s storage configuration.
+        # are working with the current system's storage configuration.
         # FIXME: Change modules and UI to work with the right device tree.
         self._storage_module.ResetPartitioning()
 

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -160,6 +160,7 @@ class VNCPassSpoke(NormalTUISpoke):
             self.apply()
             self.close()
 
+        # ruff: noqa: PLR1711
         return None
 
     def _print_error_and_redraw(self, msg):

--- a/pyanaconda/ui/tui/spokes/shell_spoke.py
+++ b/pyanaconda/ui/tui/spokes/shell_spoke.py
@@ -74,4 +74,5 @@ class ShellSpoke(NormalTUISpoke):
         self.close()
 
         # suppress the prompt
+        # ruff: noqa: PLR1711
         return None

--- a/pyanaconda/ui/webui/__init__.py
+++ b/pyanaconda/ui/webui/__init__.py
@@ -121,7 +121,6 @@ ExecStart=/usr/libexec/cockpit-ws --no-tls --port 9090 --local-session=cockpit-b
             f.write(repr(proc.pid))
         proc.wait()
         log.debug("cockpit web view has finished running")
-        return
 
     @property
     def meh_interface(self):

--- a/tests/glade_tests/test_format_string.py
+++ b/tests/glade_tests/test_format_string.py
@@ -38,7 +38,7 @@ class CheckFormatString(TestCase):
         for translatable in glade_tree.xpath(".//*[@translatable='yes']"):
             # Look for % followed by an open parenthesis (indicating %(name)
             # style substitution), one of the python format conversion flags
-            # (#0- +hlL), or one of the python conversion types 
+            # (#0- +hlL), or one of the python conversion types
             # (diouxXeEfFgGcrs)
             self.assertNotRegex(translatable.text,
                     r'%[-(#0 +hlLdiouxXeEfFgGcrs]',

--- a/tests/ruff/ruff.toml
+++ b/tests/ruff/ruff.toml
@@ -9,6 +9,7 @@ select = [
     "PL", # pylint
     "ICN", # flake8-import-conventions
     "G", # flake8-logging-format
+    "RUF", # Ruff-specific rules
 ]
 
 ignore = [
@@ -26,4 +27,6 @@ ignore = [
     "PLR5501", # Consider using `elif` instead of `else` then `if` to remove one indentation level
     "PLC1901", # `<str comparison>` can be simplified to `<str comparison>` as an empty string is falsey
     "PLW2901", # `for` loop variable `<name>` overwritten by assignment target
+    "RUF005", # Consider `<expression>` instead of concatenation
+    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
 ]

--- a/tests/ruff/ruff.toml
+++ b/tests/ruff/ruff.toml
@@ -10,6 +10,7 @@ select = [
     "ICN", # flake8-import-conventions
     "G", # flake8-logging-format
     "RUF", # Ruff-specific rules
+    "SIM", # flake8-simplify
 ]
 
 ignore = [
@@ -29,4 +30,17 @@ ignore = [
     "PLW2901", # `for` loop variable `<name>` overwritten by assignment target
     "RUF005", # Consider `<expression>` instead of concatenation
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
+    "SIM108", # Use ternary operator `tag = None if log_formatter else logr.name` instead of `if`-`else`-block
+    "SIM300", # Yoda conditions are discouraged, use `<expression>` instead
+    "SIM115", # Use context handler for opening files
+    "SIM105", # Use `contextlib.suppress(<exception-type>)` instead of `try`-`except`-`pass`
+    "SIM117", # Use a single `with` statement with multiple contexts instead of nested `with` statements
+    "SIM112", # Use capitalized environment variable `<NAME>` instead of `<name>`
+    "SIM114", # Combine `if` branches using logical `or` operator
+    "SIM118", # Use `<var> in <dict>` instead of `<var> in <dict>.keys()`
+    "SIM103", # Return the condition `<expression>` directly
+    "SIM201", # Use `<expression>` instead of `<expression>` # (negation operator position in expression)
+    "SIM102", # Use a single `if` statement instead of nested `if` statements
+    "SIM110", # Use `return any(<condition>)` instead of `for` loop
+    "SIM222", # Use `<expression>` instead of `<expression>` # (truthiness)
 ]

--- a/tests/ruff/ruff.toml
+++ b/tests/ruff/ruff.toml
@@ -2,7 +2,12 @@
 
 line-length = 99
 
-select = ["E", "F", "PL"]
+select = [
+    "E", # pycodestyle error
+    "F", # pyflakes
+    "W", # pycodestyle warning (mostly whitespace related)
+    "PL", # pylint
+]
 
 ignore = [
     "E501", # Line too long

--- a/tests/ruff/ruff.toml
+++ b/tests/ruff/ruff.toml
@@ -2,10 +2,21 @@
 
 line-length = 99
 
+select = ["E", "F", "PL"]
+
 ignore = [
     "E501", # Line too long
     "E402", # Module level import not at top of file
     "F405", # `<type>` may be undefined, or defined from star imports: `<module>`
     "F403", # `from <module> import *` used; unable to detect undefined names
     "E731", # Do not assign a `lambda` expression, use a `def`
+    "PLW0603", # Using the global statement to update `<variable>` is discouraged
+    "PLR2004", # Magic value used in comparison, consider replacing <value> with a constant variable
+    "PLR0913", # Too many arguments to function call (N > 5)
+    "PLR0915", # Too many statements (N > 50)
+    "PLR0912", # Too many branches (N > 12)
+    "PLR0911", # Too many return statements (N > 6)
+    "PLR5501", # Consider using `elif` instead of `else` then `if` to remove one indentation level
+    "PLC1901", # `<str comparison>` can be simplified to `<str comparison>` as an empty string is falsey
+    "PLW2901", # `for` loop variable `<name>` overwritten by assignment target
 ]

--- a/tests/ruff/ruff.toml
+++ b/tests/ruff/ruff.toml
@@ -8,6 +8,7 @@ select = [
     "W", # pycodestyle warning (mostly whitespace related)
     "PL", # pylint
     "ICN", # flake8-import-conventions
+    "G", # flake8-logging-format
 ]
 
 ignore = [

--- a/tests/ruff/ruff.toml
+++ b/tests/ruff/ruff.toml
@@ -7,6 +7,7 @@ select = [
     "F", # pyflakes
     "W", # pycodestyle warning (mostly whitespace related)
     "PL", # pylint
+    "ICN", # flake8-import-conventions
 ]
 
 ignore = [

--- a/tests/unit_tests/dracut_tests/test_driver_updates.py
+++ b/tests/unit_tests/dracut_tests/test_driver_updates.py
@@ -19,7 +19,7 @@
 # test_driver_updates.py - unittests for driver_updates.py
 
 import unittest
-import unittest.mock as mock
+from unittest import mock
 
 import os
 import tempfile

--- a/tests/unit_tests/pyanaconda_tests/core/test_util.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_util.py
@@ -775,6 +775,7 @@ class LazyObjectTestCase(unittest.TestCase):
         assert lazy_a1 == lazy_a2
         assert lazy_a2 == lazy_a1
 
+        # ruff: noqa: PLR0124
         assert lazy_a1 == lazy_a1
         assert lazy_a2 == lazy_a2
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -225,6 +225,7 @@ class DNFKickstartTestCase(unittest.TestCase):
         ks_in = """
         repo --name updates
         """
+        # ruff: noqa: W291
         ks_out = """
         repo --name="updates" 
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_clearpart.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_clearpart.py
@@ -1,5 +1,5 @@
 import unittest
-import unittest.mock as mock
+from unittest import mock
 
 import blivet
 

--- a/tests/unit_tests/regex_tests/test_groupparse.py
+++ b/tests/unit_tests/regex_tests/test_groupparse.py
@@ -24,8 +24,8 @@ from pyanaconda.core.regexes import GROUPLIST_FANCY_PARSE
 class GroupParseTestCase(unittest.TestCase):
     def test_group_list(self):
         """Test a list of possible group-name (GID) values with the group
-           parsing regex. 
-           
+           parsing regex.
+
            Tests are in the form of: (string, match.groups() tuple)
         """
 

--- a/ui/webui/test/end2end/storage_encryption.py
+++ b/ui/webui/test/end2end/storage_encryption.py
@@ -37,7 +37,7 @@ class StorageEncryption(End2EndTest):
         self._storage.check_encryption_selected(False)
         self._storage.set_encryption_selected(True)
         self._storage.check_encryption_selected(True)
-        
+
         self._installer.next(subpage=True)
 
         self._storage.set_password(self.luks_pass)


### PR DESCRIPTION
This enables lots of checks for ruff, hopefully bringing it closer to what we have with pylint.

See also https://beta.ruff.rs/docs/rules/

The list of ignored checks is partially a masked TODO - there are some valid detections with these. However, fixing such detections is either a too wide change, or would modify behaviour enough to warrant retesting the application.