### PR TITLE
Fix crash because of missing import statement

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -67,6 +67,7 @@ def exitHandler(rebootData):
 
     # Tear down the storage module.
     storage_proxy = STORAGE.get_proxy()
+    from pyanaconda.modules.common.task import sync_run_task
 
     for task_path in storage_proxy.TeardownWithTasks():
         task_proxy = STORAGE.get_proxy(task_path)


### PR DESCRIPTION
Fixes:

pyanaconda.errors.ExitError: gnome-kiosk exited on signal 5 Exception ignored in atexist callback:
Traceback (most recent call last):
  File "/sbin/anaconda", line 73, in exitHandler
    sync_run_task(task_proxy)
    ^^^^^^^^^^^^^

NameError: name 'sync_run_task' is not defined

This was a regression by ecae47.

Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2240087

