### PR TITLE
webui: Fixed typo to launch Live OS ISO with test/webui_testvm.py script

### DIFF
--- a/ui/webui/Makefile.am
+++ b/ui/webui/Makefile.am
@@ -30,6 +30,7 @@ TEST_OS=fedora-rawhide-boot
 PAYLOAD=fedora-rawhide-anaconda-payload
 GITHUB_BASE=rhinstaller/anaconda
 UPDATES_IMG=../../updates.img
+TEST_LIVE_OS=fedora-rawhide-live-boot
 
 export GITHUB_BASE
 export TEST_OS
@@ -96,7 +97,7 @@ bots: tools/make-bots
 	cd test && ln -sf ../bots/images images
 
 live-vm: bots $(UPDATES_IMG)
-	./test/testvm.py $(TEST_LIVE_OS)
+	./test/webui_testvm.py $(TEST_LIVE_OS)
 
 prepare-test-deps: bots test/common payload
 


### PR DESCRIPTION
To use Live OS iso boot, it is first necessary to update the bots:
1. rm -rf bots
2. make bots
Then you need to download the image and create a vm:
3. bots/image-download fedora-rawhide-live-boot
4. make live-vm
To run again, just update with update.img and run with ./test/webui_testvm.py fedora-rawhide-live-boot