### PR TITLE
Add possibility to run pylint-only test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -299,6 +299,9 @@ container-shell:
 	--cap-add=SYS_CHROOT \
 	$(CI_NAME):$(CI_TAG)
 
+container-pylint-only:
+	$(MAKE) -f ./Makefile.am container-ci CI_CMD="make tests-pylint"
+
 container-rpm-test:
 	$(CONTAINER_ENGINE) run \
 	$(CONTAINER_TEST_ARGS) \
@@ -414,7 +417,10 @@ tests-pep8:
 
 tests-pylint:
 	$(MAKE)
-	$(MAKE) TMPDIR=/var/tmp TEST_SUITE_LOG=test-suite.log TESTS=pylint/runpylint.py check
+# For a weird reason when pylint is not in TESTS included for automake (during configure)
+# it won't allow us to use makefile check to start the tests.
+# Unfortunately, we removed pylint from the TESTS because we don't want it to run as default
+	$(srcdir)/tests/pylint/runpylint | tee $(srcdir)/tests/pylint/runpylint.log
 
 tests-unit-only:
 	@mkdir -p $(USER_SITE_PACKAGES)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,7 +48,7 @@ dist_check_SCRIPTS = \
 	$(srcdir)/lib/*.py \
 	unit_tests/unit_tests.sh \
 	rpm_tests/rpm_tests.sh \
-	pylint/runpylint.py \
+	pylint/runpylint \
 	cppcheck/runcppcheck.sh \
 	testenv.sh \
 	$(srcdir)/gettext_tests/*.py \

--- a/tests/pylint/runpylint
+++ b/tests/pylint/runpylint
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# If $top_srcdir has not been set by automake, import the test environment
+if [ -z "$top_srcdir" ]; then
+    top_srcdir="$(realpath "$(dirname "$0")/../..")"
+    . "${top_srcdir}/tests/testenv.sh"
+fi
+
+exec "${top_srcdir}"/tests/pylint/runpylint.py


### PR DESCRIPTION
Pylint was recently removed from the default test suite because it caused issues on python 3.12. To be able to verify if that issue was resolved and in general improve state of running just this test this change introduce a possibility to run just pylint test in container or without the container.

Usually this should be solved by `make check TESTS=<pylint>`, unfortunately this is not possible for pylint for unknown reasons. The same situation works for unit tests but when pylint is used this way it not even try to start the tests. Seems to me like some automake magic fails here. Even automake substition doesn't work here. Seems that pylint test has to be in the TESTS variable hardcoded which can't happen if it is not part of the default runs.

Anyhow, to resolve this issue a new script was introduced to set environment variables correctly to the pylint start so it's easy and consistent to start the pylint tests.