### PR TITLE
webui: update cockpit dependencies to the latest released in rawhide

### DIFF
--- a/ui/webui/test/prepare-updates-img
+++ b/ui/webui/test/prepare-updates-img
@@ -5,9 +5,13 @@ set -eu
 # FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies
 # This will change once we include this changes upstream and start building boot.iso with the new dependencies
 # Then we can safely remove this workaround
+#
+# FIXME: Use fix from cockpit-project/cockpit#19147
+# Until that gets released, install cockpit-bridge from the PR COPR instead
+# Original URL: https://kojipkgs.fedoraproject.org//packages/cockpit/297/1.fc39/x86_64/cockpit-bridge-297-1.fc39.x86_64.rpm
 ANACONDA_WEBUI_DEPS_URLS='
-    https://kojipkgs.fedoraproject.org//packages/cockpit/293/1.fc39/x86_64/cockpit-ws-293-1.fc39.x86_64.rpm
-    https://kojipkgs.fedoraproject.org//packages/cockpit/293/1.fc39/x86_64/cockpit-bridge-293-1.fc39.x86_64.rpm
+    https://kojipkgs.fedoraproject.org//packages/cockpit/297/1.fc39/x86_64/cockpit-ws-297-1.fc39.x86_64.rpm
+    https://download.copr.fedorainfracloud.org/results/packit/cockpit-project-cockpit-19147/fedora-rawhide-x86_64/06219778-cockpit/cockpit-bridge-297-1.20230728101545089726.pr19147.3.g2e50bc074.fc39.x86_64.rpm
 '
 
 mkdir -p tmp/extra-rpms


### PR DESCRIPTION
This release changes on how the bridge sends the package files. [1]

This should fix the flake when tests would fail with empty page sometimes when using the pybridge:
wait_js_cond(ph_is_present("body")): Uncaught (in promise) Error: condition did not become true

[1] https://github.com/cockpit-project/cockpit/commit/97bd80971984cf6ce2b4faba1cad79fcb921e068

