### PR TITLE
webui: Remove obsolete check for btrfs reformat support

### DIFF
--- a/ui/webui/src/components/storage/MountPointMapping.jsx
+++ b/ui/webui/src/components/storage/MountPointMapping.jsx
@@ -439,17 +439,11 @@ const MountPointMappingContent = ({ deviceData, partitioningData, dispatch, idPr
     }, [deviceData, requests, setIsFormValid]);
 
     const handleRequestChange = (mountpoint, device, newRequestId, reformat) => {
-        const data = deviceData[device];
         const _requests = requests.map(row => {
             const newRow = { ...row };
             if (row["request-id"] === newRequestId) {
                 // Reset reformat option when changing from /
                 if (row["mount-point"] === "/" && mountpoint !== row["mount-point"] && row.reformat) {
-                    newRow.reformat = false;
-                }
-
-                // TODO: Anaconda does not support formatting btrfs yet
-                if (row["device-spec"] !== device && data?.["format-type"] === "btrfs") {
                     newRow.reformat = false;
                 }
 


### PR DESCRIPTION
Support for reformatting of btrfs volumes was added in #4970.

Btw. it looks to me like this check didn't work anyway -- `data?.["format-type"]` is always undefined which also explains why reformatting of btrfs works even with this check.