### PR TITLE
infra: Fix differential shellcheck options

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -29,9 +29,9 @@ jobs:
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}
-          exclude-path:
-            - '*.j2'
-            - '**/*.j2'
+          exclude-path: |
+            *.j2
+            **/*.j2
 
       - if: ${{ always() }}
         name: Upload artifact with ShellCheck defects in SARIF format

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,10 +1,8 @@
----
-
 name: Differential ShellCheck
 on:
   push:
   pull_request:
-    branches: [ master, rhel-* ]
+    branches: [ master, rhel-*, fedora-* ]
 
 permissions:
   contents: read
@@ -39,5 +37,3 @@ jobs:
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}
-
-...


### PR DESCRIPTION
The option is apparently meant to be a multi-line string, not a yaml list :-/

https://github.com/redhat-plumbers-in-action/differential-shellcheck/issues/309

It's not a 100% certain thing, same as the original, but hopefully should work.