### PR TITLE
infra: Add jinja-render to infrastructure files 

### DIFF
--- a/.structure-config
+++ b/.structure-config
@@ -10,6 +10,7 @@ INFRASTRUCTURE_FILES=(
 .github/
 dockerfile/
 scripts/testing/
+scripts/jinja-render
 dracut/.shellcheckrc
 docs/ci-status.rst
 )


### PR DESCRIPTION
The jinja-render script is used during the branching and infrastructure related work. This will make infra-check on PR green when changing this file.