### PR TITLE
core: Look up live user from PKEXEC_UID

### DIFF
--- a/pyanaconda/core/live_user.py
+++ b/pyanaconda/core/live_user.py
@@ -19,11 +19,14 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import os
 from collections import namedtuple
-from pwd import getpwnam
+from pwd import getpwuid
 
+from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
 
+log = get_module_logger(__name__)
 
 User = namedtuple("User", ["name", "uid", "env_add", "env_prune"])
 
@@ -37,18 +40,36 @@ def get_live_user():
     if not conf.system.provides_liveuser:
         return None
 
-    try:
-        username = "liveuser"
-        uid = getpwnam(username).pw_uid
-        env_prune = ("GDK_BACKEND",)
-        env_add = {
-            "XDG_RUNTIME_DIR": "/run/user/{}".format(uid),
-            "USER": username,
-            "HOME": "/home/{}".format(username),
-        }
-        return User(name=username,
-                    uid=uid,
-                    env_add=env_add,
-                    env_prune=env_prune)
-    except KeyError:
+    if "PKEXEC_UID" not in os.environ:
         return None
+
+    pkexec_value = os.environ.get("PKEXEC_UID")
+
+    try:
+        uid = int(pkexec_value)
+    except ValueError:
+        log.error("Wrong UID obtained from system '%s'", pkexec_value)
+        return None
+
+    if uid == 0:
+        log.warning("PKEXEC was started by root, it should be live user - not root!")
+        return None
+
+    try:
+        passwd_entry = getpwuid(uid)
+    except KeyError:
+        log.error("Can't obtain user information from pkexec UID: '%s'", pkexec_value)
+        return None
+
+    username = passwd_entry.pw_name
+    home_dir = passwd_entry.pw_dir
+    env_prune = ("GDK_BACKEND",)
+    env_add = {
+        "XDG_RUNTIME_DIR": "/run/user/{}".format(uid),
+        "USER": username,
+        "HOME": home_dir,
+    }
+    return User(name=username,
+                uid=uid,
+                env_add=env_add,
+                env_prune=env_prune)


### PR DESCRIPTION
anaconda can be run as gnome-initial-setup or liveuser on live images, depending on how its started by the use.

It currently assumes it will be started as liveuser always.

This commit makes it look up the username and home directory by querying PKEXEC_UID environment variable.
