### PR TITLE
Simplify keyboard layout handling, rely on localed more (Fedora 39)

### DIFF
--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -228,12 +228,6 @@ def set_x_keyboard_defaults(localization_proxy, xkl_wrapper):
     if can_configure_keyboard():
         xkl_wrapper.replace_layouts(new_layouts)
 
-    # the console layout configured should be "native" by default,
-    # setting that explicitly for non-ascii layouts where we prepend "us"
-    # refer: https://bugzilla.redhat.com/show_bug.cgi?id=1912609
-    if len(new_layouts) >= 2 and not langtable.supports_ascii(new_layouts[1]):
-        localization_proxy.VirtualConsoleKeymap = new_layouts[1]
-
     if len(new_layouts) >= 2 and not localization_proxy.LayoutSwitchOptions:
         # initialize layout switching if needed
         localization_proxy.LayoutSwitchOptions = ["grp:alt_shift_toggle"]

--- a/pyanaconda/modules/localization/live_keyboard.py
+++ b/pyanaconda/modules/localization/live_keyboard.py
@@ -50,17 +50,6 @@ class LiveSystemKeyboardBase(ABC):
         """
         pass
 
-    @abstractmethod
-    def read_current_keyboard_layout(self):
-        """Read keyboard layout currently used.
-
-        It is the best candidate for the virtual console keymap.
-
-        :return: keyboard layout used for virtual_console (e.g: LUKS during boot)
-        :rtype: str
-        """
-        pass
-
     @staticmethod
     def _run_as_liveuser(argv):
         """Run the command in a system as liveuser user.
@@ -87,22 +76,6 @@ class GnomeShellKeyboard(LiveSystemKeyboardBase):
         sources = self._run_as_liveuser(command_args)
         result = self._convert_to_xkb_format(sources)
         return result
-
-    def read_current_keyboard_layout(self):
-        """Read keyboard layout currently used.
-
-        It is the best candidate for the virtual console keymap.
-
-        :return: keyboard layout used for virtual_console (e.g: LUKS during boot)
-        :rtype: str
-        """
-        command_args = ["gsettings", "get", "org.gnome.desktop.input-sources", "mru-sources"]
-        sources = self._run_as_liveuser(command_args)
-        result = self._convert_to_xkb_format(sources)
-        # take first recently used which is the currently used
-        if result:
-            return result[0]
-        return ""
 
     def _convert_to_xkb_format(self, sources):
         # convert input "[('xkb', 'us'), ('xkb', 'cz+qwerty')]\n"

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -181,7 +181,7 @@ class LocaledWrapper(object):
 
         self._localed_proxy.SetX11Keyboard(
             layouts_str,
-            "",
+            "pc105",
             variants_str,
             options_str,
             convert,

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_live_keyboard.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_live_keyboard.py
@@ -45,19 +45,6 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
             ["get", "org.gnome.desktop.input-sources", "sources"]
             )
 
-    def _check_gnome_shell_current_layout_conversion(self, mocked_exec_with_capture, system_input,
-                                                     output):
-        mocked_exec_with_capture.reset_mock()
-        mocked_exec_with_capture.return_value = system_input
-
-        gs = GnomeShellKeyboard()
-
-        assert gs.read_current_keyboard_layout() == output
-        mocked_exec_with_capture.assert_called_once_with(
-            "gsettings",
-            ["get", "org.gnome.desktop.input-sources", "mru-sources"]
-            )
-
     @patch("pyanaconda.modules.localization.live_keyboard.execWithCaptureAsLiveUser")
     def test_gnome_shell_keyboard(self, mocked_exec_with_capture):
         """Test GnomeShellKeyboard live instance layouts."""
@@ -101,56 +88,4 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"wrong input",
             output=[]
-        )
-
-    @patch("pyanaconda.modules.localization.live_keyboard.execWithCaptureAsLiveUser")
-    def test_gnome_shell_current_keyboard_layout(self, mocked_exec_with_capture):
-        """Test GnomeShellKeyboard live instance current layout."""
-        # test one simple layout is set
-        self._check_gnome_shell_current_layout_conversion(
-            mocked_exec_with_capture=mocked_exec_with_capture,
-            system_input=r"[('xkb', 'us')]",
-            output="us"
-        )
-
-        # test one complex layout is set
-        self._check_gnome_shell_current_layout_conversion(
-            mocked_exec_with_capture=mocked_exec_with_capture,
-            system_input=r"[('xkb', 'cz+qwerty')]",
-            output="cz (qwerty)"
-        )
-
-        # test multiple layouts are set
-        self._check_gnome_shell_current_layout_conversion(
-            mocked_exec_with_capture=mocked_exec_with_capture,
-            system_input=r"[('xkb', 'cz+qwerty'), ('xkb', 'us')]",
-            output="cz (qwerty)"
-        )
-
-        # test layouts with ibus (ibus is ignored)
-        self._check_gnome_shell_current_layout_conversion(
-            mocked_exec_with_capture=mocked_exec_with_capture,
-            system_input=r"[('xkb', 'cz'), ('ibus', 'libpinyin')]",
-            output="cz"
-        )
-
-        # test layouts with ibus first (ibus should be skipped)
-        self._check_gnome_shell_current_layout_conversion(
-            mocked_exec_with_capture=mocked_exec_with_capture,
-            system_input=r"[('ibus', 'libpinyin'), ('xkb', 'us')]",
-            output="us"
-        )
-
-        # test only ibus layout
-        self._check_gnome_shell_current_layout_conversion(
-            mocked_exec_with_capture=mocked_exec_with_capture,
-            system_input=r"[('ibus', 'libpinyin')]",
-            output=""
-        )
-
-        # test wrong input
-        self._check_gnome_shell_current_layout_conversion(
-            mocked_exec_with_capture=mocked_exec_with_capture,
-            system_input=r"wrong input",
-            output=""
         )

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization_tasks.py
@@ -259,11 +259,10 @@ class LocalizationTasksTestCase(unittest.TestCase):
         else:
             localed.convert_keymap.assert_called_once_with(expected_convert_keymap_input)
 
