### PR TITLE
spec: Add depdendency on fs tools to anaconda-install-env-deps

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -205,6 +205,17 @@ Requires: tmux
 Requires: gdb
 # support for installation from image and live & live image installations
 Requires: rsync
+# basic filesystem tools
+%if ! 0%{?rhel}
+Requires: btrfs-progs
+Requires: ntfs-3g
+Requires: ntfsprogs
+Requires: jfsutils
+Requires: f2fs-tools
+%endif
+Requires: xfsprogs
+Requires: dosfstools
+Requires: e2fsprogs
 
 %description install-env-deps
 The anaconda-install-env-deps metapackage lists all installation environment


### PR DESCRIPTION
The tools are required for both creating these filesystems and to be able to resize them. These are now brought in by Lorax, but it makes more sense for Anaconda to depend on these.

See also https://github.com/weldr/lorax/pull/1344 the filesystems were originally brought in only because udisks used to depend on these and were added to the Lorax templates only recently.