### PR TITLE
webui: simplify webui-desktop script

### DIFF
--- a/pyanaconda/ui/webui/__init__.py
+++ b/pyanaconda/ui/webui/__init__.py
@@ -16,7 +16,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import os
 import meh
 
 from pyanaconda import ui
@@ -114,8 +113,6 @@ ExecStart=/usr/libexec/cockpit-ws --no-tls --port 9090 --local-session=cockpit-b
         # This is read by cockpit-desktop and makes it launch Firefox in kiosk mode
         # instead of the GTK WebKit based web view it launches by default.
 
-        # pylint: disable=environment-modify
-        os.environ["BROWSER"] = "/usr/bin/firefox --kiosk"
         proc = startProgram(["/usr/libexec/webui-desktop",
                             "/cockpit/@localhost/anaconda-webui/index.html"],
                             reset_lang=False)

--- a/ui/webui/webui-desktop
+++ b/ui/webui/webui-desktop
@@ -40,42 +40,6 @@ set -eu
 exec_prefix="/usr"
 libexecdir="/usr/libexec"
 
-# find suitable browser, unless already set by $BROWSER
-# We can't use xdg-open, it does too much magic behind the back to connect to
-# existing instances (outside of our namespace) and does not allow us to reduce
-# the UI, or pass options like chromium's --no-sandbox.
-detect_browser()
-{
-    [ -z "${BROWSER:-}" ] || return 0
-
-    # First choice, but it depends on gi.repository WebKit2, so check it
-    if /usr/libexec/cockpit-client --help >/dev/null 2>/dev/null; then
-        BROWSER="/usr/libexec/cockpit-client --disable-uniqueness --no-ui --external-ws"
-        return 0
-    fi
-
-    for browser in chromium-browser chromium google-chrome; do
-        if type $browser >/dev/null 2>&1; then
-            # need to disable sandboxing in user namespace, but that already isolates
-            # TODO: Find a way to disable the URL bar
-            BROWSER="$browser --no-sandbox --disable-infobars"
-            return 0
-        fi
-    done
-
-    if type firefox >/dev/null 2>&1; then
-        # TODO: Find a way to disable the privacy notice tab, via mozilla.cfg?
-        # TODO: Find a way to disable the URL bar
-        BROWSER="firefox --no-remote"
-        return 0
-    fi
-
-    # TODO: is there a simple way to use webkitgtk?
-    echo "No suitable browser found (Chromium/Chrome, or Firefox)" >&2
-    exit 1
-}
-
-
 if [ -z "${1:-}" ]; then
     echo "Usage: $0 <Cockpit path> [ssh host]" >&2
     exit 1
@@ -97,35 +61,23 @@ case "$1" in
         ;;
 esac
 
-detect_browser
-
-# start the bridge; this needs to run in the normal user session/namespace
-coproc ${2:+ssh "$2"} cockpit-bridge
-trap "kill $COPROC_PID; wait $COPROC_PID || true" EXIT INT QUIT PIPE
-
-# start ws and browser in a detached network namespace
-SCRIPT='
-set -eu
-# new namespaces have lo down by default
-ip link set lo up >&2
+BROWSER="/usr/bin/firefox --kiosk"
 
 # start browser in a temporary home dir, so that it does not interfere with your real one
-export BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
+BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
 
 # forward parent stdin and stdout (from bridge) to cockpit-ws
 # it pretty well does not matter which port we use in our own namespace, so use standard http
 # disable /etc/cockpit/
-XDG_CONFIG_DIRS="$BROWSER_HOME" COCKPIT_SUPERUSER="pkexec" '${COCKPIT_WS:-/usr/libexec/cockpit-ws}' -p 80 -a 127.0.0.90 --local-session=- <&0 >&1 &
+XDG_CONFIG_DIRS="$BROWSER_HOME" COCKPIT_SUPERUSER="pkexec" /usr/libexec/cockpit-ws -p 80 -a 127.0.0.90 --local-session=cockpit-bridge &
 WS_PID=$!
-# ... and stop using that stdin/out for everything else
-exec 0</dev/null
 exec 1>&2
 
-trap "set +e; kill $WS_PID; wait $WS_PID; rm -rf $BROWSER_HOME" EXIT INT QUIT PIPE
+trap 'set +e; kill $WS_PID; wait $WS_PID; rm -rf $BROWSER_HOME' EXIT INT QUIT PIPE
 
 # if we have netcat, use it for waiting until ws is up
 if type nc >/dev/null 2>&1; then
-    for retry in `seq 10`; do
+    for _ in `seq 10`; do
         nc -z 127.0.0.90 80 && break
         sleep 0.5;
     done
@@ -134,6 +86,4 @@ else
     sleep 3
 fi
 
-HOME="$BROWSER_HOME" '$BROWSER' http://127.0.0.90'"$URL_PATH"'
-'
-/bin/bash -c "$SCRIPT" <&${COPROC[0]} >&${COPROC[1]}
+HOME="$BROWSER_HOME" $BROWSER http://127.0.0.90"$URL_PATH"


### PR DESCRIPTION
Stop using coproc, nesting bash and calling unshare. All these are needed for the namespace isolation which we don't need in anaconda.
