### PR TITLE
Use keyboard configuration from Gnome Shell live

### DIFF
--- a/docs/release-notes/keyboard_from_live.rst
+++ b/docs/release-notes/keyboard_from_live.rst
@@ -1,0 +1,19 @@
+:Type: Live Environment
+:Summary: Use keyboard layout configuration from the Live system
+
+:Description:
+    Until now, users had to specify keyboard layout for the Live environment manually in Anaconda.
+    With this change, live system itself is responsible for the keyboard configuration and
+    Anaconda just reads the configuration from the live system for the installed system.
+
+    The live keyboard layout is used automatically only if the user does not specify it manually.
+    At this moment, only Gnome Shell environment is supported.
+
+    This is proper fix for https://bugzilla.redhat.com/show_bug.cgi?id=2016613 which was resolved
+    by a workaround in the past.
+    It is also a step forward to resolve https://bugzilla.redhat.com/show_bug.cgi?id=1955025 .
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/4976
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2016613
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1955025

--- a/pyanaconda/core/live_user.py
+++ b/pyanaconda/core/live_user.py
@@ -1,0 +1,54 @@
+#
+# live_user.py:  Provide information about liveuser user from the
+# currently running system
+#
+# Copyright (C) 2023
+# Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from collections import namedtuple
+from pwd import getpwnam
+
+from pyanaconda.core.configuration.anaconda import conf
+
+
+User = namedtuple("User", ["name", "uid", "env_add", "env_prune"])
+
+
+def get_live_user():
+    """Get the user name and uid of the liveuser user.
+
+    :return: user name and uid as namedtuple or None
+    :rtype: namedtuple User["name", "uid"]  | None
+    """
+    if not conf.system.provides_liveuser:
+        return None
+
+    try:
+        username = "liveuser"
+        uid = getpwnam(username).pw_uid
+        env_prune = ("GDK_BACKEND",)
+        env_add = {
+            "XDG_RUNTIME_DIR": "/run/user/{}".format(uid),
+            "USER": username,
+            "HOME": "/home/{}".format(username),
+        }
+        return User(name=username,
+                    uid=uid,
+                    env_add=env_add,
+                    env_prune=env_prune)
+    except KeyError:
+        return None

--- a/pyanaconda/modules/localization/installation.py
+++ b/pyanaconda/modules/localization/installation.py
@@ -26,7 +26,7 @@ from pyanaconda.localization import get_locale_console_fonts, find_best_locale_m
 from pyanaconda.modules.common.errors.installation import LanguageInstallationError, \
     KeyboardInstallationError
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.localization.localed import get_missing_keyboard_configuration
+from pyanaconda.modules.localization.utils import get_missing_keyboard_configuration
 
 log = get_module_logger(__name__)
 

--- a/pyanaconda/modules/localization/live_keyboard.py
+++ b/pyanaconda/modules/localization/live_keyboard.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from abc import ABC, abstractmethod
+from pyanaconda.core.util import execWithCaptureAsLiveUser
+from pyanaconda.core.configuration.anaconda import conf
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+def get_live_keyboard_instance():
+    """Return instance of a class based on the current running live system.
+
+    :return: instance of a LiveSystemKeyboardBase based class for the current live environment
+    :rtype: instance of class inherited from LiveSystemKeyboardBase class
+    """
+    if conf.system.provides_liveuser:
+        return GnomeShellKeyboard()
+
+    # TODO: Add support for other Live systems
+    return None
+
+
+class LiveSystemKeyboardBase(ABC):
+
+    @abstractmethod
+    def read_keyboard_layouts(self):
+        """Read keyboard configuration from the current system.
+
+        The configuration have to be returned in format which is understandable by us for the
+        installation. That means localed will understand it.
+
+        :return: a list of "layout (variant)" or "layout" layout specifications
+        :rtype: list(str)
+        """
+        pass
+
+    @staticmethod
+    def _run_as_liveuser(argv):
+        """Run the command in a system as liveuser user.
+
+        :param list argv: list of arguments for the command.
+        :return: output of the command
+        :rtype: str
+        """
+        return execWithCaptureAsLiveUser(argv[0], argv[1:])
+
+
+class GnomeShellKeyboard(LiveSystemKeyboardBase):
+
+    def read_keyboard_layouts(self):
+        """Read keyboard configuration from the current system.
+
+        The configuration have to be returned in format which is understandable by us for the
+        installation. That means localed will understand it.
+
+        :return: a list of "layout (variant)" or "layout" layout specifications
+        :rtype: list(str)
+        """
+        command_args = ["gsettings", "get", "org.gnome.desktop.input-sources", "sources"]
+        sources = self._run_as_liveuser(command_args)
+
+        # convert output "[('xkb', 'us'), ('xkb', 'cz+qwerty')]\n"
+        try:
+            sources = eval(sources.rstrip())
+        except SyntaxError:
+            log.error("Gnome Shell keyboard configuration can't be obtained from source %s!",
+                      sources)
+            return []
+
+        result = []
+
+        for t in sources:
+            # keep only 'xkb' type and ignore 'ibus' variants which can't be used in localed
+            if t[0] == "xkb":
+                layout = t[1]
+                # change layout variant from 'cz+qwerty' to 'cz (qwerty)'
+                if '+' in layout:
+                    layout, variant = layout.split('+')
+                    result.append(f"{layout} ({variant})")
+                else:
+                    result.append(layout)
+
+        return result

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -20,7 +20,6 @@ from pyanaconda.modules.common.constants.services import LOCALED
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.keyboard import join_layout_variant, parse_layout_variant, \
     InvalidLayoutVariantSpec
