### PR TITLE
Url handlers

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -351,6 +351,8 @@ mkdir %{buildroot}%{_datadir}/anaconda/addons
 # Create an empty directory for post-scripts
 mkdir %{buildroot}%{_datadir}/anaconda/post-scripts
 
+desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_datadir}/applications/anaconda-storage.desktop
+
 %if %{with live}
 # required for live installations
 desktop-file-install --dir=%{buildroot}%{_datadir}/applications %{buildroot}%{_datadir}/applications/liveinst.desktop
@@ -421,7 +423,7 @@ rm -rf \
 %{_bindir}/liveinst
 %{_datadir}/polkit-1/actions/*
 %{_libexecdir}/liveinst-setup.sh
-%{_datadir}/applications/*.desktop
+%{_datadir}/applications/liveinst.desktop
 %{_datadir}/anaconda/gnome
 %{_sysconfdir}/xdg/autostart/*.desktop
 
@@ -448,6 +450,7 @@ rm -rf \
 %dir %{_datadir}/anaconda/firefox-theme/live/chrome
 %{_datadir}/anaconda/firefox-theme/live/user.js
 %{_datadir}/anaconda/firefox-theme/live/chrome/userChrome.css
+%{_datadir}/applications/anaconda-storage.desktop
 %{_libexecdir}/webui-desktop
 
 %files gui

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,7 @@ AC_CONFIG_FILES([Makefile
                  data/liveinst/gnome/Makefile
                  data/systemd/Makefile
                  data/dbus/Makefile
+                 data/url-handlers/Makefile
                  data/window-manager/Makefile
                  data/window-manager/config/Makefile
                  po/Makefile

--- a/data/url-handlers/Makefile.am
+++ b/data/url-handlers/Makefile.am
@@ -1,6 +1,6 @@
-# data/Makefile.am for anaconda
+# url-handlers/Makefile.am for anaconda
 #
-# Copyright (C) 2009  Red Hat, Inc.
+# Copyright (C) 2023  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -15,18 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = command-stubs liveinst systemd pixmaps window-manager dbus conf.d profile.d url-handlers
-
-CLEANFILES = *~
-
-dist_pkgdata_DATA          = interactive-defaults.ks \
-			     tmux.conf \
-			     anaconda-gtk.css
-
-helpdir               = $(datadir)/$(PACKAGE_NAME)
-dist_help_DATA        = anaconda_options.txt
-
-configdir           = $(sysconfdir)/$(PACKAGE_NAME)
-dist_config_DATA    = anaconda.conf
+desktopdir         = $(datadir)/applications
+dist_desktop_DATA  = anaconda-storage.desktop
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/data/url-handlers/anaconda-storage.desktop
+++ b/data/url-handlers/anaconda-storage.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Anaconda Storage
+Exec=blivet-gui
+Type=Application
+MimeType=x-scheme-handler/anaconda-storage;
+NoDisplay=true

--- a/ui/webui/firefox-theme/default/user.js
+++ b/ui/webui/firefox-theme/default/user.js
@@ -45,3 +45,6 @@ user_pref("datareporting.policy.dataSubmissionEnabled", false);
 user_pref("toolkit.telemetry.unified", false);
 user_pref("trailhead.firstrun.didSeeAboutWelcome", true);
 
+// Allow anaconda-storage url handler
+user_pref("network.protocol-handler.external.anaconda-storage", true);
+

--- a/ui/webui/firefox-theme/live/user.js
+++ b/ui/webui/firefox-theme/live/user.js
@@ -45,3 +45,6 @@ user_pref("datareporting.policy.dataSubmissionEnabled", false);
 user_pref("toolkit.telemetry.unified", false);
 user_pref("trailhead.firstrun.didSeeAboutWelcome", true);
 
+// Allow anaconda-storage url handler
+user_pref("network.protocol-handler.external.anaconda-storage", true);
+

--- a/ui/webui/src/components/storage/InstallationMethod.jsx
+++ b/ui/webui/src/components/storage/InstallationMethod.jsx
@@ -423,7 +423,13 @@ const ModifyStorageButton = ({ isBootIso }) => {
     }
 
     return (
-        <Button variant="link" icon={<WrenchIcon />} onClick={() => cockpit.spawn(["blivet-gui"])}>
+        <Button variant="link" icon={<WrenchIcon />}
+                onClick={() => {
+                    const onBeforeUnload = window.onbeforeunload;
+                    window.onbeforeunload = null;
+                    window.location.href = "anaconda-storage:";
+                    window.onbeforeunload = onBeforeUnload;
+                }}>
             {_("Modify storage")}
         </Button>
     );


### PR DESCRIPTION
cockpit.spawn isn't a good command to run UI tools because it doesn't know the user event that lead to it getting called. UI applications need to be run with that sort of context in their environment or compositors won't start them in the foreground. This is so if a user is typing, a slow starting program doesn't steal focus inadvertently when it finally starts.

Firefox has a mechanism for launching applications with the appropriate context, however: Url Handlers.

This commit registers a url handler "anaconda-storage:" and changes the Web UI to use it instead of cockpit.spawn.