### PR TITLE
Don't copy bots in container, we don't need them

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -58,6 +58,7 @@ RUN set -ex; \
   bzip2 \
   rpm-ostree \
   python3-pip \
+  rsync \
   # Need to have restorecon for the tests execution
   policycoreutils; \
   # Install non-ELN dependencies

--- a/dockerfile/anaconda-ci/run-build-and-arg
+++ b/dockerfile/anaconda-ci/run-build-and-arg
@@ -2,7 +2,8 @@
 set -eux
 
 # Avoid clobbering the host's checkout, so work from a copy
-cp -r /anaconda /tmp/
+# Also don't copy bots, it breaks things and is useless
+rsync -a /anaconda /tmp/ --exclude ui/webui/bots
 cd /tmp/anaconda
 rm -rf test-logs
 

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -36,6 +36,7 @@ RUN set -ex; \
   curl \
   python3-polib \
   /usr/bin/xargs \
+  rsync \
   rpm-build; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     BRANCH="${git_branch}"; \


### PR DESCRIPTION
This fixes the problem where having `bots` with a downloaded image failed the `container-rpms` because the image could not be copied for some reason.

(However, we remix the container files freely left and right, which is just wonderful, so we need rsync in both containers.)

---

Another of @M4rtinK "ergonomy fixes".