### PR TITLE
f39: liveinst: Don't exec pkexec

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -23,7 +23,7 @@
 if [ "$(id -u)" -ne 0 ]; then
     xhost +si:localuser:root
     unset XAUTHORITY
-    exec pkexec "$0" "$@"
+    pkexec "$0" "$@"
 fi
 
 # pkexec clears DBUS_SESSION_BUS_ADDRESS from environment


### PR DESCRIPTION
Port of #5171. Has FE: https://bugzilla.redhat.com/show_bug.cgi?id=2238792