-from pyanaconda.core.constants import DEFAULT_KEYBOARD
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -228,31 +227,3 @@ class LocaledWrapper(object):
         self.set_keymap(orig_keymap)
 
         return ret
-
-
-def get_missing_keyboard_configuration(localed_wrapper, x_layouts, vc_keymap):
-    """Get missing keyboard settings by conversion and default values.
-
-    :param localed_wrapper: instance of systemd-localed service wrapper
-    :type localed_wrapper: LocaledWrapper
-    :param x_layouts: list of X layout specifications
-    :type x_layouts: list(str)
-    :param vc_keymap: virtual console keyboard mapping name
-    :type vc_keymap: str
-    :returns: tuple of X layouts and VC keyboard settings
-    :rtype: (list(str), str))
-    """
-    if not vc_keymap and not x_layouts:
-        log.debug("Using default value %s for missing virtual console keymap.", DEFAULT_KEYBOARD)
-        vc_keymap = DEFAULT_KEYBOARD
-
-    if not vc_keymap:
-        vc_keymap = localed_wrapper.convert_layouts(x_layouts)
-        log.debug("Missing virtual console keymap value %s converted from %s X layouts",
-                  vc_keymap, x_layouts)
-    if not x_layouts:
-        x_layouts = localed_wrapper.convert_keymap(vc_keymap)
-        log.debug("Missing X layouts value %s converted from %s virtual console keymap",
-                  x_layouts, vc_keymap)
-
-    return x_layouts, vc_keymap

--- a/pyanaconda/modules/localization/localization_interface.py
+++ b/pyanaconda/modules/localization/localization_interface.py
@@ -179,7 +179,7 @@ class LocalizationInterface(KickstartModuleInterface):
         """Set the X layouts for the system.
 
         The layout is specified by values used by setxkbmap(1).  Accepts either
-        layout format (eg "cz") or the layout(variant) format (eg "cz (qerty)")
+        layout format (eg "cz") or the layout(variant) format (eg "cz (qwerty)")
 
         :param x_layouts: List of x layout specifications.
         """

--- a/pyanaconda/modules/localization/runtime.py
+++ b/pyanaconda/modules/localization/runtime.py
@@ -19,7 +19,7 @@ from pyanaconda.core.util import execWithRedirect
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.errors.configuration import KeyboardConfigurationError
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.localization.localed import get_missing_keyboard_configuration
+from pyanaconda.modules.localization.utils import get_missing_keyboard_configuration
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.localization.installation import write_vc_configuration
 

