### PR TITLE
infra: Check container age in testing make targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -279,6 +279,8 @@ ci:
 # The SYS_CHROOT capability is required for user creation tests and was dropped on podman 4.4.X
 # https://bugzilla.redhat.com/show_bug.cgi?id=2170568
 container-ci:
+	@./scripts/testing/check-container-age.sh "$(CI_NAME):$(CI_TAG)"
+
 	$(CONTAINER_ENGINE) run \
 	--entrypoint /anaconda/dockerfile/anaconda-ci/run-build-and-arg \
 	-e CONFIGURE_ARGS="--disable-webui" \
@@ -303,6 +305,8 @@ container-pylint-only:
 	$(MAKE) -f ./Makefile.am container-ci CI_CMD="make tests-pylint"
 
 container-rpm-test:
+	@./scripts/testing/check-container-age.sh "$(RPM_NAME):$(CI_TAG)"
+
 	$(CONTAINER_ENGINE) run \
 	$(CONTAINER_TEST_ARGS) \
 	$(CI_TEST_ARGS) \
@@ -314,6 +318,8 @@ container-rpm-test:
 	    dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm'
 
 container-rpms:
+	@./scripts/testing/check-container-age.sh "$(RPM_NAME):$(CI_TAG)"
+
 	$(CONTAINER_ENGINE) run \
 	$(CONTAINER_TEST_ARGS) \
 	$(CI_TEST_ARGS) \

--- a/scripts/testing/check-container-age.sh
+++ b/scripts/testing/check-container-age.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+# container image name, eg. "quay.io/rhinstaller/anaconda-ci:master"
+container_name="$1"
+# when is an image too old - string for `date --date=`
+too_old_description="60 hours ago"
+
+container_created=$(podman image inspect --format '{{.Created}}' "$container_name")
+# dates in unix epoch seconds
+ts_container_created=$(date --date="$(echo "$container_created" | awk '{print($1 " " $2)}')" +%s)
+ts_too_old=$(date +%s --date="$too_old_description")
+
+if [ "$ts_too_old" -gt "$ts_container_created" ] ; then
+  echo "====================================================================="
+  echo "WARNING: Container is too old!"
+  echo
+  echo "name:    $container_name"
+  echo "created: $container_created"
+  echo
+  echo "To update it, run: 'podman pull $container_name'"
+  echo "====================================================================="
+  # give user time to see the message before it scrolls away
+  sleep 5
+fi


### PR DESCRIPTION
With this, users have some chance to realize what's wrong when the container is too old.