### PR TITLE
webui: Avoid crash on non-translated languages

### DIFF
--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -132,6 +132,7 @@ export const AnacondaWizard = ({ dispatch, isBootIso, osRelease, storageData, lo
                 diskSelection: storageData.diskSelection,
                 requests: storageData.partitioning ? storageData.partitioning.requests : null,
                 language,
+                localizationData,
                 osRelease
             },
             id: "installation-review",

--- a/ui/webui/src/components/review/ReviewConfiguration.jsx
+++ b/ui/webui/src/components/review/ReviewConfiguration.jsx
@@ -99,7 +99,7 @@ const DeviceRow = ({ deviceData, disk, requests }) => {
     );
 };
 
-export const ReviewConfiguration = ({ deviceData, diskSelection, language, osRelease, requests, idPrefix, setIsFormValid, storageScenarioId }) => {
+export const ReviewConfiguration = ({ deviceData, diskSelection, language, localizationData, osRelease, requests, idPrefix, setIsFormValid, storageScenarioId }) => {
     const [encrypt, setEncrypt] = useState();
 
     useEffect(() => {
@@ -133,7 +133,7 @@ export const ReviewConfiguration = ({ deviceData, diskSelection, language, osRel
                         {_("Language")}
                     </DescriptionListTerm>
                     <DescriptionListDescription id={idPrefix + "-target-system-language"}>
-                        {language["native-name"].v}
+                        {language ? language["native-name"].v : localizationData.language}
                     </DescriptionListDescription>
                 </DescriptionListGroup>
             </ReviewDescriptionList>

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -20,6 +20,7 @@ import anacondalib
 from installer import Installer
 from storage import Storage  # pylint: disable=import-error
 from review import Review
+from language import Language
 from progress import Progress
 from utils import add_public_key
 from testlib import nondestructive, test_main  # pylint: disable=import-error
@@ -73,6 +74,22 @@ class TestReview(anacondalib.VirtInstallMachineCase):
 
         i.reach(i.steps.REVIEW)
         i.begin_installation(should_fail=True, confirm_erase=False)
+
+    def testUnknownLanguage(self):
+        b = self.browser
+        m = self.machine
+        i = Installer(b, m)
+        l = Language(b, m)
+        r = Review(b)
+
+        i.open()
+        # Set language to Macedonian that is now in the installer translated languages
+        # Go to review page after it
+        l.dbus_set_language("mk_MK.UTF-8")
+        i.reach(i.steps.REVIEW)
+
+        # test the macedonian language selected
+        r.check_language("mk_MK.UTF-8")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This PR solves crash avoidance when selecting a language for which there is no translation in anaconda. The crash avoidance is created by displaying UTF language shortcuts for these languages in the Review page instead of the unknown name.