### PR TITLE
Revert the ESP maximum size back to 600MiB

### DIFF
--- a/docs/release-notes/bigger-esp.rst
+++ b/docs/release-notes/bigger-esp.rst
@@ -2,13 +2,13 @@
 :Summary: Make the EFI System Partition at least 500MiB in size
 
 :Description:
-    The size of the EFI System Partition (ESP) created by Anaconda has changed from 200 MiB to 500 MiB.
+    The minimum size of the EFI System Partition (ESP) created by Anaconda has changed from 200 MiB to 500 MiB. The maximum size, which is used in most cases, remains at 600 MiB.
 
     The reasons for this change include:
     - This partition is used to deploy firmware updates. These updates need free space of twice the SPI flash size, which will grow from 64 to 128 MiB in near future and make the current partition size too small.
-    - The larger space enables future changes to how the bootloader is deployed on Fedora.
     - The new minimum is identical with what Microsoft mandates OEMs allocate for the partition.
 
 :Links:
     - https://fedoraproject.org/wiki/Changes/BiggerESP
     - https://github.com/rhinstaller/anaconda/pull/4711
+    - https://github.com/rhinstaller/anaconda/pull/5081

--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -225,7 +225,7 @@ class EFI(Platform):
             mountpoint="/boot/efi",
             fstype="efi",
             size=Size("500MiB"),
-            max_size=Size("2GiB"),
+            max_size=Size("600MiB"),
             grow=True
         )
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
@@ -181,7 +181,7 @@ class PlatformTestCase(unittest.TestCase):
 
         self._check_partitions(
             PartSpec(mountpoint="/boot/efi", fstype="efi", grow=True,
-                     size=Size("500MiB"), max_size=Size("2GiB")),
+                     size=Size("500MiB"), max_size=Size("600MiB")),
             PartSpec(mountpoint="/boot", size=Size("1GiB"))
         )
 
@@ -256,7 +256,7 @@ class PlatformTestCase(unittest.TestCase):
 
         self._check_partitions(
             PartSpec(mountpoint="/boot/efi", fstype="efi", grow=True,
-                     size=Size("500MiB"), max_size=Size("2GiB")),
+                     size=Size("500MiB"), max_size=Size("600MiB")),
             PartSpec(mountpoint="/boot", size=Size("1GiB"))
         )
 
@@ -293,7 +293,7 @@ class PlatformTestCase(unittest.TestCase):
 
         self._check_partitions(
             PartSpec(mountpoint="/boot/efi", fstype="efi", grow=True,
-                     size=Size("500MiB"), max_size=Size("2GiB")),
+                     size=Size("500MiB"), max_size=Size("600MiB")),
             PartSpec(mountpoint="/boot", size=Size("1GiB"))
         )
 


### PR DESCRIPTION
The original issue was that 200MiB was too small, and we only increased the maximum for people experimenting with UKIs. Seeing as Anaconda chooses the maximum size in more cases than we'd like just drop the maximum size back down to 600MiB which is easily big enough for firmware updates.

This should fix several regressions like:

 * https://bugzilla.redhat.com/show_bug.cgi?id=2212121
 * https://bugzilla.redhat.com/show_bug.cgi?id=2214342

Signed-off-by: Richard Hughes <richard@hughsie.com>

Resolves: rhbz#2234951