### PR TITLE
screensaver: Look at $PKEXEC_UID not $USERHELPER_UID

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -26,6 +26,11 @@ if [ "$(id -u)" -ne 0 ]; then
     exec pkexec "$0" "$@"
 fi
 
+# pkexec clears DBUS_SESSION_BUS_ADDRESS from environment
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${PKEXEC_UID}/bus
+fi
+
 # Allow running another command in the place of anaconda, but in this same
 # environment.  This allows storage testing to make use of all the module
 # loading and lvm control in this file, too.

--- a/pyanaconda/screensaver.py
+++ b/pyanaconda/screensaver.py
@@ -60,18 +60,18 @@ session_proxy = None
 inhibit_id = None
 
 
-class SetEuidFromConsolehelper():
+class SetEuidFromPkexec():
     """Context manager to temporarily set euid from env. variable set by consolehelper.
 
-    Live installs use consolehelper to run as root, which sets the original UID in $USERHELPER_UID.
+    Live installs use pkexec to run as root, which sets the original UID in $PKEXEC_UID.
     """
     def __init__(self):
         self.old_euid = None
 
     def __enter__(self):
-        if "USERHELPER_UID" in os.environ:
+        if "PKEXEC_UID" in os.environ:
             self.old_euid = os.geteuid()
-            new_euid = int(os.environ["USERHELPER_UID"])
+            new_euid = int(os.environ["PKEXEC_UID"])
             os.seteuid(new_euid)
         return self
 
@@ -87,7 +87,7 @@ def inhibit_screensaver():
     global session_proxy
     global inhibit_id
     try:
-        with SetEuidFromConsolehelper():
+        with SetEuidFromPkexec():
             SCREENSAVER = DBusServiceIdentifier(
                 namespace=("org", "freedesktop", "ScreenSaver"),
                 message_bus=SessionMessageBus()
@@ -104,7 +104,7 @@ def uninhibit_screensaver():
         return
     log.info("Un-inhibiting screensaver.")
     try:
-        with SetEuidFromConsolehelper():
+        with SetEuidFromPkexec():
             session_proxy.UnInhibit(inhibit_id)
     except (DBusError, KeyError) as e:
         log.warning("Unable to uninhibit the screensaver: %s", e)


### PR DESCRIPTION
Since commit 919be1d50949d6a18e25a5a2c7df965c23ea1c33 anaconda has been using pkexec instead of consolehelper to get root privileges on the live image.

This caused a regression on the KDE live image, because anaconda was trying to inhibit the screensaver as the $USERHELPER_UID user which no longer gets set.

This commit changes the code to use $PKEXEC_UID which is the polkit equivalent.

