### PR TITLE
dd_extract: Add support for compressed kernel modules

### DIFF
--- a/docs/driverdisc.rst
+++ b/docs/driverdisc.rst
@@ -109,8 +109,9 @@ to respect some rules.
 Firmware and module update
 --------------------------
 
-The firmware files together with all .ko files from the RPMs are exploded to
-special module location, which has preference over built-in Anaconda modules.
+The firmware files together with all .ko, .ko.bz2, .ko.gz, .ko.xz and .ko.zst
+files from the RPMs are exploded to special module location, which has
+preference over built-in Anaconda modules.
 
 Anaconda doesn't use built-in modules (except some storage modules needed for
 the DD to function properly) during the DriverDisc mode, so even in case when

--- a/docs/release-notes/dd-compressed-kernel-modules.rst
+++ b/docs/release-notes/dd-compressed-kernel-modules.rst
@@ -1,0 +1,10 @@
+:Type: Driver Discs
+:Summary: Add support for compressed kernel modules
+
+:Description:
+    Support for Driver Discs containing compressed kernel modules has been
+    added. Support for compressed kernel modules is limited to file extensions
+    .ko.bz2, .ko.gz, .ko.xz and .ko.zst.
+
+:Links:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2032638

--- a/tests/unit_tests/dd_tests/test_dd.py
+++ b/tests/unit_tests/dd_tests/test_dd.py
@@ -133,6 +133,10 @@ koxzfile = TextRPMFile(
     path="/lib/modules/KERNELVER/extra/net/fun.ko.xz",
     contents="XZ COMPRESSED KERNEL MODULE??? YOU BETCHA"
 )
+kozstfile = TextRPMFile(
+    path="/lib/modules/KERNELVER/extra/net/fun.ko.zst",
+    contents="ZSTD COMPRESSED KERNEL MODULE??? YOU BETCHA"
+)
 
 
 # Finally, the actual test cases
@@ -244,7 +248,7 @@ class DD_Extract_TestCase(unittest.TestCase):
         cls.k_ver = "4.1.4-333"
         cls.a_ver = "22.0"
         cls.tmpdir = tempfile.mkdtemp(prefix="dd_tests.")
-        cls.rpmpayload = (binfile, kofile, koxzfile, fwfile, libfile)
+        cls.rpmpayload = (binfile, kofile, koxzfile, kozstfile, fwfile, libfile)
         make_rpm(cls.tmpdir, payload=cls.rpmpayload)
         (cls.rpmfile,) = listfiles(cls.tmpdir)
 
@@ -290,7 +294,7 @@ class DD_Extract_TestCase(unittest.TestCase):
     def test_dd_extract_modules(self):
         """dd_extract: using --modules extracts only .ko files"""
         outfiles = self.dd_extract(flags='--modules')
-        assert outfiles == set([self.outdir+kofile.path, self.outdir+koxzfile.path])
+        assert outfiles == set([self.outdir+kofile.path, self.outdir+koxzfile.path, self.outdir+kozstfile.path])
 
     def test_dd_extract_binaries(self):
         """dd_extract: using --binaries extracts only /bin, /sbin, etc."""

--- a/tests/unit_tests/dd_tests/test_dd.py
+++ b/tests/unit_tests/dd_tests/test_dd.py
@@ -129,6 +129,10 @@ kofile = TextRPMFile(
     path="/lib/modules/KERNELVER/extra/net/fun.ko",
     contents="KERNEL MODULE??? YOU BETCHA"
 )
+koxzfile = TextRPMFile(
+    path="/lib/modules/KERNELVER/extra/net/fun.ko.xz",
+    contents="XZ COMPRESSED KERNEL MODULE??? YOU BETCHA"
+)
 
 
 # Finally, the actual test cases
@@ -240,7 +244,7 @@ class DD_Extract_TestCase(unittest.TestCase):
         cls.k_ver = "4.1.4-333"
         cls.a_ver = "22.0"
         cls.tmpdir = tempfile.mkdtemp(prefix="dd_tests.")
