### PR TITLE
infra: Don't run infra check on merged PRs

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   commit-message-check:
-    if: contains(github.event.pull_request.labels.*.name, 'infrastructure')
+    if: contains(github.event.pull_request.labels.*.name, 'infrastructure') && github.event.pull_request.merged != 'true'
     runs-on: ubuntu-20.04
     name: Infra tags in commit messages
 


### PR DESCRIPTION
Rebasing the head of a merged PR results in no changes (rebased == base), which gives empty string for the difference, which lacks the infra prefix or postfix.

The reason to actually check for this is that the "port to X" labels are usually removed only after the PR has been merged. That triggers the action on closed PRs, the only such case we have.

(This is a mostly speculative fix, but it should not affect opened PRs, so that should be fine.)