### PR TITLE
webui: Prevent the Anaconda window from being closed by keyboard shortcuts

### DIFF
--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -55,6 +55,8 @@ export const Application = () => {
     const [storeInitilized, setStoreInitialized] = useState(false);
 
     useEffect(() => {
+        // Before unload ask the user for verification
+        window.onbeforeunload = e => "";
         cockpit.file("/run/anaconda/bus.address").watch(address => {
             setCriticalError();
             const clients = [

--- a/ui/webui/test/check-language
+++ b/ui/webui/test/check-language
@@ -112,10 +112,6 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
         l.check_selected_locale("he_IL")
         b.wait_attr("html", "dir", "rtl")
 
-        # Language direction should persist after reload
-        b.reload()
-        b.wait_attr("html", "dir", "rtl")
-
         l.select_locale("de_DE")
         l.check_selected_locale("de_DE")
         b.wait_attr("html", "dir", "ltr")


### PR DESCRIPTION
**The changes in this PR do not prevent closing the application window, but only add a confirmation window before quitting.**
In most browsers this behavior is prevented because it could be used to attack https://stackoverflow.com/questions/30781070/prevent-onbeforeunload-to-close-page-in-any-case. 
Therefore, this seems to me to be the only possible solution at the moment.