### PR TITLE
webui: docs: fix documentation on how to re-create the updates.img

### DIFF
--- a/ui/webui/test/README.rst
+++ b/ui/webui/test/README.rst
@@ -63,13 +63,10 @@ that the initial run may take a few minutes.
 Updating the testing environment
 --------------------------------
 
-After the code is changed the testing environemnt needs to be updated.
-The most robust way of doing this is (from top level directory)::
+After the code is changed the testing environment needs to be updated.
+The most robust way of doing this is::
 
-    rm -rf ui/webui/dist/ updates.img
-    make rpms
-    cd ui/webui
-    make ../../updates.img
+    make create-updates.img
 
 Interactive browser
 -------------------


### PR DESCRIPTION
`make rpms` step is not needed. The srpms are built from the `prepare-updates-img` script which is called from this makefile target.
