### PR TITLE
webui: fix a typo in pre-blivet dialog

### DIFF
--- a/ui/webui/src/components/storage/InstallationMethod.jsx
+++ b/ui/webui/src/components/storage/InstallationMethod.jsx
@@ -559,7 +559,7 @@ const ModifyStorageModal = ({ onClose, onToolStarted, errorHandler }) => {
           }>
             <TextContent>
                 <Text component={TextVariants.p}>
-                    {_("Blivet-gui is and advanced storage editor that lets you resize, delete, and create partitions. It can set up LVM and much more.")}
+                    {_("Blivet-gui is an advanced storage editor that lets you resize, delete, and create partitions. It can set up LVM and much more.")}
                 </Text>
                 <Text component={TextVariants.p}>
                     {_("Changes made in Blivet-gui will directly affect your storage.")}


### PR DESCRIPTION
Backport from fedora-39 branch: https://github.com/rhinstaller/anaconda/pull/5132#issuecomment-1708630821 (fix added to https://github.com/rhinstaller/anaconda/pull/5132/commits/54895f3b3d89228267353e9eae448335ec36df4c)