### PR TITLE
webui: Fix validity state during navigation

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -207,10 +207,14 @@ export const AnacondaWizard = ({ dispatch, isBootIso, osRelease, storageData, lo
     const steps = createSteps(stepsOrder);
 
     const goToStep = (newStep) => {
-        // first reset validation state to default
-        setIsFormValid(true);
-
-        cockpit.location.go([newStep.id]);
+        // Reset validation state to default, but only when actual
+        // navigation will happen.  Without navigation, the validation
+        // state will not be re-computed by the actual step component,
+        // and we shouldn't touch it.
+        if (newStep.id !== currentStepId) {
+            setIsFormValid(true);
+            cockpit.location.go([newStep.id]);
+        }
     };
 
     return (


### PR DESCRIPTION
This fixes a bug: When clicking on the currently active step, the "Next" button is disabled and isn't enabled again until the user does sufficient changes in the page.

Concretely, when the installer starts up and shows the "Welcome" step, clicking on "Welcome" in the left column will disable "Next". Selecting a different language than the current one will enable it again.

This PR fixes that by not changing the validation state in goToPage if no navigation will actually happen.
