### PR TITLE
Revert 64k ARM switcher

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -302,9 +302,6 @@ password_policies =
     user (quality 1, length 6, empty)
     luks (quality 1, length 6)
 
-# Should kernel options be shown in the software selection spoke?
-show_kernel_options = True
-
 [License]
 # A path to EULA (if any)
 #

--- a/data/profile.d/rhel.conf
+++ b/data/profile.d/rhel.conf
@@ -39,7 +39,6 @@ swap_is_recommended = True
 [User Interface]
 help_directory = /usr/share/anaconda/help/rhel
 custom_stylesheet = /usr/share/anaconda/pixmaps/redhat.css
-show_kernel_options = True
 
 [License]
 eula = /usr/share/redhat-release/EULA

--- a/pyanaconda/core/configuration/ui.py
+++ b/pyanaconda/core/configuration/ui.py
@@ -90,10 +90,6 @@ class UserInterfaceSection(Section):
         """Convert a policies string into a list of dictionaries."""
         return list(map(self._convert_policy_line, value.strip().split("\n")))
 
-    @property
-    def show_kernel_options(self):
-        return self._get_option("show_kernel_options", bool)
-
     @classmethod
     def _convert_policy_line(cls, line):
         """Convert a policy line into a dictionary."""

--- a/pyanaconda/ui/gui/spokes/software_selection.glade
+++ b/pyanaconda/ui/gui/spokes/software_selection.glade
@@ -1,28 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.40.0 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.10"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
   <object class="AnacondaSpokeWindow" id="softwareWindow">
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="hexpand">True</property>
     <property name="vexpand">True</property>
-    <property name="window-name" translatable="yes">SOFTWARE SELECTION</property>
+    <property name="window_name" translatable="yes">SOFTWARE SELECTION</property>
     <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
     <signal name="info-bar-clicked" handler="on_info_bar_clicked" swapped="no"/>
     <child internal-child="main_box">
       <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
-        <property name="can-focus">False</property>
+        <property name="can_focus">False</property>
         <property name="hexpand">True</property>
         <property name="vexpand">True</property>
         <property name="orientation">vertical</property>
         <child internal-child="nav_box">
           <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <child internal-child="nav_area">
-              <!-- n-columns=3 n-rows=3 -->
               <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
               </object>
             </child>
           </object>
@@ -34,85 +33,35 @@
         </child>
         <child internal-child="alignment">
           <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <property name="xalign">0</property>
             <property name="yalign">0</property>
-            <property name="top-padding">12</property>
-            <property name="bottom-padding">48</property>
-            <property name="left-padding">24</property>
-            <property name="right-padding">24</property>
+            <property name="top_padding">12</property>
+            <property name="bottom_padding">48</property>
+            <property name="left_padding">24</property>
+            <property name="right_padding">24</property>
             <child internal-child="action_area">
               <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <!-- n-columns=2 n-rows=3 -->
                   <object class="GtkGrid" id="grid1">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
-                    <property name="column-spacing">24</property>
-                    <property name="column-homogeneous">True</property>
-                    <child>
-                      <object class="GtkLabel" id="label2">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="valign">end</property>
-                        <property name="margin-bottom">6</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Additional software for Selected Environment</property>
-                        <property name="wrap">True</property>
-                        <property name="xalign">0</property>
-                        <attributes>
-                          <attribute name="font-desc" value="Cantarell 12"/>
-                          <attribute name="weight" value="normal"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkScrolledWindow" id="addonScrolledWindow">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="hexpand">True</property>
-                        <property name="vexpand">True</property>
-                        <property name="hscrollbar-policy">never</property>
-                        <property name="shadow-type">in</property>
-                        <child>
-                          <object class="GtkViewport" id="addonViewport">
-                            <property name="width-request">250</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <child>
-                              <object class="GtkListBox" id="addonListBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="hexpand">True</property>
-                                <signal name="row-activated" handler="on_addon_activated" swapped="no"/>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">1</property>
-                      </packing>
-                    </child>
+                    <property name="column_spacing">24</property>
+                    <property name="column_homogeneous">True</property>
                     <child>
                       <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <property name="valign">end</property>
