### PR TITLE
Correct spelling of "formatted"

### DIFF
--- a/ui/webui/src/components/storage/HelpAutopartOptions.jsx
+++ b/ui/webui/src/components/storage/HelpAutopartOptions.jsx
@@ -6,4 +6,4 @@ export const helpEraseAll = _("Remove all partitions on the selected devices, in
 
 export const helpUseFreeSpace = _("Keeps current disk layout and uses only available space.");
 
-export const helpMountPointMapping = _("This option requires that the selected device has formated partitions.");
+export const helpMountPointMapping = _("This option requires that the selected device has formatted partitions.");

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -782,7 +782,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         self.wait_mount_point_table_column_helper(3, "format", text="Mismatch")
 
         # When parent is re-formmated all child devices should be
-        # * either also reformated if selected
+        # * either also reformatted if selected
         # * either not selected (not part of the mountpoint assignment table)
         self.remove_row(5)
         self.remove_row(6)

--- a/utils/dd/rpmutils.c
+++ b/utils/dd/rpmutils.c
@@ -161,7 +161,7 @@ static int readRPM(const char *source, FD_t *fdi, Header *h)
 }
 
 /*
- * Check if the RPM is a properly formated driver
+ * Check if the RPM is a properly formatted driver
  * update package. Call ok(Header*) if it is.
  */
 int checkDDRPM(const char *source,


### PR DESCRIPTION
It has two Ts. This is primarily for the web UI case (which is visible right on the front page of the installer), but grep found two other cases of the same misspelling, so what the heck let's fix those too.