### PR TITLE
Revert "infra: Improve cache usage for container builds"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,7 +74,7 @@ TEMPLATE_RENDERER = scripts/jinja-render
 
 CONTAINER_ENGINE ?= podman
 # build/run tweaks for all containers, such as --cap-add
-CONTAINER_BUILD_ARGS ?= --cache-ttl=3h
+CONTAINER_BUILD_ARGS ?= --no-cache
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io


### PR DESCRIPTION
This reverts commit 5df7a8b39f94361380487491f8bcdec00f2cbcff.

Seems that cache-ttl is a new option for podman. Unfortunately, it wasn't mentioned in the release notes so not sure in which version it was added.

Anyway let's revert this for now.

This will fix container rebuilds which are broken right now.