### PR TITLE
webui: unpack GetDiskFreeSpace and GetDiskTotalSpace from array

### DIFF
--- a/ui/webui/src/actions/storage-actions.js
+++ b/ui/webui/src/actions/storage-actions.js
@@ -47,15 +47,15 @@ export const getDeviceDataAction = ({ device }) => {
                 .then(free => {
                     // Since the getDeviceData returns an object with variants as values,
                     // extend it with variants to keep the format consistent
-                    devData.free = cockpit.variant(String, free[0]);
+                    devData.free = cockpit.variant(String, free);
                     return getDiskTotalSpace({ diskNames: [device] });
                 })
                 .then(total => {
-                    devData.total = cockpit.variant(String, total[0]);
+                    devData.total = cockpit.variant(String, total);
                     return getFormatData({ diskName: device });
                 })
                 .then(formatData => {
-                    devData.formatData = formatData[0];
+                    devData.formatData = formatData;
                     return ({ [device]: devData });
                 })
                 .catch(console.error);

--- a/ui/webui/src/apis/storage.js
+++ b/ui/webui/src/apis/storage.js
@@ -119,7 +119,8 @@ export const getDiskFreeSpace = ({ diskNames }) => {
         "/org/fedoraproject/Anaconda/Modules/Storage/DeviceTree",
         "org.fedoraproject.Anaconda.Modules.Storage.DeviceTree.Viewer",
         "GetDiskFreeSpace", [diskNames]
-    );
+    )
+            .then(res => res[0]);
 };
 
 /**
@@ -132,7 +133,8 @@ export const getFormatData = ({ diskName }) => {
         "/org/fedoraproject/Anaconda/Modules/Storage/DeviceTree",
         "org.fedoraproject.Anaconda.Modules.Storage.DeviceTree.Viewer",
         "GetFormatData", [diskName]
-    );
+    )
+            .then(res => res[0]);
 };
 
 /**
@@ -159,7 +161,8 @@ export const getDiskTotalSpace = ({ diskNames }) => {
         "/org/fedoraproject/Anaconda/Modules/Storage/DeviceTree",
         "org.fedoraproject.Anaconda.Modules.Storage.DeviceTree.Viewer",
         "GetDiskTotalSpace", [diskNames]
-    );
+    )
+            .then(res => res[0]);
 };
 
 /**


### PR DESCRIPTION
GetDiskFreeSpace and GetDiskTotalSpace returns an array with an actual value at first index.
We then use this value to check if there is enough free space, e.g.: "diskFreeSpace < requiredSize". While it may not have caused any issues until now, since in JS comparison of array and value (e.g. [99] < 100) still evaluates correctly. But this is just an invitation for bugs in the future and needs to be fixed nevertheless