### PR TITLE
Disable geolocation on the Fedora Workstation live image (#2231339)

### DIFF
--- a/data/profile.d/fedora-workstation.conf
+++ b/data/profile.d/fedora-workstation.conf
@@ -22,3 +22,9 @@ hidden_spokes =
     NetworkSpoke
     PasswordSpoke
     UserSpoke
+
+[Localization]
+# disable localization for the Fedora Workstation live image to avoid
+# it clashing with Gnome Initial Setup setting the Live environmment and
+# installation language first
+use_geolocation = False


### PR DESCRIPTION
We need to disable geolocation for the Fedora Workstation live image or else this will clash with and possibly override the language selection performed by Gnome Initial setup, which in this environment runs before Anaconda is started.

As far as we can tell, the Fedora Workstation live image is the only image using the Fedora Workstation configuration file, so it should be safe to put it there.

Related: rhbz#2231339