### PR TITLE
webui: Start blivet-gui with --auto-dev-updates

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -17,7 +17,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 
 %if ! 0%{?rhel}
 %bcond_without live
-%define blivetguiver 2.1.12-1
+%define blivetguiver 2.4.2-3
 %else
 %bcond_with live
 %endif

--- a/ui/webui/src/components/storage/InstallationMethod.jsx
+++ b/ui/webui/src/components/storage/InstallationMethod.jsx
@@ -475,7 +475,7 @@ const startBlivetGUI = (onStart, onStarted, errorHandler) => {
     console.log("Spawning blivet-gui.");
     // We don't have an event informing that blivet-gui started so just wait a bit.
     const timeoutId = window.setTimeout(onStarted, 3000);
-    cockpit.spawn(["blivet-gui"], { err: "message" })
+    cockpit.spawn(["blivet-gui", "--auto-dev-updates"], { err: "message" })
             .then(() => {
                 console.log("blivet-gui exited.");
                 // If the blivet-gui exits earlier cancel the delay

--- a/ui/webui/test/prepare-updates-img
+++ b/ui/webui/test/prepare-updates-img
@@ -8,6 +8,7 @@ set -eu
 ANACONDA_WEBUI_DEPS_URLS='
     https://kojipkgs.fedoraproject.org/packages/cockpit/298/1.fc39/x86_64/cockpit-ws-298-1.fc39.x86_64.rpm
     https://kojipkgs.fedoraproject.org/packages/cockpit/298/1.fc39/x86_64/cockpit-bridge-298-1.fc39.x86_64.rpm
+    https://kojipkgs.fedoraproject.org/packages/blivet-gui/2.4.2/3.fc40/noarch/blivet-gui-runtime-2.4.2-3.fc40.noarch.rpm
 '
 
 mkdir -p tmp/extra-rpms


### PR DESCRIPTION
We need to tell blivet-gui to set the auto_dev_updates blivet flag to be able to gather information about existing btrfs subvolumes.

Resolves: rhbz#2238542

Depends on https://github.com/storaged-project/blivet-gui/pull/412