### PR TITLE
install-env-deps: recommend kdump-anaconda-addon

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -205,6 +205,8 @@ Requires: tmux
 Requires: gdb
 # support for installation from image and live & live image installations
 Requires: rsync
+# An addon that allows enabling kdump at install time
+Recommends: kdump-anaconda-addon
 # basic filesystem tools
 %if ! 0%{?rhel}
 Requires: btrfs-progs
@@ -234,6 +236,8 @@ Requires: fcoe-utils >= %{fcoeutilsver}
 %endif
 # only WeakRequires elsewhere and not guaranteed to be present
 Requires: device-mapper-multipath
+# only WeakRequires in -env-
+Requires: kdump-anaconda-addon
 %if ! 0%{?rhel}
 Requires: zram-generator-defaults
 %else


### PR DESCRIPTION
Way back in https://bugzilla.redhat.com/show_bug.cgi?id=1115914 and https://bugzilla.redhat.com/show_bug.cgi?id=1176483 , we wanted to get this addon included in the install environment. However, it wasn't really done properly. As things wound up, it got listed in lorax runtime-install.tmpl (which does the job of getting it in the 'traditional' installer environment, but not getting it on live images), and then to get it on live images, it was added to the anaconda-tools comps group.

This got the job done, but isn't correct. anaconda-tools is meant to contain packages that the installer might need to deploy to the installed system, not packages that should be in the installer environment. It only wound up getting the package installed in the live environment because we have to include all packages from anaconda-tools in the lives because we have no way to add packages to live installs at install time.

Adding this here is more correct, and would mean we only need to list it in one place (here) instead of two (lorax templates and comps).