### PR TITLE
webui: When re-scanning don't reset disk selection

### DIFF
--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -62,7 +62,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         s.rescan_disks()
 
         # Check that the disk selection persists when moving next and back
-        s.select_disk("vda", True)
+        s.check_disk_selected("vda", True)
         i.next()
         i.back()
         s.check_disk_selected("vda", True)
@@ -287,24 +287,26 @@ class TestStorageExtraDisks(anacondalib.VirtInstallMachineCase, StorageHelpers):
         s.check_single_disk_destination("vda")
 
         s.rescan_disks()
+
         s.check_disk_visible("vda")
         s.check_disk_visible(dev)
 
         s.wait_no_disks_detected_not_present()
 
-        s.check_disk_selected("vda", False)
+        s.check_disk_selected("vda", True)
         s.check_disk_selected(dev, False)
 
         s.rescan_disks()
-        s.wait_no_disks_detected()
+
+        s.check_disk_selected("vda", True)
+        s.check_disk_selected(dev, False)
+
+        s.select_disk(dev)
 
         # Check that disk selection is kept on Next and Back
-        disks = ["vda"]
-        for disk in disks:
-            s.select_disk(disk)
         i.next()
         i.back()
-        for disk in disks:
+        for disk in ["vda", dev]:
             s.check_disk_selected(disk)
 
 class TestUtils():
@@ -324,7 +326,7 @@ class TestUtils():
         b.wait(lambda : self.disks_loaded(s, disks))
 
         for disk in disks:
-            current_selection = s.get_disk_selected(disk)
+            current_selection = s.get_disk_selected(disk[0])
             if current_selection != disk[1]:
                 s.select_disk(disk[0], disk[1], len(disks) == 1)
 
@@ -556,6 +558,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, TestUtils):
         # Select first only vdb disk and verify that the partitioning request is correct
         i.open()
         i.next()
+
         s.rescan_disks()
 
         self.select_mountpoint(b, i, s, [(dev1, False), (dev2, True)])

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -80,7 +80,11 @@ class Storage():
             self.browser.wait_not_present(f"#{id_prefix}-selector-form li.pf-v5-c-chip-group__list-item:contains({disk})")
 
     def get_disk_selected(self, disk):
-        return self.browser.is_present(f"#{id_prefix}-selector-form li.pf-v5-c-chip-group__list-item:contains({disk})")
+        return (
+            self.browser.is_present(f"#{id_prefix}-selector-form li.pf-v5-c-chip-group__list-item:contains({disk})") or
+            (self.browser.is_present(f"#{id_prefix}-target-disk") and
+             disk in self.browser.text(f"#{id_prefix}-target-disk"))
+        )
 
     @log_step()
     def wait_no_disks(self):
@@ -281,7 +285,6 @@ class Storage():
         # Add a partition for "Use free space" scenario to be present
         self.machine.execute(f"sgdisk --new=0:0:+{size} /dev/{target}")
         self.rescan_disks()
-        self.select_disk(target, True, True)
 
     # partitions_params expected structure: [("size", "file system" {, "other mkfs.fs flags"})]
     def partition_disk(self, disk, partitions_params):

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -173,6 +173,7 @@ class Storage():
     @log_step(snapshots=True)
     def rescan_disks(self):
         self.browser.click(f"#{self._step}-rescan-disks")
+        self.browser.wait_not_present(f"#{self._step}-rescan-disks.pf-m-disabled")
 
     @log_step(snapshot_before=True)
     def check_disk_visible(self, disk, visible=True):


### PR DESCRIPTION
Instead keep selected disks if they are still usable.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=2231357#c3

