### PR TITLE
Remove PatternFly workaround from build.js

### DIFF
--- a/ui/webui/build.js
+++ b/ui/webui/build.js
@@ -83,13 +83,6 @@ const context = await esbuild.context({
                 { from: ['./src/index.html'], to: ['./index.html'] },
             ]
         }),
-        replace({
-            include: /DataList.js$/,
-            values: {
-                'import stylesGrid': "// HACK: revert when https://github.com/patternfly/patternfly-react/pull/8864 is released",
-                stylesGrid: 'styles',
-            }
-        }),
         sassPlugin({
             loadPaths: [...nodePaths, 'node_modules'],
             quietDeps: true,


### PR DESCRIPTION
Since https://github.com/patternfly/patternfly-react/pull/8864 has been merged and released by the PatternFly project, we should be able to drop this workaround from our build.js file.