### PR TITLE
webui: Add mountpoint assignment test cases with btrfs and LVM

### DIFF
--- a/ui/webui/src/components/storage/MountPointMapping.jsx
+++ b/ui/webui/src/components/storage/MountPointMapping.jsx
@@ -140,18 +140,13 @@ const DeviceColumnSelect = ({ deviceData, devices, idPrefix, lockedLUKSDevices, 
     const device = request["device-spec"];
     const options = devices.map(device => {
         const format = deviceData[device]?.formatData.description.v;
-        const formatType = deviceData[device]?.formatData.type.v;
         const size = cockpit.format_bytes(deviceData[device]?.total.v);
         const description = cockpit.format("$0, $1", format, size);
         const isLockedLUKS = lockedLUKSDevices.some(p => device.includes(p));
-        const isBiosBoot = formatType === "biosboot";
-
-        // TODO: Anaconda does not support formatting btrfs yet
-        const isBtrfsRoot = formatType === "btrfs" && request["mount-point"] === "/";
 
         return (
             <SelectOption
-              isDisabled={isLockedLUKS || isBtrfsRoot || isBiosBoot}
+              isDisabled={isLockedLUKS}
               description={description}
               key={device}
               value={device}
@@ -208,18 +203,14 @@ const DeviceColumn = ({ deviceData, devices, idPrefix, handleRequestChange, lock
 
 const FormatColumn = ({ deviceData, handleRequestChange, idPrefix, request }) => {
     const mountpoint = request["mount-point"];
-    const format = request["format-type"];
     const isRootMountPoint = mountpoint === "/";
-
-    // TODO: Anaconda does not support formatting btrfs yet
-    const isBtrfs = format === "btrfs";
 
     return (
         <Flex>
             <Checkbox
               id={idPrefix + "-checkbox"}
               isChecked={request.reformat}
-              isDisabled={isRootMountPoint || isBtrfs}
+              isDisabled={isRootMountPoint}
               label={_("Reformat")}
               onChange={checked => handleRequestChange(request["mount-point"], request["device-spec"], request["request-id"], checked)}
             />

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -654,5 +654,71 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
 
         r.check_in_disk_row(dev1, 3, "luks-")
 
+    @nondestructive
+    def testBtrfsSubvolumes(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        s = Storage(b, m)
+        r = Review(b)
+
+        self.addCleanup(m.execute, "wipefs --all /dev/vda")
+
+        disk = "/dev/vda"
+        dev = "vda"
+        tmp_mount = "/tmp/btrfs-mount-test"
+        self.partition_disk(disk, [("1MiB", "biosboot"), ("1GB", "ext4"), ("", "btrfs")])
+        m.execute(f"""
+        mkdir {tmp_mount}
+        mount {disk}3 {tmp_mount}
+        btrfs subvolume create {tmp_mount}/root
+        btrfs subvolume create {tmp_mount}/home
+        umount {tmp_mount}
+        rmdir {tmp_mount}
+        """)
+
+        self.udevadm_settle()
+
+        i.open()
+        i.next()
+        s.rescan_disks()
+
+        self.select_mountpoint(i, s, [(dev, True)])
+
+        # verify gathered requests
+        # root partition is not auto-mapped
+        self.check_row_mountpoint(1, "/boot")
+        self.check_row_device(1, "Select a device")
+        self.check_reformat(1, False)
+        self.select_row_device(1, f"{dev}2")
+        self.check_format_type(1, "ext4")
+
+        self.check_row_mountpoint(2, "/")
+        self.check_row_device(2, "Select a device")
+        self.check_reformat(2, True)
+        self.select_row_device(2, "root")
+        self.check_format_type(2, "btrfs")
+
+        self.add_mount()
+        self.select_row_device(3, "home")
+        self.check_reformat(3, False)
+        self.select_row_mountpoint(3, "/home")
+        self.check_format_type(3, "btrfs")
+
+        # Toggle reformat option
+        self.select_reformat(1)
+        self.check_reformat(1, True)
+
+        i.next()
+
+        # verify review screen
+        disk = "vda"
+        r.check_disk(disk, "16.1 GB vda (0x1af4)")
+
+        r.check_disk_row(disk, 1, "vda1: format as biosboot")
+        r.check_disk_row(disk, 2, "vda2: format as ext4, /boot, reformat")
+        r.check_disk_row(disk, 3, "root: format as btrfs, /, reformat")
+        r.check_disk_row(disk, 4, "home: format as btrfs, /home")
+
 if __name__ == '__main__':
     test_main()

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -440,7 +440,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         disk = "/dev/vda"
         dev = "vda"
         btrfsname = "btrfstest"
-        self.partition_disk(disk, [("1MiB", "biosboot"), ("1GB", "ext4"), ("10GiB", "xfs"), ("", "btrfs", "-f", "-L", btrfsname)])
+        self.partition_disk(disk, [("1MiB", "biosboot"), ("1GB", "ext4"), ("10GiB", "btrfs", "-f", "-L", btrfsname), ("", "xfs")])
+
         self.udevadm_settle()
 
         i.open()
@@ -460,14 +461,14 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         self.check_row_mountpoint(2, "/")
         self.check_row_device(2, "Select a device")
         self.check_reformat(2, True)
-        self.select_row_device(2, f"{dev}3")
-        self.check_format_type(2, "xfs")
+        self.select_row_device(2, f"btrfs")
+        self.check_format_type(2, "btrfs")
 
         self.add_mount()
-        self.select_row_device(3, f"btrfs")
-        self.check_format_type(3, "btrfs")
-        self.select_row_mountpoint(3, "/home")
+        self.select_row_device(3, f"{dev}4")
         self.check_reformat(3, False)
+        self.select_row_mountpoint(3, "/home")
+        self.check_format_type(3, "xfs")
 
         # Toggle reformat option
         self.select_reformat(1)
@@ -487,8 +488,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
 
         r.check_disk_row(disk, 1, "vda1: format as biosboot")
         r.check_disk_row(disk, 2, "vda2: format as ext4, /boot, reformat")
-        r.check_disk_row(disk, 3, "vda3: format as xfs, /, reformat")
-        r.check_disk_row(disk, 4, "btrfstest: format as btrfs, /home")
+        r.check_disk_row(disk, 3, "btrfstest: format as btrfs, /, reformat")
+        r.check_disk_row(disk, 4, "vda4: format as xfs, /home")
 
     @nondestructive
     def testNoRootMountPoint(self):

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -409,7 +409,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
 
             command += f"\n{' '.join(sgdisk)}"
 
-            if params[1] != "biosboot":
+            if params[1] not in ("biosboot", None):
                 mkfs = [f"mkfs.{params[1]}"]
 
                 # force flag
@@ -719,6 +719,73 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         r.check_disk_row(disk, 2, "vda2: format as ext4, /boot, reformat")
         r.check_disk_row(disk, 3, "root: format as btrfs, /, reformat")
         r.check_disk_row(disk, 4, "home: format as btrfs, /home")
+
+    @nondestructive
+    def testLVM(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        s = Storage(b, m)
+        r = Review(b)
+
+        vgname = "fedoravg"
+
+        self.addCleanup(m.execute, "wipefs --all /dev/vda")
+        self.addCleanup(m.execute, f"vgremove -y -ff {vgname}")
+
+        disk = "/dev/vda"
+        dev = "vda"
+        self.partition_disk(disk, [("1MiB", "biosboot"), ("1GB", "ext4"), ("", None)])
+        m.execute(f"""
+        vgcreate -y -f {vgname} {disk}3
+        lvcreate -y -l50%FREE -n root {vgname}
+        mkfs.ext4 -F /dev/{vgname}/root
+        lvcreate -y -l100%FREE -n home {vgname}
+        mkfs.ext4 -F /dev/{vgname}/home
+        """)
+
+        self.udevadm_settle()
+
+        i.open()
+        i.next()
+        s.rescan_disks()
+
+        self.select_mountpoint(i, s, [(dev, True)])
+
+        # verify gathered requests
+        # root partition is not auto-mapped
+        self.check_row_mountpoint(1, "/boot")
+        self.check_row_device(1, "Select a device")
+        self.check_reformat(1, False)
+        self.select_row_device(1, f"{dev}2")
+        self.check_format_type(1, "ext4")
+
+        self.check_row_mountpoint(2, "/")
+        self.check_row_device(2, "Select a device")
+        self.check_reformat(2, True)
+        self.select_row_device(2, f"{vgname}-root")
+        self.check_format_type(2, "ext4")
+
+        self.add_mount()
+        self.select_row_device(3, f"{vgname}-home")
+        self.check_reformat(3, False)
+        self.select_row_mountpoint(3, "/home")
+        self.check_format_type(3, "ext4")
+
+        # Toggle reformat option
+        self.select_reformat(1)
+        self.check_reformat(1, True)
+
+        i.next()
+
+        # verify review screen
+        disk = "vda"
+        r.check_disk(disk, "16.1 GB vda (0x1af4)")
+
+        r.check_disk_row(disk, 1, "vda1: format as biosboot")
+        r.check_disk_row(disk, 2, "vda2: format as ext4, /boot, reformat")
+        r.check_disk_row(disk, 3, f"{vgname}-root: format as ext4, /, reformat")
+        r.check_disk_row(disk, 4, f"{vgname}-home: format as ext4, /home")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Two test cases with more complex storage -- btrfs subvolumes and plain LVM setup.
First commit is taken from #4964, I'll remove it in the final version.
