### PR TITLE
storage: Handle BTRFS with systemd-boot

### DIFF
--- a/pyanaconda/modules/storage/bootloader/systemd.py
+++ b/pyanaconda/modules/storage/bootloader/systemd.py
@@ -112,6 +112,11 @@ class SystemdBoot(BootLoader):
             root_uuid = util.execWithCapture("findmnt", [ "-sfn", "-oUUID", "/" ],
                                              root=conf.target.system_root)
             args += " root=UUID=" + root_uuid
+
+            for image in self.images:
+                if image.device.type == "btrfs subvolume":
+                    args += "rootflags=subvol=" + image.device.name
+
             config.write(args)
 
         # rather than creating a mess in python lets just


### PR DESCRIPTION
While XFS and LVM installs work with systemd-boot we need to special case BTRFS because the filesystem plugin isn't appending the required args to the boot_args. This matches similar code in the extlinux and zipl bootloaders, but not grub2 because it handles this case in grub-tools.

Resolves: rhbz#2237327

