### PR TITLE
webui: Allow changing and removing duplicate required mount points

### DIFF
--- a/ui/webui/src/components/storage/MountPointMapping.jsx
+++ b/ui/webui/src/components/storage/MountPointMapping.jsx
@@ -138,7 +138,7 @@ const MountPointColumn = ({ handleRequestChange, idPrefix, isRequiredMountPoint,
     return (
         <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsNone" }}>
             <Flex spaceItems={{ default: "spaceItemsMd" }}>
-                {isRequiredMountPoint
+                {isRequiredMountPoint && !duplicatedMountPoint
                     ? (
                         <FlexItem
                           className="mount-point-mapping__mountpoint-text"
@@ -299,6 +299,7 @@ const RequestsTable = ({
     const columnClassName = idPrefix + "__column";
     const getRequestRow = (request) => {
         const isRequiredMountPoint = !!requiredMountPointOptions.find(val => val.value === request["mount-point"]);
+        const duplicatedMountPoint = isDuplicateRequestField(requests, "mount-point", request["mount-point"]);
         const rowId = idPrefix + "-row-" + request["request-id"];
 
         return {
@@ -344,7 +345,7 @@ const RequestsTable = ({
                 },
                 {
                     title: (
-                        isRequiredMountPoint ? null : <MountPointRowRemove request={request} setRequests={setRequests} />
+                        (isRequiredMountPoint && !duplicatedMountPoint) ? null : <MountPointRowRemove request={request} setRequests={setRequests} />
                     ),
                     props: { className: columnClassName }
                 }


### PR DESCRIPTION
If user by tries to add second / or  /boot mount point we need to allow them to change or remove it.

Before:

![image](https://github.com/rhinstaller/anaconda/assets/5063197/b91d98c4-e7f7-482d-a1f2-6632664d6941)

After:

![image](https://github.com/rhinstaller/anaconda/assets/5063197/c4972c33-89ff-4117-92ba-d1019c880cc2)
