### PR TITLE
webui: Enable source maps

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -437,7 +437,9 @@ rm -rf \
 %{_datadir}/cockpit/anaconda-webui/index.css.LEGAL.txt
 %{_datadir}/cockpit/anaconda-webui/index.html
 %{_datadir}/cockpit/anaconda-webui/index.js.gz
+%{_datadir}/cockpit/anaconda-webui/index.js.map
 %{_datadir}/cockpit/anaconda-webui/index.css.gz
+%{_datadir}/cockpit/anaconda-webui/index.css.map
 %{_datadir}/cockpit/anaconda-webui/manifest.json
 %{_datadir}/metainfo/org.cockpit-project.anaconda-webui.metainfo.xml
 %{_datadir}/cockpit/anaconda-webui/po.*.js.gz

--- a/ui/webui/build.js
+++ b/ui/webui/build.js
@@ -54,7 +54,7 @@ function watch_dirs(dir, on_change) {
 }
 
 const context = await esbuild.context({
-    ...!production ? { sourcemap: "linked" } : {},
+    sourcemap: "linked",
     bundle: true,
     entryPoints: ["./src/index.js"],
     external: ['*.woff', '*.woff2', '*.jpg', '*.svg', '../../assets*'], // Allow external font files which live in ../../static/fonts


### PR DESCRIPTION
Looks like disabling minification is not enough for a proper debugging experience. Without source maps the source code is visible and readable, but still presented as a single big JS file.

With source maps, the original files and folders from which the Web UI JS code has been built are also visible, making JS issue debugging much more efficient.