### PR TITLE
infra: Raise kstest errors in the permian step

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -280,6 +280,14 @@ jobs:
               "kstestParams":{"platform":"${{ needs.pr-info.outputs.platform }}"}
             }'
 
+          # Permian hides the exit code of launcher, so error out this step manually based on logs
+          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
+          if [ -n "$rc" ]; then
+            exit $rc
+          else
+            exit 111
+          fi
+
       # Needed so that other jobs are able to clean the working dir
       # FIXME: we should investigate running permian/launch sudo-less
       - name: Make artefacts created by sudo cleanable
@@ -298,17 +306,6 @@ jobs:
             kickstart-tests/data/logs/kstest-*/*.log
             kickstart-tests/data/additional_repo/*.rpm
             permian/permian.log
-
-      # Permian hides the exit code of launcher
-      - name: Pass the launch script exit code
-        working-directory: ./permian
-        run: |
-          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
-          if [ -n "$rc" ]; then
-            exit $rc
-          else
-            exit 111
-          fi
 
       - name: Set result status
         if: always()

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -274,6 +274,14 @@ jobs:
               "kstestParams":{"platform":"${{ needs.pr-info.outputs.platform }}"}
             }'
 
+          # Permian hides the exit code of launcher, so error out this step manually based on logs
+          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
+          if [ -n "$rc" ]; then
+            exit $rc
+          else
+            exit 111
+          fi
+
       # Needed so that other jobs are able to clean the working dir
       # FIXME: we should investigate running permian/launch sudo-less
       - name: Make artefacts created by sudo cleanable
@@ -292,17 +300,6 @@ jobs:
             kickstart-tests/data/logs/kstest-*/*.log
             kickstart-tests/data/additional_repo/*.rpm
             permian/permian.log
-
-      # Permian hides the exit code of launcher
-      - name: Pass the launch script exit code
-        working-directory: ./permian
-        run: |
-          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
-          if [ -n "$rc" ]; then
-            exit $rc
-          else
-            exit 111
-          fi
 
       - name: Set result status
         if: always()


### PR DESCRIPTION
This makes it so that opening the GH web page automatically opens logs with the actual errors. Previously, it showed only a cryptic message "Runner return code: 1". and the actual errors were in a successfully completed step.

Tested manually:
- success - https://github.com/VladimirSlavik/anaconda/actions/runs/6110525397
- failure - https://github.com/VladimirSlavik/anaconda/actions/runs/6110738341

(Note: Comment workflows run from master for all branches = works also on f39 etc.)