### PR TITLE
Do not show unusable devices in mount point assignment 

### DIFF
--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -895,7 +895,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
 
         disk = "/dev/vda"
         dev = "vda"
-        s.partition_disk(disk, [("1GB", "udf")])
+        s.partition_disk(disk, [("1GB", "udf"), ("1GB", None), ("1GB", "lvmpv")])
         s.udevadm_settle()
 
         i.open()
@@ -911,6 +911,10 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase):
         self.check_format_type(3, "udf")
         self.select_reformat(3)
         self.wait_mount_point_table_column_helper(3, "format", text="Selected")
+
+        # unformatted and unmountable devices should not be available
+        self.check_device_available(1, f"{dev}2", False)
+        self.check_device_available(1, f"{dev}3", False)
 
 if __name__ == '__main__':
     test_main()

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -298,10 +298,13 @@ class Storage():
             command += f"\n{' '.join(sgdisk)}"
 
             if params[1] not in ("biosboot", None):
-                mkfs = [f"mkfs.{params[1]}"]
+                if params[1] == "lvmpv":
+                    mkfs = ["pvcreate"]
+                else:
+                    mkfs = [f"mkfs.{params[1]}"]
 
                 # force flag
-                if params[1] in ["xfs", "btrfs"]:
+                if params[1] in ["xfs", "btrfs", "lvmpv"]:
                     mkfs.append("-f")
                 elif params[1] in ["ext4", "etx3", "ext2", "ntfs"]:
                     mkfs.append("-F")


### PR DESCRIPTION
This makes sure that devices that cannot be mounted are not shown in the mount point assignment and not considered when checking whether mount point assignment should be allowed or not. LUKS encrypted devices and swap devices are also allowed in mount point assignment.