### PR TITLE
webui: Enable source maps and enable minification

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -437,7 +437,9 @@ rm -rf \
 %{_datadir}/cockpit/anaconda-webui/index.css.LEGAL.txt
 %{_datadir}/cockpit/anaconda-webui/index.html
 %{_datadir}/cockpit/anaconda-webui/index.js.gz
+%{_datadir}/cockpit/anaconda-webui/index.js.map
 %{_datadir}/cockpit/anaconda-webui/index.css.gz
+%{_datadir}/cockpit/anaconda-webui/index.css.map
 %{_datadir}/cockpit/anaconda-webui/manifest.json
 %{_datadir}/metainfo/org.cockpit-project.anaconda-webui.metainfo.xml
 %{_datadir}/cockpit/anaconda-webui/po.*.js.gz

--- a/ui/webui/build.js
+++ b/ui/webui/build.js
@@ -54,7 +54,7 @@ function watch_dirs(dir, on_change) {
 }
 
 const context = await esbuild.context({
-    ...!production ? { sourcemap: "linked" } : {},
+    sourcemap: "linked",
     bundle: true,
     entryPoints: ["./src/index.js"],
     external: ['*.woff', '*.woff2', '*.jpg', '*.svg', '../../assets*'], // Allow external font files which live in ../../static/fonts
@@ -63,7 +63,7 @@ const context = await esbuild.context({
         ".js": "jsx",
         ".py": "text",
     },
-    minify: false,
+    minify: production,
     nodePaths,
     outdir,
     target: ['es2020'],


### PR DESCRIPTION
Looks like source-maps are necessary to provide context about the source code structure (eq. not showing it just like a single huge combined JS file). At the same time they provide context for the minified JS files.

So to reduce the installed size impact, we can turn on minification again & make sure source maps are built.

This makes debugging possible at all times while keeping the size impact of shipping the source maps manageable.