### PR TITLE
iscsi: Allow changing iSCSI initiator name once set

### DIFF
--- a/pyanaconda/modules/storage/iscsi/iscsi.py
+++ b/pyanaconda/modules/storage/iscsi/iscsi.py
@@ -69,7 +69,7 @@ class ISCSIModule(KickstartBaseModule):
 
         :param initiator: a name of the initiator
         """
-        if not iscsi.initiator_set:
+        if not iscsi.initiator_set or (initiator != iscsi.initiator and self.can_set_initiator()):
             iscsi.initiator = initiator
             self.initiator_changed.emit()
             log.debug("The iSCSI initiator is set to '%s'.", initiator)
@@ -79,9 +79,10 @@ class ISCSIModule(KickstartBaseModule):
     def can_set_initiator(self):
         """Can the initiator be set?
 
-        Once the initiator name is set it can't be changed.
+        Initiator name can be changed when no sessions are active.
         """
-        return not iscsi.initiator_set
+        active = iscsi._get_active_sessions()
+        return not active
 
     def get_interface_mode(self):
         """Get the mode of interfaces used for iSCSI operations.

--- a/pyanaconda/modules/storage/iscsi/iscsi_interface.py
+++ b/pyanaconda/modules/storage/iscsi/iscsi_interface.py
@@ -70,11 +70,7 @@ class ISCSIInterface(KickstartModuleInterfaceTemplate):
     def CanSetInitiator(self) -> Bool:
         """Can the iSCSI initator be set?
 
-        Once the initiator name is set it can't be changed.
-        FIXME
-        Investigate if it needs to be so strict? Perhaps it has to be frozen only
-        once there are active nodes logged in, or once any nodes were discovered.
-        This would need to be changed in blivet/iscsi.py.
+        Initiator name can be changed when no sessions are active.
         """
         return self.implementation.can_set_initiator()
 


### PR DESCRIPTION
Blivet (and UDisks) now allow changing of the initiator name which can now be changed unless an active session already exists.

Resolves: rhbz#2223977

Blivet changes: https://github.com/storaged-project/blivet/pull/1147