### PR TITLE
infra: bump the pylint-and-astroid group in /dockerfile with 2 updates

### DIFF
--- a/dockerfile/anaconda-ci/requirements.txt
+++ b/dockerfile/anaconda-ci/requirements.txt
@@ -17,8 +17,8 @@ pyyaml
 jinja2
 
 # pylint and its supporting libs
-pylint == 2.17.4
-astroid == 2.15.5
+pylint == 2.17.5
+astroid == 2.15.6
 
 # ruff for fast linting
 ruff == 0.0.284


### PR DESCRIPTION
Backport of https://github.com/rhinstaller/anaconda/pull/4990