-        cls.rpmpayload = (binfile, kofile, fwfile, libfile)
+        cls.rpmpayload = (binfile, kofile, koxzfile, fwfile, libfile)
         make_rpm(cls.tmpdir, payload=cls.rpmpayload)
         (cls.rpmfile,) = listfiles(cls.tmpdir)
 
@@ -286,7 +290,7 @@ class DD_Extract_TestCase(unittest.TestCase):
     def test_dd_extract_modules(self):
         """dd_extract: using --modules extracts only .ko files"""
         outfiles = self.dd_extract(flags='--modules')
-        assert outfiles == set([self.outdir+kofile.path])
+        assert outfiles == set([self.outdir+kofile.path, self.outdir+koxzfile.path])
 
     def test_dd_extract_binaries(self):
         """dd_extract: using --binaries extracts only /bin, /sbin, etc."""

--- a/tests/unit_tests/dd_tests/test_dd.py
+++ b/tests/unit_tests/dd_tests/test_dd.py
@@ -292,7 +292,7 @@ class DD_Extract_TestCase(unittest.TestCase):
                 assert binmode & expectmode == expectmode
 
     def test_dd_extract_modules(self):
-        """dd_extract: using --modules extracts only .ko files"""
+        """dd_extract: using --modules extracts only .ko, .ko.bz2, .ko.gz, .ko.xz and .ko.zst files"""
         outfiles = self.dd_extract(flags='--modules')
         assert outfiles == set([self.outdir+kofile.path, self.outdir+koxzfile.path, self.outdir+kozstfile.path])
 

--- a/utils/dd/dd_extract.c
+++ b/utils/dd/dd_extract.c
@@ -116,22 +116,31 @@ int dlabelFilter(const char* name, const struct stat *fstat, int packageflags, v
     if ((packageflags & dup_firmwares) && !strncmp("lib/firmware/", name, 13))
         return 1;
 
-    /* we do not want kernel files */
-    if (!(packageflags & dup_modules))
-        return 0;
+    /* unpack kernel modules if the package was marked as module-package */
+    if ((packageflags & dup_modules)) {
+        /* check if the file has at least three chars eg .SS */
+        if (l>=3) {
+            if (!strcmp(".ko", name+l-3))
+                return 1;
+        }
+        /* check if the file has at least six chars eg .SS.CC */
+        if (l>=6) {
+            if (!strcmp(".ko.gz", name+l-6))
+                return 1;
+            if (!strcmp(".ko.xz", name+l-6))
+                return 1;
+        }
+        /* check if the file has at least seven chars eg .SS.CCC */
+        if (l>=7) {
+            if (!strcmp(".ko.bz2", name+l-7))
+                return 1;
+            if (!strcmp(".ko.zst", name+l-7))
+                return 1;
+        }
+    }
 
-    /* check if the file has at least four chars eg X.SS */
-    if (l<3)
-        return 0;
-    l-=3;
-
-    /* and we want only .ko files here */
-    if (strcmp(".ko", name+l))
-        return 0;
-
-    /* we are unpacking kernel module.. */
-
-    return 1;
+    /* we do not want kernel files etc. */
+    return 0;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
This PR adds support for handling compressed kernel modules to dd_extract. In particular for *.ko.gz, *.ko.xz, *.ko.bz2, *.ko.zst (these seem to be the common file extensions also supported by rpm macros). It has been opened against master to ensure the feature will be available in rhel-10 (it is of low interest for Fedora), but I plan to later also open PR against rhel-9 (and maybe rhel-8?).

I have not been able to run the full test suite locally, but instead tested dd_extract manually. I do hope the tests may be run as part of this PR.

Note that I only extended the dd_extract tests to verify it is working for xz compressed kernel modules. Shall I add cases for the other 3 file extensions as well?

Please let me know if anything seems wrong or if I forgot anything you need, first time contributing to anaconda.