### PR TITLE
Fix spelling mistake / typo: "Criticall error"

### DIFF
--- a/ui/webui/src/components/Error.jsx
+++ b/ui/webui/src/components/Error.jsx
@@ -180,7 +180,7 @@ export const CriticalError = ({ exception, isBootIso, reportLinkURL }) => {
           description={description}
           reportLinkURL={addExceptionDataToReportURL(reportLinkURL, exception)}
           idPrefix={idPrefix}
-          title={_("Criticall error")}
+          title={_("Critical error")}
           titleIconVariant="danger"
           logFile="/tmp/webui.log"
           detailsLabel={_("Error details")}


### PR DESCRIPTION
Noticed this when finding a crash in the installer today. This is a translation break, I guess, but shouldn't be too bad as it was only added eight days ago?