### PR TITLE
Dont run browser as root

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -22,13 +22,17 @@
 # unprivileged, restart running as root.
 if [ "$(id -u)" -ne 0 ]; then
     xhost +si:localuser:root
-    unset XAUTHORITY
     pkexec "$0" "$@"
 fi
 
-# pkexec clears DBUS_SESSION_BUS_ADDRESS from environment
-if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
-    export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${PKEXEC_UID}/bus
+# pkexec clears the environment, so get it back
+if [ -n "${PKEXEC_UID}" ]; then
+    INSTALLER_USER=$(id -n -u "${PKEXEC_UID}")
+    readarray -t user_environment < <(pkexec --user "${INSTALLER_USER}" env XDG_RUNTIME_DIR="/run/user/${PKEXEC_UID}" systemctl --user show-environment)
+
+    for variable in "${user_environment[@]}"; do
+        export "$variable"
+    done
 fi
 
 # Allow running another command in the place of anaconda, but in this same

--- a/ui/webui/firefox-theme/default/user.js
+++ b/ui/webui/firefox-theme/default/user.js
@@ -20,9 +20,6 @@ user_pref("browser.startup.page", 0);
 user_pref("browser.startup.homepage", "about:blank");
 user_pref("browser.startup.homepage_override.once", {});
 
-// Use a window manager titlebar
-user_pref("browser.tabs.inTitlebar", 0);
-
 // Hide the bookmarks
 user_pref("browser.toolbars.bookmarks.visibility", "never");
 

--- a/ui/webui/webui-desktop
+++ b/ui/webui/webui-desktop
@@ -66,7 +66,18 @@ esac
 
 # prepare empty firefox profile dir with theme based on the passed profile id
 FIREFOX_THEME_DIR="/usr/share/anaconda/firefox-theme"
-FIREFOX_PROFILE_PATH="/tmp/anaconda-firefox-profile"
+
+# PKEXEC_UID is the uid for "gnome-initial-setup" or "liveuser"
+# depending on how the installer gets started.
+#
+# It's unset on non-live-images, so we just use the current user then (root)
+if [ -n "$PKEXEC_UID" ]; then
+  INSTALLER_USER=$(id -n -u ${PKEXEC_UID})
+else
+  INSTALLER_USER=$(id -n -u)
+fi
+
+FIREFOX_PROFILE_PATH="${XDG_RUNTIME_DIR}/anaconda/firefox-profile"
 
 # make sure the profile directory exists and is empty
 if [ -d ${FIREFOX_PROFILE_PATH} ]
@@ -74,13 +85,13 @@ then
     echo "Cleaning up existing Anaconda Firefox profile directory."
     rm -rf ${FIREFOX_PROFILE_PATH}
 fi
-mkdir -p ${FIREFOX_PROFILE_PATH}
+pkexec --user "${INSTALLER_USER}" mkdir -p ${FIREFOX_PROFILE_PATH}
 
 # populate the profile directory with our custom Firefox theme
 # - theme id is passed as the second argument of this script
 THEME_PATH="${FIREFOX_THEME_DIR}/${THEME_ID}"
 
-cp -a "${THEME_PATH}/." ${FIREFOX_PROFILE_PATH}
+pkexec --user "${INSTALLER_USER}" cp -a "${THEME_PATH}/." ${FIREFOX_PROFILE_PATH}
 
 # FIXME: is this hardcoded resolution necessary ?
 BROWSER=(/usr/bin/firefox --new-instance --window-size "1024,768" --profile "${FIREFOX_PROFILE_PATH}")
@@ -122,11 +133,9 @@ else
     sleep 3
 fi
 
-# We're running firefox as root, and it doesn't like that, so clear XAUTHORITY and
-# XDG_RUNTIME_DIR so it is willing to start.
-unset XAUTHORITY XDG_RUNTIME_DIR
+readarray -t user_environment < <(pkexec --user "${INSTALLER_USER}" env XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR}" systemctl --user show-environment)
 
-HOME="$BROWSER_HOME" MOZ_APP_TITLE="" MOZ_APP_REMOTINGNAME="liveinst" XDG_CURRENT_DESKTOP=GNOME MOZ_GTK_TITLEBAR_DECORATION=client "${BROWSER[@]}" http://"$WEBUI_ADDRESS""$URL_PATH" &
+HOME="$BROWSER_HOME" MOZ_APP_TITLE="" MOZ_APP_REMOTINGNAME="liveinst" XDG_CURRENT_DESKTOP=GNOME MOZ_GTK_TITLEBAR_DECORATION=client pkexec --user $INSTALLER_USER env "${user_environment[@]}" "${BROWSER[@]}" http://"$WEBUI_ADDRESS""$URL_PATH" &
 B_PID=$!
 
 wait $B_PID

--- a/ui/webui/webui-desktop
+++ b/ui/webui/webui-desktop
@@ -122,6 +122,10 @@ else
     sleep 3
 fi
 
+# We're running firefox as root, and it doesn't like that, so clear XAUTHORITY and
+# XDG_RUNTIME_DIR so it is willing to start.
+unset XAUTHORITY XDG_RUNTIME_DIR
+
 HOME="$BROWSER_HOME" MOZ_APP_TITLE="" MOZ_APP_REMOTINGNAME="liveinst" XDG_CURRENT_DESKTOP=GNOME MOZ_GTK_TITLEBAR_DECORATION=client $BROWSER http://"$WEBUI_ADDRESS""$URL_PATH" &
 B_PID=$!
 

--- a/ui/webui/webui-desktop
+++ b/ui/webui/webui-desktop
@@ -83,7 +83,7 @@ THEME_PATH="${FIREFOX_THEME_DIR}/${THEME_ID}"
 cp -a "${THEME_PATH}/." ${FIREFOX_PROFILE_PATH}
 
 # FIXME: is this hardcoded resolution necessary ?
-BROWSER="/usr/bin/firefox --new-instance --window-size 1024,768 --profile ${FIREFOX_PROFILE_PATH}"
+BROWSER=(/usr/bin/firefox --new-instance --window-size "1024,768" --profile "${FIREFOX_PROFILE_PATH}")
 
 # start browser in a temporary home dir, so that it does not interfere with your real one
 BROWSER_HOME=$(mktemp --directory --tmpdir cockpit.desktop.XXXXXX)
@@ -126,7 +126,7 @@ fi
 # XDG_RUNTIME_DIR so it is willing to start.
 unset XAUTHORITY XDG_RUNTIME_DIR
 
-HOME="$BROWSER_HOME" MOZ_APP_TITLE="" MOZ_APP_REMOTINGNAME="liveinst" XDG_CURRENT_DESKTOP=GNOME MOZ_GTK_TITLEBAR_DECORATION=client $BROWSER http://"$WEBUI_ADDRESS""$URL_PATH" &
+HOME="$BROWSER_HOME" MOZ_APP_TITLE="" MOZ_APP_REMOTINGNAME="liveinst" XDG_CURRENT_DESKTOP=GNOME MOZ_GTK_TITLEBAR_DECORATION=client "${BROWSER[@]}" http://"$WEBUI_ADDRESS""$URL_PATH" &
 B_PID=$!
 
 wait $B_PID


### PR DESCRIPTION
Right now firefox gets run as root which it really doesn't like doing. We have a workaround in place (unset XAUTHORITY) to prevent it from even erroring on start up.

There's no good reason to run it as root though. We can just run it unprivileged since all the heavy lifting is in privileged backend code anyway.