### PR TITLE
infra: Improve cache usage for container builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,7 @@ TEMPLATE_RENDERER = scripts/jinja-render
 
 CONTAINER_ENGINE ?= podman
 # build/run tweaks for all containers, such as --cap-add
-CONTAINER_BUILD_ARGS ?= --no-cache
+CONTAINER_BUILD_ARGS ?= --cache-ttl=3h
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io


### PR DESCRIPTION
We were using --no-cache which makes script development much slower than with the cache, however, with the cache the dnf calls are skipped most of the time.

Let's change the --no-cache option to --cache-ttl=3h, so the cache will be used if it is younger than 3 hours.