-    def _create_live_keyboard_mock(self, layouts, current_layout):
+    def _create_live_keyboard_mock(self, layouts):
         live_keyboard_mock = Mock()
 
         live_keyboard_mock.read_keyboard_layouts.return_value = layouts
-        live_keyboard_mock.read_current_keyboard_layout.return_value = current_layout
 
         return live_keyboard_mock
 
@@ -351,8 +350,8 @@ class LocalizationTasksTestCase(unittest.TestCase):
             )
 
     def test_get_missing_keyboard_configuration_from_live(self):
-        """Test the gt_missing_keyboard_configuration from Live system."""
-        # Take layouts from Live system but their are empty
+        """Test the get_missing_keyboard_configuration from Live system."""
+        # Take layouts from Live system but they are empty
         with self._create_localed_mock(
                 convert_layouts_output="",
                 convert_keymap_output=[DEFAULT_KEYBOARD],
@@ -365,26 +364,9 @@ class LocalizationTasksTestCase(unittest.TestCase):
                 result_x_layouts=[DEFAULT_KEYBOARD],
                 result_vc_keymap=DEFAULT_KEYBOARD,
                 localed=mocked_localed,
-                live_keyboard=self._create_live_keyboard_mock(layouts=[],
-                                                              current_layout="")
+                live_keyboard=self._create_live_keyboard_mock(layouts=[])
             )
-        # Take layouts and current_layout from Live system
-        with self._create_localed_mock(
-                convert_layouts_output="cz",
-                convert_keymap_output=[DEFAULT_KEYBOARD],
-                expected_convert_layouts_input=["cz"],
-                expected_convert_keymap_input=None
-        ) as mocked_localed:
-            self._get_missing_keyboard_configuration_test(
-                input_x_layouts=[],
-                input_vc_keymap="",
-                result_x_layouts=["cz", "us"],
-                result_vc_keymap="cz",
-                localed=mocked_localed,
-                live_keyboard=self._create_live_keyboard_mock(layouts=["cz", "us"],
-                                                              current_layout="cz")
-            )
-        # Take layouts only from Live system (vc_keymap is converted from live layouts)
+        # Take layouts from Live system (vc_keymap is converted from live layouts)
         with self._create_localed_mock(
                 convert_layouts_output="cz",
                 convert_keymap_output=[],
@@ -397,8 +379,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
                 result_x_layouts=["cz", "us"],
                 result_vc_keymap="cz",
                 localed=mocked_localed,
-                live_keyboard=self._create_live_keyboard_mock(layouts=["cz", "us"],
-                                                              current_layout="")
+                live_keyboard=self._create_live_keyboard_mock(layouts=["cz", "us"])
             )
         # Layouts are set by user but vc_keymap not (convert layouts to VC without live)
         with self._create_localed_mock(
@@ -413,8 +394,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
                 result_x_layouts=["cz"],
                 result_vc_keymap="cz",
                 localed=mocked_localed,
-                live_keyboard=self._create_live_keyboard_mock(layouts=[],
-                                                              current_layout="")
+                live_keyboard=self._create_live_keyboard_mock(layouts=[])
             )
         # VC keymap is set by user but layouts are taken from Live
         with self._create_localed_mock(
@@ -429,8 +409,7 @@ class LocalizationTasksTestCase(unittest.TestCase):
                 result_x_layouts=["us"],
                 result_vc_keymap="cz",
                 localed=mocked_localed,
-                live_keyboard=self._create_live_keyboard_mock(layouts=["us"],
-                                                              current_layout="")
+                live_keyboard=self._create_live_keyboard_mock(layouts=["us"])
             )
 
     @patch("pyanaconda.modules.localization.runtime.conf")


### PR DESCRIPTION
There are a couple of specific bugs in the current code:

* https://bugzilla.redhat.com/show_bug.cgi?id=2238854
* https://bugzilla.redhat.com/show_bug.cgi?id=2239213

which could both be solved by just...trying less hard. Let's not try to set the console layout directly on the old set_x_keyboard_defaults path, and let's not have special code to set the console layout when reading configs from the live image, let's just read in the X layouts from the live config then rely on the existing code to ask localed to pick a console layout for us.

This also sets the keyboard model to "pc105" when requesting a console layout from localed. This is because localed only applies match "bonuses" for matching variants and options if the model matches. We need the variant "bonus" match to get the right result for Bulgarian, at least. Almost every line in kbd-model-map has the model set to "pc105", so let's just go with that. The only line with a different model *and* a variant is es-dvorak, and there is an xkb-converted layout for that, so it shouldn't make any difference there.

With current stable systemd this will give us wrong results in several cases (e.g. Russian installs will get US console layout). With current git HEAD systemd - after
https://github.com/systemd/systemd/pull/29215 - I believe this gives the same or better results in all cases on both new and old workflows (I have tested at least Russian and several Bulgarian paths). With
https://github.com/systemd/systemd/pull/29236 on top, we also get the correct result for Bulgarian with no variant, "bg_bds-utf8". Without that PR but with this change, we get the incorrect "bg_pho-utf8" in that case. Without this change, we set the console layout to "bg", which does not exist and causes errors on system startup and fallback to the "us" layout.

Resolves: rhbz#2238854
Resolves: rhbz#2239213