### PR TITLE
Ignore btrfs snapshots in mountpoint assignment

### DIFF
--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -135,6 +135,10 @@ class ManualPartitioningModule(PartitioningModule):
             if not device.isleaf and not device.raw_device.type == "btrfs subvolume":
                 continue
 
+            # We don't want to allow to use snapshots in mount point assignment.
+            if device.raw_device.type == "btrfs snapshot":
+                continue
+
             # Is the device usable?
             if device.protected or device.size == Size(0):
                 continue

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -690,6 +690,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         mount {disk}3 {tmp_mount}
         btrfs subvolume create {tmp_mount}/root
         btrfs subvolume create {tmp_mount}/home
+        btrfs subvolume snapshot {tmp_mount}/root {tmp_mount}/snapshot1
         umount {tmp_mount}
         rmdir {tmp_mount}
         """)
@@ -701,6 +702,9 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         s.rescan_disks()
 
         self.select_mountpoint(i, s, [(dev, True)])
+
+        # btrfs snapshots should not be available
+        self.check_device_available(1, "snapshot1", False)
 
         # verify gathered requests
         # root partition is not auto-mapped


### PR DESCRIPTION
There could be potentially thousands of snapshots on the system, we don't want to deal with this in the UI so we'll allow assigning mount points only to btrfs (sub)volumes.