### PR TITLE
Add 'localhost-live' to ignored hostnames for device naming

### DIFF
--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -418,7 +418,7 @@ class InstallerStorage(Blivet):
 
     def _get_hostname(self):
         """Return a hostname."""
-        ignored_hostnames = {None, "", 'localhost', 'localhost.localdomain'}
+        ignored_hostnames = {None, "", 'localhost', 'localhost.localdomain', 'localhost-live'}
 
         network_proxy = NETWORK.get_proxy()
         hostname = network_proxy.Hostname


### PR DESCRIPTION
We already ignore 'localhost' and it doesn't really make sense to use 'localhost-live' when naming devices we are going to create.

Resolves: rhbz#2173474