### PR TITLE
Drop kbd-legacy requirement in localization module

### DIFF
--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -27,7 +27,6 @@ from pyanaconda.localization import get_available_translations, get_common_langu
 from pyanaconda.modules.common.base import KickstartService
 from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.modules.common.containers import TaskContainer
-from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.common.structures.language import LanguageData, LocaleData
 from pyanaconda.modules.localization.localization_interface import LocalizationInterface
 from pyanaconda.modules.localization.kickstart import LocalizationKickstartSpecification
@@ -246,22 +245,6 @@ class LocalizationService(KickstartService):
         if not self._localed_wrapper:
             self._localed_wrapper = LocaledWrapper()
         return self._localed_wrapper
-
-    def collect_requirements(self):
-        """Return installation requirements for this module.
-
-        :return: a list of requirements
-        """
-        requirements = []
-
-        # Install support for non-ascii keyboard layouts (#1919483).
-        if self.vc_keymap and not langtable.supports_ascii(self.vc_keymap):
-            requirements.append(Requirement.for_package(
-                package_name="kbd-legacy",
-                reason="Required to support the '{}' keymap.".format(self.vc_keymap)
-            ))
-
-        return requirements
 
     def install_with_tasks(self):
         """Return the installation tasks of this module.

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -27,7 +27,6 @@ from tests.unit_tests.pyanaconda_tests import check_kickstart_interface, \
     patch_dbus_publish_object, PropertiesChangedCallback, check_dbus_property, check_task_creation
 
 from pyanaconda.modules.common.constants.services import LOCALIZATION
-from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.common.structures.language import LanguageData, LocaleData
 from pyanaconda.modules.localization.installation import LanguageInstallationTask, \
     KeyboardInstallationTask
@@ -161,21 +160,6 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         """Test the CollectRequirements method."""
         # No default requirements.
         assert self.localization_interface.CollectRequirements() == []
-
-        # No additional support for ascii keyboard layouts.
-        self.localization_interface.VirtualConsoleKeymap = "en"
-        assert self.localization_interface.CollectRequirements() == []
-
-        # Additional support for non-ascii keyboard layouts.
-        self.localization_interface.VirtualConsoleKeymap = "ru"
-
-        requirements = Requirement.from_structure_list(
-            self.localization_interface.CollectRequirements()
-        )
-
-        assert len(requirements) == 1
-        assert requirements[0].type == "package"
-        assert requirements[0].name == "kbd-legacy"
 
     def test_languages(self):
         languages = list(self.localization_interface.GetLanguages())


### PR DESCRIPTION
This won't work right in all cases, because it asks langtable whether the kbd layout supports ASCII, but langtable has a list of xkb layouts. Sometimes the names match appropriately, but not always. For instance, if you install in Kazakh, the xkb layout is 'kz' but the kbd layout is 'kazakh', so this code will ask langtable "does the layout called 'kazakh' support ASCII?". langtable does not have an entry called 'kazakh', so it will default to answering "yes", which is the wrong answer, and this code would not add a requirement for kbd-legacy when it should.

Also, desktop ostrees do not currently include anaconda-tools (the comps group where kbd-legacy is listed because this anaconda code exists), so I noticed a while back that this was broken on ostree installs and we wound up making kbd-legacy a hard dependency of kbd again:

* https://bugzilla.redhat.com/show_bug.cgi?id=2127513
* https://src.fedoraproject.org/rpms/kbd/c/2c03718

so we don't really need anaconda to do anything special here, we can just assume that it's going to be installed. I think it's simpler to just keep this current situation (always install kbd-legacy) than to try and fix this code somehow, then ensure kbd-legacy is pulled into ostrees, all just to save less than a megabyte of disk space *only* for netinsts and DVD installs.