### PR TITLE
webui: Update request IDs when removing mount point row

### DIFF
--- a/ui/webui/src/components/storage/MountPointMapping.jsx
+++ b/ui/webui/src/components/storage/MountPointMapping.jsx
@@ -160,6 +160,10 @@ const MountPointColumn = ({ handleRequestChange, idPrefix, isRequiredMountPoint,
 
     const swapMountpoint = mountpoint === "swap";
 
+    useEffect(() => {
+        setMountPointText(request["mount-point"] || "");
+    }, [request]);
+
     return (
         <Flex direction={{ default: "column" }} spaceItems={{ default: "spaceItemsNone" }}>
             <Flex spaceItems={{ default: "spaceItemsMd" }}>
@@ -298,7 +302,13 @@ const FormatColumn = ({ deviceData, handleRequestChange, idPrefix, request, requ
 
 const MountPointRowRemove = ({ request, setRequests }) => {
     const handleRemove = () => {
-        setRequests(requests => requests.filter(r => r["request-id"] !== request["request-id"]));
+        // remove row from requests and update requests with higher ID
+        setRequests(requests => requests.filter(r => r["request-id"] !== request["request-id"]).map(({
+            ...r
+        }) => ({
+            ...r,
+            "request-id": r["request-id"] > request["request-id"] ? r["request-id"] - 1 : r["request-id"],
+        })));
     };
 
     return (

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -785,7 +785,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         # * either also reformatted if selected
         # * either not selected (not part of the mountpoint assignment table)
         self.remove_row(5)
-        self.remove_row(6)
+        self.remove_row(5)
         self.wait_mount_point_table_column_helper(3, "format", present=False)
         self.wait_mount_point_table_column_helper(4, "format", present=False)
 
@@ -865,6 +865,24 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         r.check_disk_row(disk, 2, f"{vgname}-root, 6.01 GB: format as ext4, /")
         r.check_disk_row(disk, 3, f"{vgname}-home, 8.12 GB: mount, /home")
         r.check_disk_row(disk, 4, f"{vgname}-swap, 902 MB: mount, swap")
+
+        i.back(previous_page=i.steps.CUSTOM_MOUNT_POINT)
+
+        # remove the /home row and check that row 3 is now swap
+        self.remove_row(3)
+
+        self.check_row_mountpoint(3, "swap")
+        self.check_row_device(3, f"{vgname}-swap")
+
+        i.next()
+
+        # verify review screen
+        disk = "vda"
+        r.check_disk(disk, "16.1 GB vda (0x1af4)")
+
+        r.check_disk_row(disk, 1, "vda2, 1.07 GB: mount, /boot")
+        r.check_disk_row(disk, 2, f"{vgname}-root, 6.01 GB: format as ext4, /")
+        r.check_disk_row(disk, 3, f"{vgname}-swap, 902 MB: mount, swap")
 
     @nondestructive
     def testUnusableFormats(self):


### PR DESCRIPTION
When removing a mount point row, we need to decrease IDs for the requests with higher IDs to avoid having duplicate ID when adding a new row.

Resolves: rhbz#2232398