### PR TITLE
liveinst: Don't exec pkexec

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -23,7 +23,7 @@
 if [ "$(id -u)" -ne 0 ]; then
     xhost +si:localuser:root
     unset XAUTHORITY
-    exec pkexec "$0" "$@"
+    pkexec "$0" "$@"
 fi
 
 # pkexec clears DBUS_SESSION_BUS_ADDRESS from environment


### PR DESCRIPTION
Running exec pkexec, makes it fail when started via double-forking (since it can't look at the parent pid to make policy decisions).

That breaks budgie installer launching and maybe other desktops.

This commit drops the exec to fix that.