--- a/pyanaconda/modules/localization/utils.py
+++ b/pyanaconda/modules/localization/utils.py
@@ -1,0 +1,49 @@
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.core.constants import DEFAULT_KEYBOARD
+
+from pyanaconda.anaconda_loggers import get_module_logger
+log = get_module_logger(__name__)
+
+
+def get_missing_keyboard_configuration(localed_wrapper, x_layouts, vc_keymap):
+    """Get missing keyboard settings by conversion and default values.
+
+    :param localed_wrapper: instance of systemd-localed service wrapper
+    :type localed_wrapper: LocaledWrapper
+    :param x_layouts: list of X layout specifications
+    :type x_layouts: list(str)
+    :param vc_keymap: virtual console keyboard mapping name
+    :type vc_keymap: str
+    :returns: tuple of X layouts and VC keyboard settings
+    :rtype: (list(str), str))
+    """
+    if not vc_keymap and not x_layouts:
+        log.debug("Using default value %s for missing virtual console keymap", DEFAULT_KEYBOARD)
+        vc_keymap = DEFAULT_KEYBOARD
+
+    if not vc_keymap:
+        vc_keymap = localed_wrapper.convert_layouts(x_layouts)
+        log.debug("Missing virtual console keymap value %s converted from %s X layouts",
+                  vc_keymap, x_layouts)
+    if not x_layouts:
+        x_layouts = localed_wrapper.convert_keymap(vc_keymap)
+        log.debug("Missing X layouts value %s converted from %s virtual console keymap",
+                  x_layouts, vc_keymap)
+
+    return x_layouts, vc_keymap

--- a/tests/unit_tests/pyanaconda_tests/core/test_system.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_system.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+from unittest import TestCase
+from unittest.mock import patch, Mock
+from pyanaconda.core.live_user import get_live_user, User
+
+
+class GetLiveUserTests(TestCase):
+
+    @patch("pyanaconda.core.live_user.conf")
+    @patch("pyanaconda.core.live_user.getpwnam")
+    def test_get_live_user(self, getpwnam_mock, conf_mock):
+        # not live = early exit
+        conf_mock.system.provides_liveuser = False
+        assert get_live_user() is None
+        getpwnam_mock.assert_not_called()
+
+        # live and has user
+        conf_mock.system.provides_liveuser = True
+        getpwnam_mock.return_value = Mock(pw_uid=1024)
+        assert get_live_user() == User(name="liveuser",
+                                       uid=1024,
+                                       env_prune=("GDK_BACKEND",),
+                                       env_add={
+                                           "XDG_RUNTIME_DIR": "/run/user/1024",
+                                           "USER": "liveuser",
+                                           "HOME": "/home/liveuser",
+                                       })
+        getpwnam_mock.assert_called_once_with("liveuser")
+        getpwnam_mock.reset_mock()
+
+        # supposedly live but missing user
+        getpwnam_mock.side_effect = KeyError
+        assert get_live_user() is None
+        getpwnam_mock.assert_called_once_with("liveuser")

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -39,11 +39,11 @@ from pyanaconda.modules.localization.installation import LanguageInstallationTas
     KeyboardInstallationTask, write_vc_configuration, VC_CONF_FILE_PATH, write_x_configuration, \
     X_CONF_DIR, X_CONF_FILE_NAME
 from pyanaconda.modules.localization.localization import LocalizationService
-from pyanaconda.modules.localization.localed import get_missing_keyboard_configuration, \
-    LocaledWrapper
+from pyanaconda.modules.localization.localed import LocaledWrapper
 from pyanaconda.modules.localization.localization_interface import LocalizationInterface
 from pyanaconda.modules.localization.runtime import GetMissingKeyboardConfigurationTask, \
     ApplyKeyboardTask, AssignGenericKeyboardSettingTask, try_to_load_keymap
+from pyanaconda.modules.localization.utils import get_missing_keyboard_configuration
 from pyanaconda.modules.common.task import TaskInterface
 from dasbus.typing import get_variant, Str, Bool
 


### PR DESCRIPTION
Use keyboard configuration from live media before fallbacking to default.

This changeset sets the keyboard layout from live when no configuration was done by user. This way we know that we targeting web UI only because otherwise we force user to do the configuration (have to verify).

_Currently this is just a draft. Needs more polishing. Missing pieces below._

Please check that your PR follows these rules:
* [x] [**Use first layout fro mru as source for vconsole**] This needs to be done to use currently used keyboard for LUKS unlocking.

* [x] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.

* [x] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.

* [x] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.

* [x] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.

* [x] [**Verify that we don't broke spins nor boot.iso**] The logic here builds on premise that keyboard is forced on non web UI installations to be set. I should verify this is true.