### PR TITLE
infra: Revert DNF 5 changes in containers

### DIFF
--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
   dnf update -y; \
   # Install dependencies
   dnf install -y \
-  dnf5-plugins \
+  'dnf-command(copr)' \
   npm \
   git \
   curl \


### PR DESCRIPTION
Revert "Fix anaconda-rpm container for DNF5 (#infra)"

This reverts commit 3056776f5f41e08b0b9a5021fc44faaefdb2fade.

----

I am not sure how fast this will propagate and what it affects, so let's check the situation more than just merging this...