-                        <property name="margin-bottom">6</property>
+                        <property name="margin_bottom">6</property>
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Base Environment</property>
                         <property name="wrap">True</property>
@@ -123,139 +72,88 @@
                         </attributes>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">0</property>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="orientation">vertical</property>
+                        <property name="can_focus">False</property>
+                        <property name="valign">end</property>
+                        <property name="margin_bottom">6</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">Additional software for Selected Environment</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                        <attributes>
+                          <attribute name="font-desc" value="Cantarell 12"/>
+                          <attribute name="weight" value="normal"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkScrolledWindow" id="addonScrolledWindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="hscrollbar_policy">never</property>
+                        <property name="shadow_type">in</property>
                         <child>
-                          <object class="GtkScrolledWindow" id="environmentScrolledWindow">
+                          <object class="GtkViewport" id="addonViewport">
+                            <property name="width_request">250</property>
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="events">GDK_STRUCTURE_MASK | GDK_SCROLL_MASK</property>
-                            <property name="hexpand">True</property>
-                            <property name="vexpand">True</property>
-                            <property name="hscrollbar-policy">never</property>
-                            <property name="shadow-type">in</property>
+                            <property name="can_focus">False</property>
                             <child>
-                              <object class="GtkViewport" id="environmentViewport">
-                                <property name="width-request">250</property>
+                              <object class="GtkListBox" id="addonListBox">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <child>
-                                  <object class="GtkListBox" id="environmentListBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="hexpand">True</property>
-                                    <signal name="row-activated" handler="on_environment_activated" swapped="no"/>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="kernelBox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="orientation">vertical</property>
-                            <property name="spacing">12</property>
-                            <child>
-                              <object class="GtkLabel" id="label3">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="valign">end</property>
-                                <property name="margin-top">12</property>
+                                <property name="can_focus">False</property>
                                 <property name="hexpand">True</property>
-                                <property name="label" translatable="yes">Kernel Options</property>
-                                <property name="wrap">True</property>
-                                <property name="xalign">0</property>
-                                <attributes>
-                                  <attribute name="font-desc" value="Cantarell 12"/>
-                                  <attribute name="weight" value="normal"/>
-                                </attributes>
+                                <signal name="row-activated" handler="on_addon_activated" swapped="no"/>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <!-- n-columns=2 n-rows=1 -->
-                              <object class="GtkGrid" id="kernelComboGrid">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="row-spacing">12</property>
-                                <child>
-                                  <object class="GtkLabel" id="kernelPageSizeLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-start">12</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="label" translatable="yes">Page size:</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="kernelPageSizeCombo">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="active">0</property>
-                                    <property name="id-column">0</property>
-                                    <child>
-                                      <object class="GtkCellRendererText"/>
-                                      <attributes>
-                                        <attribute name="markup">1</attribute>
-                                        <attribute name="single-paragraph-mode">1</attribute>
-                                        <attribute name="text">1</attribute>
-                                      </attributes>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">0</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">3</property>
-                              </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">1</property>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">1</property>
                       </packing>
                     </child>
                     <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
+                      <object class="GtkScrolledWindow" id="environmentScrolledWindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="events">GDK_STRUCTURE_MASK | GDK_SCROLL_MASK</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="hscrollbar_policy">never</property>
+                        <property name="shadow_type">in</property>
+                        <child>
+                          <object class="GtkViewport" id="environmentViewport">
+                            <property name="width_request">250</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkListBox" id="environmentListBox">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="hexpand">True</property>
+                                <signal name="row-activated" handler="on_environment_activated" swapped="no"/>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>

