### PR TITLE
infra: Name built images sensibly

### DIFF
--- a/.github/workflows/build-boot-iso.yml
+++ b/.github/workflows/build-boot-iso.yml
@@ -188,6 +188,19 @@ jobs:
           path: |
             images/*.iso
 
+      - name: Add comment with link to PR
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha="${{ needs.pr-info.outputs.sha }}"
+          url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo -n "\`boot.iso\` built successfully based on commit $sha. " >> comment.txt
+          echo -e "Download it from the bottom of the [job status page]($url).\n" >> comment.txt
+          echo "Comment to be posted:"
+          cat comment.txt
+          gh pr comment ${{ github.event.issue.number }} -F comment.txt
+
       - name: Set result status
         if: always()
         uses: octokit/request-action@v2.x

--- a/.github/workflows/build-boot-iso.yml
+++ b/.github/workflows/build-boot-iso.yml
@@ -63,6 +63,22 @@ jobs:
           echo "arguments are: $ARGS"
           echo "args=${ARGS}" >> $GITHUB_OUTPUT
 
+      - name: Construct image description
+        id: image_description
+        run: |
+          set -eux
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+            # manual run from actions page
+            branch_name="$GITHUB_REF_NAME"
+            sha="$GITHUB_SHA"
+            echo "image_description=$branch_name-$sha" >> $GITHUB_OUTPUT
+          else
+            # comment on PR
+            pr_num="${{ github.event.issue.number }}"
+            sha="${{ steps.pr_api.outcome == 'success' && fromJson(steps.pr_api.outputs.data).head.sha }}"
+            echo "image_description=pr$pr_num-$sha" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set outputs
         id: set_outputs
         run: |
@@ -80,6 +96,7 @@ jobs:
       allowed_user: ${{ steps.set_outputs.outputs.allowed_user }}
       sha: ${{ steps.set_outputs.outputs.sha }}
       args: ${{ steps.parse_args.outputs.args }}
+      image_description: ${{ steps.image_description.outputs.image_description }}
 
   run:
     needs: pr-info
@@ -140,6 +157,7 @@ jobs:
             -v `pwd`/images:/images:z \
             $WEBUI_OPTIONAL_ARG \
             $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG
+          mv images/boot.iso "images/${{ needs.pr-info.outputs.image_description }}-boot.iso"
 
       - name: Collect logs
         if: always()
@@ -149,12 +167,12 @@ jobs:
           path: |
            images/*.log
 
-      - name: Upload image artifacts
+      - name: Upload image
         uses: actions/upload-artifact@v3
         with:
-          name: images
+          name: image ${{ needs.pr-info.outputs.image_description }}
           path: |
-            images/boot.iso
+            images/*.iso
 
       - name: Set result status
         if: always()

--- a/.github/workflows/build-boot-iso.yml
+++ b/.github/workflows/build-boot-iso.yml
@@ -18,6 +18,7 @@ on:
 permissions:
   contents: read
   statuses: write
+  pull-requests: write
 
 jobs:
   pr-info:
@@ -78,6 +79,19 @@ jobs:
             sha="${{ steps.pr_api.outcome == 'success' && fromJson(steps.pr_api.outputs.data).head.sha }}"
             echo "image_description=pr$pr_num-$sha" >> $GITHUB_OUTPUT
           fi
+
+      - name: Mark comment as seen
+        if: github.event_name != 'workflow_dispatch'
+        # https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-an-issue-comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='eyes'
 
       - name: Set outputs
         id: set_outputs

--- a/.github/workflows/build-boot-iso.yml.j2
+++ b/.github/workflows/build-boot-iso.yml.j2
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   statuses: write
+  pull-requests: write
 
 jobs:
   pr-info:
@@ -72,6 +73,19 @@ jobs:
             sha="${{ steps.pr_api.outcome == 'success' && fromJson(steps.pr_api.outputs.data).head.sha }}"
             echo "image_description=pr$pr_num-$sha" >> $GITHUB_OUTPUT
           fi
+
+      - name: Mark comment as seen
+        if: github.event_name != 'workflow_dispatch'
+        # https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28#create-reaction-for-an-issue-comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions" \
+            -f content='eyes'
 
       - name: Set outputs
         id: set_outputs

--- a/.github/workflows/build-boot-iso.yml.j2
+++ b/.github/workflows/build-boot-iso.yml.j2
@@ -182,6 +182,19 @@ jobs:
           path: |
             images/*.iso
 
+      - name: Add comment with link to PR
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha="${{ needs.pr-info.outputs.sha }}"
+          url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo -n "\`boot.iso\` built successfully based on commit $sha. " >> comment.txt
+          echo -e "Download it from the bottom of the [job status page]($url).\n" >> comment.txt
+          echo "Comment to be posted:"
+          cat comment.txt
+          gh pr comment ${{ github.event.issue.number }} -F comment.txt
+
       - name: Set result status
         if: always()
         uses: octokit/request-action@v2.x

--- a/.github/workflows/build-boot-iso.yml.j2
+++ b/.github/workflows/build-boot-iso.yml.j2
@@ -57,6 +57,22 @@ jobs:
           echo "arguments are: $ARGS"
           echo "args=${ARGS}" >> $GITHUB_OUTPUT
 
+      - name: Construct image description
+        id: image_description
+        run: |
+          set -eux
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] ; then
+            # manual run from actions page
+            branch_name="$GITHUB_REF_NAME"
+            sha="$GITHUB_SHA"
+            echo "image_description=$branch_name-$sha" >> $GITHUB_OUTPUT
+          else
+            # comment on PR
+            pr_num="${{ github.event.issue.number }}"
+            sha="${{ steps.pr_api.outcome == 'success' && fromJson(steps.pr_api.outputs.data).head.sha }}"
+            echo "image_description=pr$pr_num-$sha" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set outputs
         id: set_outputs
         run: |
@@ -74,6 +90,7 @@ jobs:
       allowed_user: ${{ steps.set_outputs.outputs.allowed_user }}
       sha: ${{ steps.set_outputs.outputs.sha }}
       args: ${{ steps.parse_args.outputs.args }}
+      image_description: ${{ steps.image_description.outputs.image_description }}
 
   run:
     needs: pr-info
@@ -134,6 +151,7 @@ jobs:
             -v `pwd`/images:/images:z \
             $WEBUI_OPTIONAL_ARG \
             $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG
+          mv images/boot.iso "images/${{ needs.pr-info.outputs.image_description }}-boot.iso"
 
       - name: Collect logs
         if: always()
@@ -143,12 +161,12 @@ jobs:
           path: |
            images/*.log
 
-      - name: Upload image artifacts
+      - name: Upload image
         uses: actions/upload-artifact@v3
         with:
-          name: images
+          name: image ${{ needs.pr-info.outputs.image_description }}
           path: |
-            images/boot.iso
+            images/*.iso
 
       - name: Set result status
         if: always()


### PR DESCRIPTION
Instead of boot.iso, name the images according to what they are built from:
- `pr<#>-<hash>-boot.iso`
- `master-<hash>-boot.iso`

A similar scheme is used for the artifact zip names.