### PR TITLE
infra: Fix permissions for Permian GitHub reporter

### DIFF
--- a/.github/workflows/webui-tests.yml
+++ b/.github/workflows/webui-tests.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: read
   statuses: write
+  checks: write
 
 jobs:
   pr-info:

--- a/.github/workflows/webui-tests.yml.j2
+++ b/.github/workflows/webui-tests.yml.j2
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   statuses: write
+  checks: write
 
 jobs:
   pr-info:


### PR DESCRIPTION
This should fix Permian not being able to report results of webui e2e tests to PR
