### PR TITLE
webui: make 'Next' by default 'disabled' and let each component update it

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -195,7 +195,7 @@ export const AnacondaWizard = ({ dispatch, isBootIso, osRelease, storageData, lo
 
     const goToStep = (newStep) => {
         // first reset validation state to default
-        setIsFormValid(true);
+        setIsFormValid(false);
 
         cockpit.location.go([newStep.id]);
     };

--- a/ui/webui/src/components/review/ReviewConfiguration.jsx
+++ b/ui/webui/src/components/review/ReviewConfiguration.jsx
@@ -104,7 +104,7 @@ const DeviceRow = ({ deviceData, disk, requests }) => {
     );
 };
 
-export const ReviewConfiguration = ({ deviceData, diskSelection, language, osRelease, requests, idPrefix, storageScenarioId }) => {
+export const ReviewConfiguration = ({ deviceData, diskSelection, language, osRelease, requests, idPrefix, setIsFormValid, storageScenarioId }) => {
     const [encrypt, setEncrypt] = useState();
 
     useEffect(() => {
@@ -117,7 +117,8 @@ export const ReviewConfiguration = ({ deviceData, diskSelection, language, osRel
             }
         };
         initializeEncrypt();
-    }, []);
+        setIsFormValid(true);
+    }, [setIsFormValid]);
 
     return (
         <AnacondaPage title={_("Review and install")}>


### PR DESCRIPTION
The components were disabling the button also before, if the step was not ready. However, there were a few mili seconds where the button would be enabled, before being updated.
