### PR TITLE
webui: increase default size of log review text area in critical erro…

### DIFF
--- a/ui/webui/src/components/Error.jsx
+++ b/ui/webui/src/components/Error.jsx
@@ -137,6 +137,7 @@ export const CriticalError = ({ exception, isBootIso, reportLinkURL }) => {
                       onChange={setLogContent}
                       resizeOrientation="vertical"
                       id="critical-error-review-attached-log"
+                      rows={7}
                     />
                     <FormHelperText isHidden={false}>
                         <HelperText>


### PR DESCRIPTION
This brings the log review text area more in line with the mockup: https://github.com/rhinstaller/anaconda/pull/4942#issuecomment-1661722007.

PR:
![Screenshot from 2023-08-10 16-01-10](https://github.com/rhinstaller/anaconda/assets/1220237/2772bfad-a0b7-4ff0-ae0d-1afe32a10552)

Current state:
![Screenshot from 2023-08-10 16-01-36](https://github.com/rhinstaller/anaconda/assets/1220237/c01b30fa-f1b0-4e75-9118-671d391d7ae3)
