### PR TITLE
make: Update POT file correctly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,7 +125,7 @@ pot-update-check: pot
 # - copy pot file to this repository
 # - check if pot file is changed (ignore the POT-Creation-Date otherwise it's always changed)
 	@TEMP_DIR=$$(mktemp --tmpdir -d anaconda-localization-XXXXXXXXXX) || exit 5 ; \
-	git clone --depth 1 -b $(GIT_L10N_SHA) -- $(L10N_REPOSITORY) $$TEMP_DIR || exit 6 ; \
+	git clone --depth 1 -b $(GIT_L10N_BRANCH) -- $(L10N_REPOSITORY) $$TEMP_DIR || exit 6 ; \
 	cp $(srcdir)/po/anaconda.pot $$TEMP_DIR/$(L10N_DIR)/ || exit 7 ; \
 	pushd $$TEMP_DIR/$(L10N_DIR) ; \
 	git difftool --trust-exit-code -y -x "diff -u -I '^\"POT-Creation-Date: .*$$'" HEAD ./anaconda.pot &>/dev/null ; \

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -220,6 +220,14 @@ $(POTFILE): main_js.pot main.pot extra.pot
 $(POFILES): $(PO_DOWNLOADED_FLAG)
 
 $(PO_DOWNLOADED_FLAG):
+# To download po files from the l10n repo at an arbitrary commit $(GIT_L10N_SHA):
+# - clone the repo into /tmp at any branch without actually checking out any files
+# - fetch the commit, so it can be checked out
+# - check out the commit
+# - copy the .po files
+# - remove the repo again
+# - remove any trailing semicolons (";") in Plural-Forms header entries
+# - create the flag file
 	TEMP_DIR=$$(mktemp --tmpdir -d anaconda-localization-XXXXXXXXXX) && \
 	git clone --depth 1 -b $(GIT_L10N_BRANCH) --no-checkout -- $(L10N_REPOSITORY) $$TEMP_DIR && \
 	(cd $$TEMP_DIR && git fetch --depth 1 origin $(GIT_L10N_SHA) && git checkout $(GIT_L10N_SHA)) && \


### PR DESCRIPTION
The changes from 70d7814e6eccc1142298e08fb2c18f55c7c15d37 were mistakenly applied to the top level makefile.

----

Needed to fix the daily pot file updates in l10n repo: https://github.com/rhinstaller/anaconda-l10n/actions/workflows/pot-file-update.yaml