### PR TITLE
webui: Introduce cockpit-style debug() helper

### DIFF
--- a/ui/webui/src/apis/localization.js
+++ b/ui/webui/src/apis/localization.js
@@ -18,6 +18,7 @@
 import cockpit from "cockpit";
 
 import { getLanguageAction, getLanguagesAction } from "../actions/localization-actions.js";
+import { debug } from "../helpers/log.js";
 
 export class LocalizationClient {
     constructor (address) {
@@ -159,11 +160,11 @@ export const startEventMonitorLocalization = ({ dispatch }) => {
                 if (args[0] === "org.fedoraproject.Anaconda.Modules.Localization" && Object.hasOwn(args[1], "Language")) {
                     dispatch(getLanguageAction());
                 } else {
-                    console.debug(`Unhandled signal on ${path}: ${iface}.${signal}`, JSON.stringify(args));
+                    debug(`Unhandled signal on ${path}: ${iface}.${signal}`, JSON.stringify(args));
                 }
                 break;
             default:
-                console.debug(`Unhandled signal on ${path}: ${iface}.${signal}`, JSON.stringify(args));
+                debug(`Unhandled signal on ${path}: ${iface}.${signal}`, JSON.stringify(args));
             }
         });
 };

--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -22,6 +22,8 @@ import {
     getPartitioningDataAction
 } from "../actions/storage-actions.js";
 
+import { debug } from "../helpers/log.js";
+
 export class StorageClient {
     constructor (address) {
         if (StorageClient.instance && (!address || StorageClient.instance.address === address)) {
@@ -488,11 +490,11 @@ export const startEventMonitorStorage = ({ dispatch }) => {
                     const last = args[1].CreatedPartitioning.v.length - 1;
                     dispatch(getPartitioningDataAction({ partitioning: args[1].CreatedPartitioning.v[last] }));
                 } else {
-                    console.debug(`Unhandled signal on ${path}: ${iface}.${signal} ${JSON.stringify(args)}`);
+                    debug(`Unhandled signal on ${path}: ${iface}.${signal} ${JSON.stringify(args)}`);
                 }
                 break;
             default:
-                console.debug(`Unhandled signal on ${path}: ${iface}.${signal} ${JSON.stringify(args)}`);
+                debug(`Unhandled signal on ${path}: ${iface}.${signal} ${JSON.stringify(args)}`);
             }
         });
 };

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -41,6 +41,7 @@ import { InstallationLanguage } from "./localization/InstallationLanguage.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
 import { ReviewConfiguration, ReviewConfigurationConfirmModal } from "./review/ReviewConfiguration.jsx";
 import { exitGui } from "../helpers/exit.js";
+import { debug } from "../helpers/log.js";
 import { usePageLocation } from "hooks";
 import {
     applyStorage,
@@ -296,7 +297,7 @@ const Footer = ({
         onBack();
         if (activeStep.id === "installation-review") {
             resetPartitioning().then(() => {
-                console.log("resetPartitioning");
+                debug("resetPartitioning");
             }, console.error);
         }
     };

--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -38,6 +38,7 @@ import { PayloadsClient } from "../apis/payloads";
 import { RuntimeClient, getIsFinal } from "../apis/runtime";
 
 import { readConf } from "../helpers/conf.js";
+import { debug } from "../helpers/log.js";
 import { useReducerWithThunk, reducer, initialState } from "../reducer.js";
 
 export const Application = () => {
@@ -103,7 +104,7 @@ export const Application = () => {
 
     // Postpone rendering anything until we read the dbus address and the default configuration
     if (!criticalError && (!address || !conf || beta === undefined || !osRelease || !storeInitilized)) {
-        console.debug("Loading initial data...");
+        debug("Loading initial data...");
         return null;
     }
 

--- a/ui/webui/src/components/storage/InstallationMethod.jsx
+++ b/ui/webui/src/components/storage/InstallationMethod.jsx
@@ -42,8 +42,8 @@ import {
 } from "../../apis/storage.js";
 
 import { getDevicesAction, getDiskSelectionAction } from "../../actions/storage-actions.js";
-
 import { AnacondaPage } from "../AnacondaPage.jsx";
+import { debug } from "../../helpers/log.js";
 
 import "./InstallationMethod.scss";
 
@@ -89,7 +89,7 @@ const LocalStandardDisks = ({ deviceData, diskSelection, dispatch, idPrefix, isB
     const [isOpen, setIsOpen] = useState(false);
     const refUsableDisks = useRef();
 
-    console.debug("LocalStandardDisks: deviceData: ", JSON.stringify(Object.keys(deviceData)), ", diskSelection: ", JSON.stringify(diskSelection));
+    debug("LocalStandardDisks: deviceData: ", JSON.stringify(Object.keys(deviceData)), ", diskSelection: ", JSON.stringify(diskSelection));
 
     useEffect(() => {
         if (isRescanningDisks) {

--- a/ui/webui/src/helpers/log.js
+++ b/ui/webui/src/helpers/log.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// see https://github.com/cockpit-project/cockpit/blob/main/HACKING.md#debug-logging-in-javascript-console
+export function debug (...args) {
+    if (window.debugging === "all" || window.debugging?.includes("anaconda")) {
+        console.debug("anaconda", ...args);
+    }
+}

--- a/ui/webui/test/README.rst
+++ b/ui/webui/test/README.rst
@@ -82,6 +82,31 @@ You can also run a test against Firefox instead of Chromium::
 
 See below for details.
 
+Debug logging
+-------------
+Enable debug messages in an interactive browser in the JS console with:
+
+.. code-block:: javascript
+
+    window.debugging = "anaconda"
+
+You can do that in a test as well, after the `Installer.open()` call:
+
+.. code-block:: python
+
+    self.brower.eval_js('window.debugging = "anaconda"')
+
+This also supports other values, e.g. get verbose logging for `dbus` interactions. See
+`Cockpit documentation <https://github.com/cockpit-project/cockpit/blob/main/HACKING.md#debug-logging-in-javascript-console>`_.
+
+For debugging failures on CI without interactive access, it is helpful to
+enable CDP and VM interaction logging as well:
+
+.. code-block:: python
+
+    self.browser.cdp.trace = True
+    self.machine.verbose = True
+
 
 Manual testing
 --------------


### PR DESCRIPTION
Change the noisy console.debug() messages and one less important console.log() to a debug() wrapper which checks `window.debugging`, like the other cockpit modules [1].

[1] https://github.com/cockpit-project/cockpit/blob/main/HACKING.md#debug-logging-in-javascript-console

----

[Rendered README](https://github.com/martinpitt/anaconda/blob/debug-messages/ui/webui/test/README.rst#debug-logging)

Tested with:
```diff
--- ui/webui/test/check-language
+++ ui/webui/test/check-language
@@ -57,6 +57,9 @@ class TestLanguage(anacondalib.VirtInstallMachineCase):
         self.addCleanup(l.select_locale, "en_US")
 
         i.open()
+        b.eval_js('window.debugging = "anaconda"')
+        b.cdp.trace = True
+        m.verbose = True
 
         # Expect the default language - this is en at this point - adjust the test when better guess is implemented
         b.wait_in_text("h2", "Welcome to Fedora Linux")

```
and running the test now has the expected verbosity and debug messages, e.g.
```
TEST STEP] select_locale, with de_DE
-> wait: ph_is_present("#installation-language-language-search .pf-c-text-input-group__text-input")
> debug: anaconda Loading initial data...

```