### PR TITLE
Revert "tests: Run pytest in parallel on available cpu cores"

### DIFF
--- a/dockerfile/anaconda-ci/requirements.txt
+++ b/dockerfile/anaconda-ci/requirements.txt
@@ -9,7 +9,6 @@ coverage
 rpmfluff  # rpm mocking
 freezegun  # time manipulation
 pytest
-pytest-xdist  # run pytest on multiple cpu cores
 
 # jinja templates
 pyyaml

--- a/tests/unit_tests/unit_tests.sh
+++ b/tests/unit_tests/unit_tests.sh
@@ -11,4 +11,4 @@ if [ $# -eq 0 ]; then
     set -- "$top_srcdir/tests/unit_tests"
 fi
 
-exec pytest -vv --log-level=NOTSET -n auto ${UNIT_TESTS_PATTERN:+-k $UNIT_TESTS_PATTERN} "$@"
+exec pytest -vv --log-level=NOTSET ${UNIT_TESTS_PATTERN:+-k $UNIT_TESTS_PATTERN} "$@"


### PR DESCRIPTION
This reverts commit 9aba8c0492e908af7f9a846f9e408280a51550a6.

Looks like there are several tests that race but somehow missed the initial testing :-/