### PR TITLE
WebUI: drop eslint flowtype plugin

### DIFF
--- a/ui/webui/.eslintrc.json
+++ b/ui/webui/.eslintrc.json
@@ -8,7 +8,7 @@
     "parserOptions": {
         "ecmaVersion": 2022
     },
-    "plugins": ["flowtype", "react", "react-hooks"],
+    "plugins": ["react", "react-hooks"],
     "rules": {
         "indent": ["error", 4,
             {

--- a/ui/webui/package.json
+++ b/ui/webui/package.json
@@ -25,7 +25,6 @@
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-jsx": "^11.0.0",
     "eslint-config-standard-react": "^13.0.0",
-    "eslint-plugin-flowtype": "^8.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",


### PR DESCRIPTION
No JavaScript code uses the flowtype annotations.