### PR TITLE
webui: Show warning when trying to use non-ASCII LUKS passphrase

### DIFF
--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -104,7 +104,8 @@ const PasswordFormFields = ({
     onConfirmChange,
     passwordStrength,
     ruleLength,
-    ruleConfirmMatches
+    ruleConfirmMatches,
+    ruleAscii
 }) => {
     const [passwordHidden, setPasswordHidden] = useState(true);
     const [confirmHidden, setConfirmHidden] = useState(true);
@@ -154,6 +155,15 @@ const PasswordFormFields = ({
                         >
                             {_("Must be at least 8 characters")}
                         </HelperTextItem>
+                        {ruleAscii &&
+                        <HelperTextItem
+                          id={idPrefix + "-password-rule-ascii"}
+                          isDynamic
+                          variant="warning"
+                          component="li"
+                        >
+                            {_("The passphrase you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts when typing it.")}
+                        </HelperTextItem>}
                     </HelperText>
                 </FormHelperText>
             </FormGroup>
@@ -253,6 +263,10 @@ export const DiskEncryption = ({
         return getRuleLength(password);
     }, [password]);
 
+    const ruleAscii = useMemo(() => {
+        return password.length > 0 && !/^[\x20-\x7F]*$/.test(password);
+    }, [password]);
+
     const encryptedDevicesCheckbox = content => (
         <Checkbox
           id={idPrefix + "-encrypt-devices"}
@@ -273,6 +287,7 @@ export const DiskEncryption = ({
           passwordConfirmLabel={_("Confirm passphrase")}
           ruleLength={ruleLength}
           ruleConfirmMatches={ruleConfirmMatches}
+          ruleAscii={ruleAscii}
           onChange={setPassword}
           onConfirmChange={setConfirmPassword}
         />

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -138,6 +138,18 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         s.check_pw_rule("match", "error")
         s.check_pw_strength("weak")
 
+        # Non-ASCII password
+        s.set_password(8 * "š")
+        s.check_password(8 * "š")
+        s.check_pw_rule("8-chars", "success")
+        s.check_pw_rule("match", "error")
+        s.check_pw_rule("ascii", "warning")
+        s.check_pw_strength("weak")
+
+        # Valid ASCII password
+        s.set_password("abcdefgh")
+        s.check_password("abcdefgh")
+
         # Set the password confirm
         s.set_password_confirm("abcdefg")
         s.check_pw_rule("match", "error")


### PR DESCRIPTION
We show this warning in the GTK UI so we should show it in the WebUI too.

Resolves: rhbz#2234518
Related: rhbz#2231339

Fedora 39 backport of #5102 
