### PR TITLE
test: allow booting a Live OS ISO with test/webui_testvm.py script

### DIFF
--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -95,6 +95,9 @@ bots: tools/make-bots
 	GITHUB_BASE="cockpit-project/cockpit" tools/make-bots
 	cd test && ln -sf ../bots/images images
 
+live-vm: bots $(UPDATES_IMG)
+	./test/testvm.py $(TEST_LIVE_OS)
+
 prepare-test-deps: bots test/common payload
 
 .PHONY: payload

--- a/ui/webui/test/webui_testvm.py
+++ b/ui/webui/test/webui_testvm.py
@@ -33,20 +33,25 @@ def cmd_cli():
     try:
         machine.start()
 
-        print("You can connect to the VM in the following ways:")
-        # print ssh command
-        print("ssh -o ControlPath=%s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p %s %s@%s" %
-              (machine.ssh_master, machine.ssh_port, machine.ssh_user, machine.ssh_address))
-        # print Cockpit web address
-        print(
-            "http://%s:%s/cockpit/@localhost/anaconda-webui/index.html" %
-            (machine.web_address, machine.web_port)
-        )
+        live_os = machine.is_live()
+        if not live_os:
+            print("You can connect to the VM in the following ways:")
+            # print ssh command
+            print("ssh -o ControlPath=%s -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p %s %s@%s" %
+                  (machine.ssh_master, machine.ssh_port, machine.ssh_user, machine.ssh_address))
+            # print Cockpit web address
+            print(
+                "http://%s:%s/cockpit/@localhost/anaconda-webui/index.html" %
+                (machine.web_address, machine.web_port)
+            )
 
-        # rsync development files over so /usr/local/share/cockpit is created with a development version
-        if args.rsync:
-            # Rather annoying the node_modules path needs to be explicitly added for webpack
-            subprocess.check_call(["npm", "run", "build"], env={'RSYNC': args.host, "PATH": "/usr/bin/:node_modules/.bin", "LINT": "0"})
+            # rsync development files over so /usr/local/share/cockpit is created with a development version
+            if args.rsync:
+                # Rather annoying the node_modules path needs to be explicitly added for webpack
+                subprocess.check_call(["npm", "run", "build"], env={'RSYNC': args.host, "PATH": "/usr/bin/:node_modules/.bin", "LINT": "0"})
+        else:
+            print("You can start the installer by running the following command on the terminal in the test VM:")
+            print("liveinst --graphical --updates=http://10.0.2.2:%s/updates.img" % (machine.http_updates_img_port))
 
         # print marker that the VM is ready; tests can poll for this to wait for the VM
         print("RUNNING")


### PR DESCRIPTION
The commands to bring up a fedora Live VM for testing are now simplified to the following:

1. make live-vm
2. Once the VM is up and running you should manually start the Installer by typing the the VM's terminal the command that is printed in the 'make live-vm' stdout

In case the updates.img pre-exists one can simply spawn the VM with:
1. ./test/webui_testvm.py fedora-rawhide-live-boot
2. Same as above

