### PR TITLE
Nested btrfs subvolumes support enhancements in backend

### DIFF
--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -62,6 +62,10 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
         reformat = mount_data.reformat
         format_type = mount_data.format_type
 
+        if not reformat and not mount_data.mount_point:
+            # XXX empty request, ignore
+            return
+
         device = storage.devicetree.resolve_device(device_spec)
         if device is None:
             raise StorageError(

--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -91,6 +91,26 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
 
             if device.raw_device.type in ("btrfs volume", "btrfs subvolume"):
                 # 'Format', or rather clear the device by recreating it
+
+                # recreating @device will remove all nested subvolumes of it, we cannot allow
+                # using these nested subvolumes for other MountPointRequest without also
+                # re-creating them
+                if device.raw_device.type == "btrfs volume":
+                    depending_subvolumes = device.raw_device.subvolumes
+                elif device.raw_device.type == "btrfs subvolume":
+                    depending_subvolumes = [sub.name for sub in device.raw_device.volume.subvolumes
+                                            if sub.depends_on(device.raw_device)]
+                problem_subvolumes = [req for req in self._requests if (req.mount_point
+                                                                        and not req.reformat
+                                                                        and req.device_spec in
+                                                                        depending_subvolumes)]
+                if problem_subvolumes:
+                    err = (_("{} mounted as {}").format(dep.device_spec,
+                                                        dep.mount_point) for dep in problem_subvolumes)
+                    raise StorageError(
+                        _("Reformatting the '{}' subvolume will remove the following nested "
+                          "subvolumes which cannot be reused: {}").format(device.raw_device.name,
+                                                                          ", ".join(err)))
                 device = self._recreate_device(storage, device_spec)
                 mount_data.mount_options = device.format.options
             else:

--- a/ui/webui/src/components/storage/MountPointMapping.jsx
+++ b/ui/webui/src/components/storage/MountPointMapping.jsx
@@ -345,8 +345,8 @@ const MountPointMappingContent = ({ deviceData, partitioningData, dispatch, idPr
                 return {
                     "device-spec": cockpit.variant("s", row["device-spec"]),
                     "format-type": cockpit.variant("s", row["format-type"]),
-                    "mount-point": cockpit.variant("s", newRequest !== undefined ? newRequest["mount-point"] : row["mount-point"]),
-                    reformat: cockpit.variant("b", newRequest !== undefined ? !!newRequest.reformat : row.reformat),
+                    "mount-point": cockpit.variant("s", newRequest !== undefined ? newRequest["mount-point"] : ""),
+                    reformat: cockpit.variant("b", newRequest !== undefined ? !!newRequest.reformat : false),
                 };
             });
         };


### PR DESCRIPTION
The backend check for nested btrfs subvolumes is now a bit obsoleted by #5004 which won't allow to progress with the unsupported selection from the frontend, but I think it still makes sense to have this sanity check in the backend and we need it for the TUI mountpoint assignment anyways.
