### PR TITLE
infra: Fix check of test results in webui-tests workflow

### DIFF
--- a/.github/workflows/webui-tests.yml
+++ b/.github/workflows/webui-tests.yml
@@ -242,6 +242,7 @@ jobs:
       # Permian exit code doesn't reflect the test results
       - name: Check tests results
         working-directory: ./permian
+        shell: bash {0}
         run: |
           fails=$( grep -E '<failure .* type="failure"/>|<error .* type="error"/>' xunit*.xml )
           if [ -n "$fails" ]; then

--- a/.github/workflows/webui-tests.yml.j2
+++ b/.github/workflows/webui-tests.yml.j2
@@ -236,6 +236,7 @@ jobs:
       # Permian exit code doesn't reflect the test results
       - name: Check tests results
         working-directory: ./permian
+        shell: bash {0}
         run: |
           fails=$( grep -E '<failure .* type="failure"/>|<error .* type="error"/>' xunit*.xml )
           if [ -n "$fails" ]; then


### PR DESCRIPTION
The check doesn't work with the default "bash -e"