--- a/pyanaconda/ui/gui/spokes/software_selection.py
+++ b/pyanaconda/ui/gui/spokes/software_selection.py
@@ -32,13 +32,9 @@ from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.gui.spokes.lib.detailederror import DetailedErrorDialog
 from pyanaconda.ui.gui.spokes.lib.software_selection import GroupListBoxRow, SeparatorRow, \
     EnvironmentListBoxRow
-from pyanaconda.ui.gui.utils import escape_markup
 from pyanaconda.ui.lib.software import SoftwareSelectionCache, get_software_selection_status, \
     is_software_selection_complete, get_group_data, get_environment_data
 from pyanaconda.ui.lib.subscription import is_cdn_registration_required
-from pyanaconda.ui.lib.software import FEATURE_64K, KernelFeatures, get_kernel_from_properties, \
-    get_available_kernel_features, get_kernel_titles_and_descriptions
-from pyanaconda.core.configuration.anaconda import conf
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -97,23 +93,6 @@ class SoftwareSelectionSpoke(NormalSpoke):
         self._addon_list_box.set_focus_vadjustment(
             Gtk.Scrollable.get_vadjustment(addon_viewport)
         )
-
-        # Display a group of options for selecting desired properties of a kernel
-        self._kernel_box = self.builder.get_object("kernelBox")
-        self._combo_kernel_page_size = self.builder.get_object("kernelPageSizeCombo")
-        self._label_kernel_page_size = self.builder.get_object("kernelPageSizeLabel")
-
-        # Normally I would create these in the .glade file but due to a bug they weren't
-        # created properly
-        self._model_kernel_page_size = Gtk.ListStore(str, str)
-
-        kernel_labels = get_kernel_titles_and_descriptions()
-        for i in ["4k", "64k"]:
-            self._model_kernel_page_size.append([i, "<b>%s</b>\n%s" % \
-                                                (escape_markup(kernel_labels[i][0]),
-                                                 escape_markup(kernel_labels[i][1]))])
-        self._combo_kernel_page_size.set_model(self._model_kernel_page_size)
-        self._available_kernels = get_available_kernel_features(self.payload)
 
     @property
     def _selection(self):
@@ -235,12 +214,10 @@ class SoftwareSelectionSpoke(NormalSpoke):
         # Create a new software selection cache.
         self._selection_cache = SoftwareSelectionCache(self.payload.proxy)
         self._selection_cache.apply_selection_data(self._selection)
-        self._available_kernels = get_available_kernel_features(self.payload)
 
         # Refresh up the UI.
         self._refresh_environments()
         self._refresh_groups()
-        self._refresh_kernel_features()
 
         # Set up the info bar.
         self.clear_info()
@@ -314,51 +291,12 @@ class SoftwareSelectionSpoke(NormalSpoke):
             listbox.remove(child)
             del child
 
-    def _refresh_kernel_features(self):
-        """Display options for selecting kernel features."""
-
-        # Only showing parts of kernel box relevant for current system.
-        self._available_kernels = get_available_kernel_features(self.payload)
-
-        if not conf.ui.show_kernel_options:
-            show_kernels = False
-        else:
-            show_kernels = False
-            for (_key, val) in self._available_kernels.items():
-                if val:
-                    show_kernels = True
-                    break
-
-        if show_kernels:
-            self._kernel_box.set_visible(True)
-            self._kernel_box.set_no_show_all(False)
-
-            # Arm 64k page size kernel combo
-            self._combo_kernel_page_size.set_visible(self._available_kernels[FEATURE_64K])
-            self._combo_kernel_page_size.set_no_show_all(not self._available_kernels[FEATURE_64K])
-            self._label_kernel_page_size.set_visible(self._available_kernels[FEATURE_64K])
-            self._label_kernel_page_size.set_no_show_all(not self._available_kernels[FEATURE_64K])
-        else:
-            # Hide the entire box.
-            self._kernel_box.set_visible(False)
-            self._kernel_box.set_no_show_all(True)
-
     def apply(self):
         """Apply the changes."""
         self._kickstarted = False
 
         selection = self._selection_cache.get_selection_data()
         log.debug("Setting new software selection: %s", selection)
