### PR TITLE
Improve build of the ISO creating containers

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -122,10 +122,15 @@ There are two options to develop and test changes which are not yet released.
 
 To find out more information about quick way to propagate your changes into the existing installation ISO image see `this blogpost <https://rhinstaller.wordpress.com/2019/10/11/anaconda-debugging-and-testing-part-1/>`_.
 
+Another way is to build the boot.iso directly (takes more time but it's easier to do). See the next section to find out how to build the ISO.
+
 Building installation images
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Bulding the ISO is the most precise way to find the behavior of Anaconda in the installation environment. However, it needs a lot of HW resources and time to build.
+During the build, you will be ask for ``sudo`` password. Unfortunately, it is required to run the build as root because the build process needs to work with ``/dev/loop`` devices.
+Please do not use `toolbx <https://github.com/containers/toolbox>`_ or `distrobox <https://github.com/89luca89/distrobox>`_ because the commands below are calling podman under root which is hard to achieve from inside of other container.
 
-Another way is to build the boot.iso or Live image directly (takes more time but it's easier to do).
+Follow these steps to build the ISO you need.
 
 **First build Anaconda RPM files with our container**::
 
@@ -137,18 +142,18 @@ Then build an image containing those RPMs.
 
 To build a regular boot.iso from these RPMs use (loop device mounting requires root privileges)::
 
-  sudo make -f ./Makefile.am anaconda-iso-creator-build # to build the container if it doesn't exists already
-  sudo make -f ./Makefile.am container-iso-build
+  make -f ./Makefile.am anaconda-iso-creator-build # to build the container if it doesn't exists already
+  make -f ./Makefile.am container-iso-build
 
 To build a Web UI boot.iso run::
 
-  sudo make -f ./Makefile.am anaconda-iso-creator-build # to build the container if it doesn't exists already
-  sudo make -f ./Makefile.am container-webui-iso-build
+  make -f ./Makefile.am anaconda-iso-creator-build # to build the container if it doesn't exists already
+  make -f ./Makefile.am container-webui-iso-build
 
 To build a Web UI in Live image run::
 
-  sudo make -f ./Makefile.am anaconda-live-iso-creator-build # to build the container if it doesn't exists already
-  sudo make -f ./Makefile.am container-live-iso-build
+  make -f ./Makefile.am anaconda-live-iso-creator-build # to build the container if it doesn't exists already
+  make -f ./Makefile.am container-live-iso-build
 
 The resulting ISO will be stored in ``./result/iso`` directory.
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -210,7 +210,9 @@ anaconda-release-build: anaconda-rpm-build
 	$(RELEASE_DOCKERFILE)
 
 anaconda-iso-creator-build:
-	$(CONTAINER_ENGINE) build \
+	@sudo -nv 2>/dev/null || echo "You will be prompted for sudo password because this container has to be used under root!"
+
+	sudo $(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=image=$(BASE_CONTAINER) \
@@ -218,7 +220,9 @@ anaconda-iso-creator-build:
 	$(ISO_CREATOR_DOCKERFILE)
 
 anaconda-live-iso-creator-build:
-	$(CONTAINER_ENGINE) build \
+	@sudo -nv 2>/dev/null || echo "You will be prompted for sudo password because this container has to be used under root!"
+
+	sudo $(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) --pull-always \
 	$(CONTAINER_ADD_ARGS) \
 	--build-arg=image=$(BASE_CONTAINER) \

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -21,6 +21,7 @@ mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
 mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
 
 INPUT_RPMS=/anaconda-rpms/
+OUT_DIR=/images/
 REPO_DIR=/tmp/anaconda-rpms/
 
 # create repo from provided Anaconda RPMs
@@ -37,6 +38,9 @@ lorax -p Fedora -v "$VERSION_ID" -r "$VERSION_ID" \
       -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ \
       -s file://$REPO_DIR/ \
       "$@" \
-      output || cp *.log /images/
+      output || cp *.log "$OUT_DIR"
 
-cp output/images/boot.iso /images/
+cp output/images/boot.iso "$OUT_DIR"
+
+# fix permissions to user permissions on the built artifacts
+chown -Rv --reference="$INPUT_RPMS" "$OUT_DIR"

--- a/dockerfile/anaconda-iso-creator/lorax-build-webui
+++ b/dockerfile/anaconda-iso-creator/lorax-build-webui
@@ -27,6 +27,7 @@ mknod -m 0660 /dev/loop0 b 7 0  2> /dev/null || true
 mknod -m 0660 /dev/loop1 b 7 1  2> /dev/null || true
 
 INPUT_RPMS=/anaconda-rpms/
+OUT_DIR=/images/
 REPO_DIR=/tmp/anaconda-rpms/
 
 # create repo from provided Anaconda RPMs
@@ -49,6 +50,9 @@ lorax -p Fedora -v "$VERSION_ID" -r "$VERSION_ID" \
       -s file://$REPO_DIR/ \
       -i anaconda-webui -i webui_payload -i cockpit-ws -i cockpit-bridge -i firefox -i dbus-glib --rootfs-size 5 \
       "$@" \
-      output || cp *.log /images/
+      output || cp *.log "$OUT_DIR"
 
-cp output/images/boot.iso /images/
+cp output/images/boot.iso "$OUT_DIR"
+
+# fix permissions to user permissions on the built artifacts
+chown -Rv --reference="$INPUT_RPMS" "$OUT_DIR"

--- a/dockerfile/anaconda-live-iso-creator/lmc-build
+++ b/dockerfile/anaconda-live-iso-creator/lmc-build
@@ -17,7 +17,8 @@ set -eux
 
 INPUT_RPMS=/anaconda-rpms/
 REPO_DIR=/tmp/anaconda-rpms/
-LOG_DIR=/images/logs/
+OUT_DIR=/images/
+LOG_DIR="$OUT_DIR"/logs/
 # fedora-kickstarts clone during the Anaconda build
 # https://pagure.io/fedora-kickstarts/tree/main
 WORKSTATION_KS=/lorax/workstation.ks
@@ -108,9 +109,12 @@ livemedia-creator \
     --ram=$proposed_mem \
     --iso=/lorax/fedora-rawhide-boot.iso \
     --ks=$WORKSTATION_KS \
-    --logfile=/images/logs/build.log \
+    --logfile="$LOG_DIR/build.log" \
     --resultdir=/lorax/result
 
 stop_http_server
 
-cp ./result/Fedora-Workstation.iso /images/
+cp ./result/Fedora-Workstation.iso "$OUT_DIR"
+
+# fix permissions to user permissions on the built artifacts
+chown -Rv --reference="$INPUT_RPMS" "$OUT_DIR"


### PR DESCRIPTION
### Change the ownership of the artifacts build from the ISO builds
The ISO builds are required to be done under root. That means that the resulting artifacts are also root owned. That makes troubles with `git clean` or similar calls. To solve that copy the `owner` and `group` from the input Anaconda RPMs to output artifacts. That should be correct most of the time.

### Also remove requirements to run make commands as root
The `sudo make ...` is just wrong and should not be used anymore. Instead `sudo` calls are abstracted in the `Makefile`.

### Improve usage of the container build cache
~Cache could save a lot of time during development but could cause outdated images because container don't know if the DNF call is outdated. To resolve this with a compromise let's set the cache live to ~24~ 6 hours. When cache is older than ~24~ 6 hours it will be ignored otherwise it's used.
This is significant improvement to container development!~
Moved to https://github.com/rhinstaller/anaconda/pull/5073

### Reduce size of the images
~For all the DNF calls disable weak dependencies.
This is harder to test but should be easily to fix potential issues.
However, the saving should be nice. In my simple testing:~

~anaconda-ci on master branch:
original size: 2.68 GiB
new size: 2.22 GiB~
Moved to https://github.com/rhinstaller/anaconda/pull/5072

### Improve the documentation of the ISO builds
Reflect new changes.
Improve the state based on the feedback I've got.