### PR TITLE
set_x_keyboard_defaults: drop space when calling supports_ascii

### DIFF
--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -214,7 +214,9 @@ def set_x_keyboard_defaults(localization_proxy, xkl_wrapper):
         # take the first locale (with highest rank) from the list and
         # store it normalized
         new_layouts = [normalize_layout_variant(layouts[0])]
-        if not langtable.supports_ascii(layouts[0]):
+        # annoyingly, langtable expects *no* space between layout and
+        # (variant) here
+        if not langtable.supports_ascii(layouts[0].replace(" ", "")):
             # The default keymap setting should have "us" before the native layout
             # which does not support ascii,
             # refer: https://bugzilla.redhat.com/show_bug.cgi?id=1039185


### PR DESCRIPTION
We 'normalize' (in xkb terms) the discovered 'best' layout+variant right before calling `langtable.supports_ascii` here. That involves ensuring there's a space between the layout string and the variant string, e.g. "us (dvorak)", not "us(dvorak)". Sadly, langtable actually wants the *opposite*: it never wants there to be a space. Compare:

>>> langtable.supports_ascii("bg (phonetic)")
True
>>> langtable.supports_ascii("bg(phonetic)")
False

False is the correct answer - the phonetic variant of the Bulgarian layout cannot type Latin characters. langtable's default answer is True, if it can't find the layout you ask for it always just returns True. We get the wrong answer if we ask with a space.

I'm not sure there's any real-world case where this matters - it would need to be a case where langtable's recommended layout for a locale is one that uses a variant *and* is not ASCII- capable. Off the top of my head I can't think of any of those, though arguably, it maybe *should* suggest a variant layout for Bulgarian (my web searches suggest the phonetic layouts are more popular than the non-variant layout, which isn't phonetic). But it seems a good idea to be safe just in case there is one, or one appears in future.