### PR TITLE
webui: debounce password quality checks to be done only once per 300ms

### DIFF
--- a/ui/webui/package.json
+++ b/ui/webui/package.json
@@ -48,6 +48,7 @@
     "@patternfly/react-log-viewer": "^4.51.2",
     "@patternfly/react-table": "^4.75.2",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "throttle-debounce": "^5.0.0"
   }
 }

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -17,6 +17,7 @@
 
 import cockpit from "cockpit";
 import React, { useState, useEffect } from "react";
+import { debounce } from "throttle-debounce";
 
 import {
     Button,
@@ -110,6 +111,12 @@ const PasswordFormFields = ({
 }) => {
     const [passwordHidden, setPasswordHidden] = useState(true);
     const [confirmHidden, setConfirmHidden] = useState(true);
+    const [_password, _setPassword] = useState(password);
+
+    useEffect(() => {
+        debounce(300, () => onChange(_password))();
+    }, [_password, onChange]);
+
     return (
         <>
             <FormGroup
@@ -119,8 +126,8 @@ const PasswordFormFields = ({
                 <InputGroup>
                     <TextInput
                       type={passwordHidden ? "password" : "text"}
-                      value={password}
-                      onChange={onChange}
+                      value={_password}
+                      onChange={_setPassword}
                       id={idPrefix + "-password-field"}
                     />
                     <Button


### PR DESCRIPTION
Otherwise this call is performed for each user key stroke, resulting in a pretty inefficient password check.

Will fix the following flake: https://cockpit-logs.us-east-1.linodeobjects.com/pull-4946-20230725-160918-c9d5fa06-fedora-rawhide-boot/log.html#11