### PR TITLE
Don't directly copy webui files in makeupdates script

### DIFF
--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -182,10 +182,6 @@ def copy_updated_files(tag, updates, cwd, builddir):
         finally:
             shutil.rmtree(tmpdir)
 
-    # Copy the Web UI support.
-    if os.path.exists('ui/webui/dist'):
-        install_to_dir("ui/webui/dist", "usr/share/cockpit/anaconda-webui")
-
     try:
         lines = do_git_diff(tag)
     except RuntimeError as e:


### PR DESCRIPTION
Originally we tried to copy webui files directly when creating an updates image, like we do with our python, glade, C and other files.

But eventually it turned out to be easier to builds the RPMs and then include those into the updates image instead.

But the original code was still in place, causing issues such as causing an unexpected attempt to start the Web UI when trying to change something in the Anaconda text interface.

So lets drop the direct copy of the webui files from the makeupdates script, at least for now.

This should not influence the current Web UI workflow, which already works with RPMs exclusively & should avoid issues when makeupdates is used in non-Web-UI use cases.