### PR TITLE
infra: Migrate missing checkout GH actions to v4

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -150,7 +150,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -236,7 +236,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -303,7 +303,7 @@ jobs:
        STATUS_NAME: updates-img
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -346,7 +346,7 @@ jobs:
 
       - name: Clone repository
         # need the repo to successfully post a comment :-/
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 1

--- a/.github/workflows/build-image.yml.j2
+++ b/.github/workflows/build-image.yml.j2
@@ -144,7 +144,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -230,7 +230,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -297,7 +297,7 @@ jobs:
        STATUS_NAME: updates-img
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -340,7 +340,7 @@ jobs:
 
       - name: Clone repository
         # need the repo to successfully post a comment :-/
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 1

--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout anaconda repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/container-rebuild-action.yml.j2
+++ b/.github/workflows/container-rebuild-action.yml.j2
@@ -53,7 +53,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout anaconda repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -125,7 +125,7 @@ jobs:
           sudo rm -rf * .git
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -140,7 +140,7 @@ jobs:
           git rebase origin/${{ env.TARGET_BRANCH }}
 
       - name: Check out kickstart-tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/kickstart-tests
           path: kickstart-tests
@@ -150,14 +150,14 @@ jobs:
         run: scripts/generate-testcases.py -t ./testlib/test_cases/kstest-template.tc.yaml.j2 . -o ./testlib/test_cases
 
       - name: Clone Permian repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/permian
           path: permian
           ref: main
 
       - name: Clone tplib repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/tplib
           path: tplib

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -119,7 +119,7 @@ jobs:
           sudo rm -rf * .git
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -134,7 +134,7 @@ jobs:
           git rebase origin/${{ env.TARGET_BRANCH }}
 
       - name: Check out kickstart-tests
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/kickstart-tests
           path: kickstart-tests
@@ -144,14 +144,14 @@ jobs:
         run: scripts/generate-testcases.py -t ./testlib/test_cases/kstest-template.tc.yaml.j2 . -o ./testlib/test_cases
 
       - name: Clone Permian repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/permian
           path: permian
           ref: main
 
       - name: Clone tplib repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/tplib
           path: tplib

--- a/.github/workflows/l10n-po-update.yml
+++ b/.github/workflows/l10n-po-update.yml
@@ -34,7 +34,7 @@ jobs:
           sudo apt install -y make git
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/anaconda
           ref: ${{ matrix.branch }}

--- a/.github/workflows/l10n-po-update.yml.j2
+++ b/.github/workflows/l10n-po-update.yml.j2
@@ -31,7 +31,7 @@ jobs:
           sudo apt install -y make git
 
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/anaconda
           ref: ${{ matrix.branch }}

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build anaconda-ci container
         run: make -f Makefile.am anaconda-ci-build

--- a/.github/workflows/push-tests.yml.j2
+++ b/.github/workflows/push-tests.yml.j2
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build anaconda-ci container
         run: make -f Makefile.am anaconda-ci-build

--- a/.github/workflows/release-automatically.yml
+++ b/.github/workflows/release-automatically.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0

--- a/.github/workflows/release-automatically.yml.j2
+++ b/.github/workflows/release-automatically.yml.j2
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0

--- a/.github/workflows/tests-daily.yml
+++ b/.github/workflows/tests-daily.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.target_branch }}
 
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.target_branch }}
 

--- a/.github/workflows/tests-daily.yml.j2
+++ b/.github/workflows/tests-daily.yml.j2
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.target_branch }}
 
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.target_branch }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # TODO: Are we able to remove ref, fetch-depth and Rebase task? Seems that the checkout
           # without ref is doing the rebase for us.
@@ -112,7 +112,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # TODO: Are we able to remove ref, fetch-depth and Rebase task? Seems that the checkout
           # without ref is doing the rebase for us.

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # TODO: Are we able to remove ref, fetch-depth and Rebase task? Seems that the checkout
           # without ref is doing the rebase for us.
@@ -155,7 +155,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # TODO: Are we able to remove ref, fetch-depth and Rebase task? Seems that the checkout
           # without ref is doing the rebase for us.

--- a/.github/workflows/try-release-daily.yml
+++ b/.github/workflows/try-release-daily.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
 

--- a/.github/workflows/try-release-daily.yml.j2
+++ b/.github/workflows/try-release-daily.yml.j2
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
 

--- a/.github/workflows/webui-periodic.yml
+++ b/.github/workflows/webui-periodic.yml
@@ -44,7 +44,7 @@ jobs:
 
       # The test library is in anaconda repository
       - name: Clone anaconda repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0
@@ -52,14 +52,14 @@ jobs:
 
       # TODO: use main branch when the webui workflow is merged there
       - name: Clone Permian repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/permian
           path: permian
           ref: devel
 
       - name: Clone tplib repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/tplib
           path: tplib

--- a/.github/workflows/webui-periodic.yml.j2
+++ b/.github/workflows/webui-periodic.yml.j2
@@ -38,7 +38,7 @@ jobs:
 
       # The test library is in anaconda repository
       - name: Clone anaconda repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0
@@ -46,14 +46,14 @@ jobs:
 
       # TODO: use main branch when the webui workflow is merged there
       - name: Clone Permian repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/permian
           path: permian
           ref: devel
 
       - name: Clone tplib repository
-        uses: actions/checkout@v3.3.0
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/tplib
           path: tplib

--- a/.github/workflows/webui-tests.yml
+++ b/.github/workflows/webui-tests.yml
@@ -108,7 +108,7 @@ jobs:
           sudo rm -rf * .git
 
       - name: Clone anaconda repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -124,14 +124,14 @@ jobs:
 
       # TODO: use main branch when the webui workflow is merged there
       - name: Clone Permian repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/permian
           path: permian
           ref: devel
 
       - name: Clone tplib repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/tplib
           path: tplib

--- a/.github/workflows/webui-tests.yml.j2
+++ b/.github/workflows/webui-tests.yml.j2
@@ -102,7 +102,7 @@ jobs:
           sudo rm -rf * .git
 
       - name: Clone anaconda repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr-info.outputs.sha }}
           fetch-depth: 0
@@ -118,14 +118,14 @@ jobs:
 
       # TODO: use main branch when the webui workflow is merged there
       - name: Clone Permian repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/permian
           path: permian
           ref: devel
 
       - name: Clone tplib repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: rhinstaller/tplib
           path: tplib


### PR DESCRIPTION
Dependabot migrated a few of these but not all of them. Let's change the rest.

Original dependabot change https://github.com/rhinstaller/anaconda/pull/5123