### PR TITLE
webui: fix make rsync not updating the test VM

### DIFF
--- a/ui/webui/test/machine_install.py
+++ b/ui/webui/test/machine_install.py
@@ -147,6 +147,8 @@ class VirtInstallMachine(VirtMachine):
             else:
                 raise AssertionError("Webui initialization did not finish")
 
+            # Symlink /usr/share/cockpit to /usr/local/share/cockpit so that rsync works without killing cockpit-bridge
+            Machine.execute(self, "mkdir -p /usr/local/share/cockpit/anaconda-webui && mount --bind /usr/share/cockpit /usr/local/share/cockpit")
         except Exception as e:
             self.kill()
             raise e


### PR DESCRIPTION
`make rsync` stores the new files in /usr/local/share/cockpit whilst the original files are in /usr/share/cockpit.

So the running session doesn't recognize the new
directory in /usr/local/, that'd require a bridge restart.

This is not possible to do as that makes anaconda think that user Quit the installation.