-
-        # Select kernel
-        property_64k = self._available_kernels[FEATURE_64K] and \
-            self._combo_kernel_page_size.get_active_id() == FEATURE_64K
-        kernel_properties = KernelFeatures(property_64k)
-        kernel = get_kernel_from_properties(kernel_properties)
-        if kernel is not None and conf.ui.show_kernel_options:
-            log.debug("Selected kernel package: %s", kernel)
-            selection.packages.append(kernel)
-            selection.excluded_packages.append("kernel")
 
         self.payload.set_packages_selection(selection)
 

--- a/pyanaconda/ui/lib/software.py
+++ b/pyanaconda/ui/lib/software.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2023 Red Hat, Inc.
+# Copyright (C) 2021  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -15,18 +15,12 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from collections import namedtuple
-from blivet.arch import is_aarch64
-
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.structures.comps import CompsEnvironmentData, CompsGroupData
 from pyanaconda.modules.common.structures.packages import PackagesSelectionData
 
 log = get_module_logger(__name__)
-
-FEATURE_64K = "64k"
-KernelFeatures = namedtuple("KernelFeatures", ["page_size_64k"])
 
 
 def get_environment_data(dnf_proxy, environment_name):
@@ -100,41 +94,6 @@ def get_software_selection_status(dnf_proxy, selection, kickstarted=False):
     )
 
     return environment_data.name
-
-
-def get_available_kernel_features(payload):
-    """Returns a dictionary with that shows which kernels should be shown in the UI.
-    """
-    features = {
-        FEATURE_64K: is_aarch64() and any(payload.match_available_packages("kernel-64k"))
-    }
-
-    return features
-
-
-def get_kernel_titles_and_descriptions():
-    """Returns a dictionary with descriptions and titles for different kernel options.
-    """
-    kernel_features = {
-        "4k": (_("4k"), _("More efficient memory usage in smaller environments")),
-        "64k": (_("64k"), _("System performance gains for memory-intensive workloads")),
-    }
-
-    return kernel_features
-
-
-def get_kernel_from_properties(features):
-    """Translates the selection of required properties into a kernel package name and returns it
-    or returns None if no properties were selected.
-    """
-    kernels = {
-        # ARM 64k    Package Name
-        ( False   ): None,
-        ( True    ): "kernel-64k",
-    }
-
-    kernel_package = kernels[features[0]]
-    return kernel_package
 
 
 class SoftwareSelectionCache(object):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -23,12 +23,9 @@ from pyanaconda.ui.lib.software import get_software_selection_status, \
     is_software_selection_complete, SoftwareSelectionCache, get_group_data, get_environment_data
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.core.threads import thread_manager
-from pyanaconda.ui.lib.software import FEATURE_64K, KernelFeatures, \
-    get_kernel_from_properties, get_available_kernel_features, get_kernel_titles_and_descriptions
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.constants import THREAD_PAYLOAD, THREAD_CHECK_SOFTWARE, \
     THREAD_SOFTWARE_WATCHER, PAYLOAD_TYPE_DNF
-from pyanaconda.core.configuration.anaconda import conf
 
 from simpleline.render.containers import ListColumnContainer
 from simpleline.render.prompt import Prompt
@@ -72,8 +69,6 @@ class SoftwareSpoke(NormalTUISpoke):
 
         # Get the packages configuration.
         self._selection_cache = SoftwareSelectionCache(self.payload.proxy)
-        self._kernel_selection = None
-        self._available_kernels = None
 
         # Are we taking values (package list) from a kickstart file?
         self._kickstarted = flags.automatedInstall and self.payload.proxy.PackagesKickstarted
