### PR TITLE
webui: fix button spacing in BZ error reporting dialog

### DIFF
--- a/ui/webui/src/components/Error.jsx
+++ b/ui/webui/src/components/Error.jsx
@@ -19,6 +19,7 @@ import cockpit from "cockpit";
 import React, { useEffect, useState } from "react";
 
 import {
+    ActionList,
     Button,
     Form,
     FormGroup,
@@ -104,16 +105,18 @@ export const BZReportModal = ({
                       </HelperText>
                   </FormHelperText>
                   <StackItem>
-                      <Button
-                        variant="primary"
-                        isLoading={preparingReport}
-                        isDisabled={logContent === undefined || preparingReport || !isConnected}
-                        icon={<ExternalLinkAltIcon />}
-                        onClick={() => openBZIssue(reportLinkURL)}
-                        component="a">
-                          {preparingReport ? _("Preparing report") : _("Report issue")}
-                      </Button>
-                      {buttons}
+                      <ActionList>
+                          <Button
+                            variant="primary"
+                            isLoading={preparingReport}
+                            isDisabled={logContent === undefined || preparingReport || !isConnected}
+                            icon={<ExternalLinkAltIcon />}
+                            onClick={() => openBZIssue(reportLinkURL)}
+                            component="a">
+                              {preparingReport ? _("Preparing report") : _("Report issue")}
+                          </Button>
+                          {buttons}
+                      </ActionList>
                   </StackItem>
               </Stack>
           }>


### PR DESCRIPTION
Original screenshot (buttons too close together in Critical Error dialog):
![Screenshot from 2023-09-05 14-03-16](https://github.com/rhinstaller/anaconda/assets/1220237/c84833e0-6cb7-447f-af86-72ae7e6a704f)
Patched screenshot:
![Screenshot from 2023-09-05 14-02-04](https://github.com/rhinstaller/anaconda/assets/1220237/f43d870a-5d5b-4d44-af0a-61dc347123e2)

The change affects also Report Issue dialog:
Original screenshot:
![Screenshot from 2023-09-05 14-02-45](https://github.com/rhinstaller/anaconda/assets/1220237/d2b37a67-7ef0-466e-b3df-e54754d37bc2)

Patched screenshot:
![Screenshot from 2023-09-05 14-01-45](https://github.com/rhinstaller/anaconda/assets/1220237/222dc76d-da53-41c1-9d47-f235e78f8a95)
