### PR TITLE
webui: use monospace font in critical error dialog

### DIFF
--- a/ui/webui/src/components/Error.jsx
+++ b/ui/webui/src/components/Error.jsx
@@ -36,6 +36,8 @@ import { ExternalLinkAltIcon } from "@patternfly/react-icons";
 
 import { exitGui } from "../helpers/exit.js";
 
+import "./Error.scss";
+
 const _ = cockpit.gettext;
 
 export const bugzillaPrefiledReportURL = (productQueryData) => {

--- a/ui/webui/src/components/Error.scss
+++ b/ui/webui/src/components/Error.scss
@@ -1,0 +1,8 @@
+#critical-error-review-attached-log {
+  font-family: var(--pf-global--FontFamily--monospace);
+  font-size: var(--pf-global--FontSize--sm);
+}
+
+#critical-error-review-details {
+  font-family: var(--pf-global--FontFamily--monospace);
+}


### PR DESCRIPTION
This brings the fonts used in the dialog more in line with the mockup: https://github.com/rhinstaller/anaconda/pull/4942#issuecomment-1661722007.

PR:
![critical_error_monospace](https://github.com/rhinstaller/anaconda/assets/1220237/aa2d1f98-49bd-4907-8cb8-e2360a133f73)

Current state:
![critical_error_default](https://github.com/rhinstaller/anaconda/assets/1220237/06df02fd-db9e-484a-bbef-bfc6d04d0c53)