@@ -96,9 +91,6 @@ class SoftwareSpoke(NormalTUISpoke):
     def _initialize(self):
         """Initialize the spoke in a separate thread."""
         thread_manager.wait(THREAD_PAYLOAD)
-
-        self._available_kernels = get_available_kernel_features(self.payload)
-        self._kernel_selection = dict.fromkeys(self._available_kernels, False)
 
         # Initialize and check the software selection.
         self._initialize_selection()
@@ -260,8 +252,7 @@ class SoftwareSpoke(NormalTUISpoke):
                     self.data,
                     self.storage,
                     self.payload,
-                    self._selection_cache,
-                    self._kernel_selection
+                    self._selection_cache
                 )
                 ScreenHandler.push_screen_modal(spoke)
                 self.apply()
@@ -278,19 +269,6 @@ class SoftwareSpoke(NormalTUISpoke):
         selection = self._selection_cache.get_selection_data()
         log.debug("Setting new software selection: %s", selection)
 
-        # Processing chosen kernel
-        if conf.ui.show_kernel_options:
-            self._available_kernels = get_available_kernel_features(self.payload)
-            feature_64k = self._available_kernels[FEATURE_64K] and \
-                self._kernel_selection[FEATURE_64K]
-            features = KernelFeatures(feature_64k)
-            kernel = get_kernel_from_properties(features)
-            if kernel:
-                log.debug("Selected kernel package: %s", kernel)
-                selection.packages.append(kernel)
-                selection.excluded_packages.append("kernel")
-
-        log.debug("Setting new software selection: %s", self._selection)
         self.payload.set_packages_selection(selection)
 
     def execute(self):
@@ -319,12 +297,11 @@ class AdditionalSoftwareSpoke(NormalTUISpoke):
     """The spoke for choosing the additional software."""
     category = SoftwareCategory
 
-    def __init__(self, data, storage, payload, selection_cache, kernel_selection):
+    def __init__(self, data, storage, payload, selection_cache):
         super().__init__(data, storage, payload)
         self.title = N_("Software selection")
         self._container = None
         self._selection_cache = selection_cache
-        self._kernel_selection = kernel_selection
 
     def refresh(self, args=None):
         """Refresh the screen."""
@@ -365,79 +342,11 @@ class AdditionalSoftwareSpoke(NormalTUISpoke):
         else:
             self._selection_cache.deselect_group(group)
 
-    def _show_kernel_features_screen(self, kernels):
-        """Returns True if at least one non-standard kernel is available.
-        """
-        if not conf.ui.show_kernel_options:
-            return False
-        for val in kernels.values():
-            if val:
-                return True
-        return False
-
     def input(self, args, key):
         if self._container.process_user_input(key):
             return InputState.PROCESSED_AND_REDRAW
-        if key.lower() == Prompt.CONTINUE:
-            available_kernels = get_available_kernel_features(self.payload)
-            if self._show_kernel_features_screen(available_kernels):
-                spoke = KernelSelectionSpoke(self.data, self.storage, self.payload,
-                                             self._selection_cache, self._kernel_selection,
-                                             available_kernels)
-                ScreenHandler.push_screen_modal(spoke)
-            self.execute()
-            self.close()
-            return InputState.PROCESSED
-
-        return super().input(args, key)
-
-    def apply(self):
-        pass
-
-class KernelSelectionSpoke(NormalTUISpoke):
-    """A subspoke for selecting kernel features.
-    """
-    def __init__(self, data, storage, payload, selection_cache, _kernel_selection, available_kernels):
-        super().__init__(data, storage, payload)
-        self.title = N_("Kernel Options")
-        self._container = None
-        self._selection_cache = selection_cache
-        self._kernel_selection = _kernel_selection
-        self._available_kernels = available_kernels
-
-    def refresh(self, args=None):
-        NormalTUISpoke.refresh(self)
-
-        # Retrieving translated UI strings
-        labels = get_kernel_titles_and_descriptions()
-
-        # Updating kernel availability
-        self._available_kernels = get_available_kernel_features(self.payload)
-        self._container = ListColumnContainer(2, columns_width=38, spacing=2)
-
-        # Rendering kernel checkboxes
-        for (name, val) in self._kernel_selection.items():
-            if not self._available_kernels[name]:
-                continue
-            (title, text) = labels[name]
-            widget = CheckboxWidget(title="%s" % title, text="%s" % text, completed=val)
-            self._container.add(widget, callback=self._set_kernel_callback, data=name)
-
-        self.window.add_with_separator(TextWidget(_("Kernel options")))
-        self.window.add_with_separator(self._container)
-
-    def _set_kernel_callback(self, data):
-        self._kernel_selection[data] = not self._kernel_selection[data]
-
-    def input(self, args, key):
-        if self._container.process_user_input(key):
-            return InputState.PROCESSED_AND_REDRAW
-
-        if key.lower() == Prompt.CONTINUE:
-            self.close()
-            return InputState.PROCESSED
-
-        return super().input(args, key)
+        else:
+            return super().input(args, key)
 
     def apply(self):
         pass

