### PR TITLE
Disable systemd-boot on live media

### DIFF
--- a/pyanaconda/modules/storage/bootloader/systemd.py
+++ b/pyanaconda/modules/storage/bootloader/systemd.py
@@ -151,3 +151,11 @@ class SystemdBoot(BootLoader):
 
     def write_config_images(self, config):
         return True
+
+    def is_valid_stage1_device(self, device, early=False):
+        valid = True
+        if conf.system.provides_liveuser:
+            raise BootLoaderError("systemd-boot cannot be utilized on live media with grub.")
+        else:
+            valid = super().is_valid_stage1_device(device, early)
+        return valid


### PR DESCRIPTION
<del>This fixes https://bugzilla.redhat.com/show_bug.cgi?id=2237327, by adding the btrfs subvolumes like zipl and extlinux to the systemd-boot strings. Grub has special cased this in grub-tools, otherwise a better fix would have been to get the btrfs subvolume boot string into boot_args when BTRFS was selected rather than depending on each bootloader to discover and fix them up.</del>

It also partially fixes https://bugzilla.redhat.com/show_bug.cgi?id=2234638 by providing a nicer message on live installs. This fix isn't ideal because 1: The webui apparently doesn't have a way to actually display storage/bootloader errors like the old anaconda UI does. 2: Its a bit later in the installation than I would have liked, but moving it earlier tends to blow up the webUI in even less ideal ways.

Suggestions are welcome...

