### PR TITLE
webui: Use client side decorations for browser

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -22,13 +22,17 @@
 # unprivileged, restart running as root.
 if [ "$(id -u)" -ne 0 ]; then
     xhost +si:localuser:root
-    unset XAUTHORITY
     exec pkexec "$0" "$@"
 fi
 
-# pkexec clears DBUS_SESSION_BUS_ADDRESS from environment
-if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
-    export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${PKEXEC_UID}/bus
+# pkexec clears the environment, so get it back
+if [ -n "${PKEXEC_UID}" ]; then
+    INSTALLER_USER=$(id -n -u "${PKEXEC_UID}")
+    readarray -t user_environment < <(pkexec --user "${INSTALLER_USER}" env XDG_RUNTIME_DIR="/run/user/${PKEXEC_UID}" systemctl --user show-environment)
+
+    for variable in "${user_environment[@]}"; do
+        export "$variable"
+    done
 fi
 
 # Allow running another command in the place of anaconda, but in this same

--- a/ui/webui/firefox-theme/default/chrome/userChrome.css
+++ b/ui/webui/firefox-theme/default/chrome/userChrome.css
@@ -14,3 +14,7 @@
 #titlebar:has(#tabbrowser-tabs tab:only-of-type) + #nav-bar:not(:focus-within) {
   visibility: collapse;
 }
+
+.titlebar-close {
+  display: none;
+}

--- a/ui/webui/firefox-theme/default/user.js
+++ b/ui/webui/firefox-theme/default/user.js
@@ -20,9 +20,6 @@ user_pref("browser.startup.page", 0);
 user_pref("browser.startup.homepage", "about:blank");
 user_pref("browser.startup.homepage_override.once", {});
 
-// Use a window manager titlebar
-user_pref("browser.tabs.inTitlebar", 0);
-
 // Hide the bookmarks
 user_pref("browser.toolbars.bookmarks.visibility", "never");
 

--- a/ui/webui/firefox-theme/live/chrome/userChrome.css
+++ b/ui/webui/firefox-theme/live/chrome/userChrome.css
@@ -14,3 +14,7 @@
 #titlebar:has(#tabbrowser-tabs tab:only-of-type) + #nav-bar:not(:focus-within) {
   visibility: collapse;
 }
+
+.titlebar-close {
+  display: none;
+}

--- a/ui/webui/firefox-theme/live/user.js
+++ b/ui/webui/firefox-theme/live/user.js
@@ -20,9 +20,6 @@ user_pref("browser.startup.page", 0);
 user_pref("browser.startup.homepage", "about:blank");
 user_pref("browser.startup.homepage_override.once", {});
 
-// Use a window manager titlebar
-user_pref("browser.tabs.inTitlebar", 0);
-
 // Hide the bookmarks
 user_pref("browser.toolbars.bookmarks.visibility", "never");
 

--- a/ui/webui/webui-desktop
+++ b/ui/webui/webui-desktop
@@ -122,6 +122,10 @@ else
     sleep 3
 fi
 
+# We're running firefox as root, and it doesn't like that, so clear XAUTHORITY and
+# XDG_RUNTIME_DIR so it is willing to start.
+unset XAUTHORITY XDG_RUNTIME_DIR
+
 HOME="$BROWSER_HOME" $BROWSER http://"$WEBUI_ADDRESS""$URL_PATH" &
 B_PID=$!
 


### PR DESCRIPTION
At the moment we show a titlebar with "Mozilla Firefox" in the title.

It looks much better to use client side decorations where the titlebar is rendered different and without Firefox branding.

This commit achieves that by:

1. Undoing the config override that forces the server side titlebar to be on
2. Putting MOZ_GTK_TITLEBAR_DECORATION=client in the environment so firefox (which is currently running as root segregated from the session) knows its okay to use client side decorations.
