### PR TITLE
infra: Label correctly branched fedora version

### DIFF
--- a/.github/labeler.yml.j2
+++ b/.github/labeler.yml.j2
@@ -5,7 +5,7 @@
 {% if distro_release == "rawhide" %}
 f{$ rawhide_fedora_version $}:
 {% else %}
-f{$ branched_fedora_version $}:
+f{$ distro_release $}:
 {% endif %}
 - '**'
 


### PR DESCRIPTION
On the branched branch, refer to its own release