### PR TITLE
infra: Fix makeupdates script place for liveinst

### DIFF
--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -259,7 +259,7 @@ def copy_updated_files(tag, updates, cwd, builddir):
         elif gitfile.startswith("data/profile.d"):
             install_to_dir(gitfile, "etc/anaconda/profile.d")
         elif gitfile == "data/liveinst/liveinst":
-            install_to_dir(gitfile, "usr/sbin")
+            install_to_dir(gitfile, "usr/bin")
         elif gitfile.startswith("data/liveinst/gnome"):
             install_to_dir(gitfile, "usr/share/anaconda/gnome")
         elif gitfile.startswith("data/pixmaps"):


### PR DESCRIPTION
This script was removed from sbin directory in
919be1d50949d6a18e25a5a2c7df965c23ea1c33 so fix this issue.