### PR TITLE
docs: use correct path for manual VM testing command

### DIFF
--- a/ui/webui/test/README.rst
+++ b/ui/webui/test/README.rst
@@ -114,7 +114,7 @@ Manual testing
 You can conduct manual interactive testing against a test image by starting the
 image like so::
 
-    webui_testvm.py fedora-rawhide-boot
+    test/webui_testvm.py fedora-rawhide-boot
 
 Once the machine is booted and the cockpit socket has been activated, a
 message will be printed describing how to access the virtual machine, via


### PR DESCRIPTION
All commands in the readme assume that the current directory is `ui/webui`, so the VM command is missing `test/` from the path.