### PR TITLE
cppcheck: Pretend we know more macros

### DIFF
--- a/tests/cppcheck/runcppcheck.sh
+++ b/tests/cppcheck/runcppcheck.sh
@@ -57,6 +57,7 @@ cppcheck_output="$(echo "$filelist" |
         -DG_DEFINE_ABSTRACT_TYPE \
         -DG_DEFINE_TYPE_WITH_CODE \
         -DHAVE_WORKING_FORK \
+        -DG_GNUC_END_IGNORE_DEPRECATIONS \
         --force \
         2>&1 )"
 


### PR DESCRIPTION
This fixes unit tests and thus also container rebuilds.

This randomly appeared recently. The code checked is stable. Done with the expectation that the C code in widgets is EOL and just needs to survive a few more more Fedoras.