--- a/tests/unit_tests/pyanaconda_tests/ui/test_software.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_software.py
@@ -16,7 +16,6 @@
 # Red Hat, Inc.
 #
 import unittest
-from unittest.mock import patch
 from unittest.mock import Mock
 
 from dasbus.structure import compare_data
@@ -26,8 +25,8 @@ from pyanaconda.modules.common.structures.packages import PackagesSelectionData
 from pyanaconda.modules.payloads.payload.dnf.dnf import DNFModule
 from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager
 from pyanaconda.ui.lib.software import is_software_selection_complete, \
-    get_software_selection_status, SoftwareSelectionCache, get_kernel_from_properties, \
-    get_available_kernel_features, KernelFeatures
+    get_software_selection_status, SoftwareSelectionCache
+
 
 def get_dnf_proxy(dnf_manager):
     """Create a DNF payload proxy using the specified DNF manager."""
@@ -95,35 +94,6 @@ class SoftwareSelectionUITestCase(unittest.TestCase):
 
         status = get_software_selection_status(self.dnf_proxy, selection, kickstarted=True)
         assert status == "Custom software selected"
-
-    def test_get_kernel_from_properties(self):
-        """Test if kernel features are translated to corrent package names."""
-        assert get_kernel_from_properties(
-            KernelFeatures(page_size_64k=False)) is None
-        assert get_kernel_from_properties(
-            KernelFeatures(page_size_64k=True)) == "kernel-64k"
-
-    @patch("pyanaconda.ui.lib.software.is_aarch64")
-    def test_get_available_kernel_features(self, is_aarch64):
-        """test availability of kernel packages"""
-        payload = Mock()
-        payload.match_available_packages.return_value = ["ntoskrnl"]
-        is_aarch64.return_value = False
-
-        res = get_available_kernel_features(payload)
-        assert isinstance(res, dict)
-        assert len(res) > 0
-        assert not res["64k"]
-        is_aarch64.assert_called_once()
-
-        is_aarch64.return_value = True
-        assert is_aarch64()
-        res = get_available_kernel_features(payload)
-        assert res["64k"]
-
-        payload.match_available_packages.return_value = []
-        res = get_available_kernel_features(payload)
-        assert not res["64k"]
 
 
 class SoftwareSelectionCacheTestCase(unittest.TestCase):


### PR DESCRIPTION
Revert of https://github.com/rhinstaller/anaconda/pull/4858 .

Unfortunately, this changeset is breaking composes now by https://github.com/rhinstaller/anaconda/pull/4858#issuecomment-1652180161 .

The issue is that this changeset was written for RHEL-9 branch but RHEL-9 don't have modularized payload. So all the calls to the payload (or most of them) are wrong. We need bigger changes to this feature before we can get it back.

We can take a look on this after the deadlines we have now. This code is not a priority for now.