### PR TITLE
webui: do not hardcode the required mount points in the getInitialRequests

### DIFF
--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -57,7 +57,7 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         b.assert_pixels(
             "#app",
             "review-step-basic",
-            ignore=["#betanag-icon"],
+            ignore=["#betanag-icon", ".logo"],
             wait_animations=False,
         )
 

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -50,7 +50,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b.assert_pixels(
             "#app",
             "storage-step-basic",
-            ignore=["#betanag-icon"],
+            ignore=["#betanag-icon", ".logo"],
             wait_animations=False,
         )
 
@@ -101,7 +101,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b.assert_pixels(
             "#app",
             "storage-step-basic-live",
-            ignore=["#betanag-icon"],
+            ignore=["#betanag-icon", ".logo"],
             wait_animations=False,
         )
 
@@ -152,7 +152,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b.assert_pixels(
             "#app",
             "storage-step-encrypt",
-            ignore=["#betanag-icon"],
+            ignore=["#betanag-icon", ".logo"],
             wait_animations=False,
         )
 
@@ -164,7 +164,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b.assert_pixels(
             "#app",
             "storage-step-password",
-            ignore=["#betanag-icon"],
+            ignore=["#betanag-icon", ".logo"],
             wait_animations=False,
         )
 


### PR DESCRIPTION
We have the required mount points array now available from the backend.

Additionally document the getInitialRequests method.

