### PR TITLE
Fix install complete text

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_progress.py
+++ b/pyanaconda/ui/gui/spokes/installation_progress.py
@@ -114,12 +114,12 @@ class ProgressSpoke(StandaloneSpoke):
             continue_text = _(
                 "%s is now successfully installed and ready for you to use!\n"
                 "Go ahead and reboot your system to start using it!"
-            ) % get_product_name
+            ) % get_product_name()
         else:
             continue_text = _(
                 "%s is now successfully installed and ready for you to use!\n"
                 "Go ahead and quit the application to start using it!"
-            ) % get_product_name
+            ) % get_product_name()
 
         label = self.builder.get_object("rebootLabel")
         label.set_text(continue_text)


### PR DESCRIPTION
19162ba16a9a440cbea00b1a745f372d21989c39 forgot to call the function, so the text now reads something like:
"<function get_product_name at 0xfooobar> is now successfully installed and ready for you to use!"

Let's fix that :)