### PR TITLE
webui: Disable minification     

### DIFF
--- a/ui/webui/build.js
+++ b/ui/webui/build.js
@@ -63,7 +63,7 @@ const context = await esbuild.context({
         ".js": "jsx",
         ".py": "text",
     },
-    minify: production,
+    minify: false,
     nodePaths,
     outdir,
     target: ['es2020'],


### PR DESCRIPTION
Disable minification when we build our JS code, so that the code we ship in our RPMs can be debugged.

This should improve the debugging of runtime issues on any media built from RPM packages as well as for any cases where we apply updates images built from RPM packages.