### PR TITLE
webui: Stop pinning cockpit package versions, support testing against a cockpit PR

### DIFF
--- a/ui/webui/test/README.rst
+++ b/ui/webui/test/README.rst
@@ -210,6 +210,10 @@ You can set these environment variables to configure the test suite::
     TEST_OS    The OS to run the tests in.  Currently supported values:
                   "fedora-rawhide-boot"
 
+    TEST_SCENARIO The only supported non-default scenario is `cockpit-pr-N`,
+                  to install the cockpit packages from its pull request #N,
+                  from the automatic packit COPR.
+
     TEST_BROWSER  What browser should be used for testing. Currently supported values:
                      "chromium"
                      "firefox"

--- a/ui/webui/test/build-rpms
+++ b/ui/webui/test/build-rpms
@@ -11,7 +11,7 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-missing_packages = "cockpit-ws cockpit-bridge dbus-glib"
+missing_packages = "cockpit-ws cockpit-bridge cockpit-storaged dbus-glib"
 
 from machine.machine_core import machine_virtual  # NOQA: imported through parent.py
 

--- a/ui/webui/test/build-rpms
+++ b/ui/webui/test/build-rpms
@@ -35,7 +35,7 @@ def build_rpms(srpm, image, verbose, quick):
         # FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies
         # This will change once we include this changes upstream and start building boot.iso with the new dependencies
         # Then we can safely remove this workaround
-        machine.execute(f"dnf download --destdir /var/tmp/build/ {missing_packages}", stdout=sys.stdout, timeout=1800)
+        machine.execute(f"dnf download --destdir /var/tmp/build/ {missing_packages}", stdout=sys.stdout, timeout=300)
 
         # download rpms
         vm_rpms = machine.execute("find /var/tmp/build -name '*.rpm' -not -name '*.src.rpm'").strip().split()

--- a/ui/webui/test/build-rpms
+++ b/ui/webui/test/build-rpms
@@ -31,10 +31,15 @@ def build_rpms(srpm, image, verbose, quick):
         machine.execute("su builder -c 'mock --no-clean --disablerepo=* --offline --resultdir /var/tmp/build "
                         f"{mock_opts} --rebuild /var/tmp/build/SRPMS/*.src.rpm'", timeout=1800)
 
+        scenario = os.environ.get("TEST_SCENARIO")
+        if scenario and scenario.startswith("cockpit-pr-"):
+            cockpit_pr = scenario.split("-")[-1]
+            machine.execute(f"dnf copr enable -y packit/cockpit-project-cockpit-{cockpit_pr}", stdout=sys.stdout)
+
         # download cockpit rpms
         # FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies
         # This will change once we include this changes upstream and start building boot.iso with the new dependencies
-        # Then we can safely remove this workaround
+        # Then we can move this to the /cockpit-pr scenario above
         machine.execute(f"dnf download --destdir /var/tmp/build/ {missing_packages}", stdout=sys.stdout, timeout=300)
 
         # download rpms

--- a/ui/webui/test/build-rpms
+++ b/ui/webui/test/build-rpms
@@ -11,7 +11,7 @@ import sys
 BOTS_DIR = os.path.realpath(f'{__file__}/../../bots')
 sys.path.append(BOTS_DIR)
 
-missing_packages = "dbus-glib"
+missing_packages = "cockpit-ws cockpit-bridge dbus-glib"
 
 from machine.machine_core import machine_virtual  # NOQA: imported through parent.py
 

--- a/ui/webui/test/prepare-updates-img
+++ b/ui/webui/test/prepare-updates-img
@@ -2,12 +2,8 @@
 
 set -eu
 
-# FIXME boot.iso on rawhide does not currently contain the new cockpit dependencies
-# This will change once we include this changes upstream and start building boot.iso with the new dependencies
-# Then we can safely remove this workaround
+# FIXME latest firefox breaks our tests: https://bugzilla.redhat.com/show_bug.cgi?id=2242446
 ANACONDA_WEBUI_DEPS_URLS='
-    https://kojipkgs.fedoraproject.org/packages/cockpit/298/1.fc39/x86_64/cockpit-ws-298-1.fc39.x86_64.rpm
-    https://kojipkgs.fedoraproject.org/packages/cockpit/298/1.fc39/x86_64/cockpit-bridge-298-1.fc39.x86_64.rpm
     https://kojipkgs.fedoraproject.org/packages/firefox/118.0/1.fc40/x86_64/firefox-118.0-1.fc40.x86_64.rpm
 '
 
@@ -28,11 +24,10 @@ make srpm
 popd
 
 # build the anaconda srpm (and result RPMs go in `tmp/rpms`) && download anaconda-webui missing dependencies
-# cockpit RPMs are hardcoded above for gating purposes
 test/build-rpms -v ../../result/build/00-srpm-build/anaconda-*.src.rpm
 
 # makeupdates must be run from the top level of the anaconda source tree
 pushd ../../
 # shellcheck disable=SC2086,SC2046
-scripts/makeupdates --add ui/webui/tmp/rpms/anaconda-*.rpm ${ANACONDA_WEBUI_DEPS_RPMS} ui/webui/tmp/rpms/firefox-*.rpm ui/webui/tmp/rpms/dbus-glib-*.rpm
+scripts/makeupdates --add ui/webui/tmp/rpms/anaconda-*.rpm ui/webui/tmp/rpms/cockpit-*.rpm ui/webui/tmp/rpms/dbus-glib-*.rpm ${ANACONDA_WEBUI_DEPS_RPMS}
 popd

--- a/ui/webui/test/prepare-updates-img
+++ b/ui/webui/test/prepare-updates-img
@@ -29,5 +29,5 @@ test/build-rpms -v ../../result/build/00-srpm-build/anaconda-*.src.rpm
 # makeupdates must be run from the top level of the anaconda source tree
 pushd ../../
 # shellcheck disable=SC2086,SC2046
-scripts/makeupdates --add ui/webui/tmp/rpms/anaconda-*.rpm ui/webui/tmp/rpms/cockpit-*.rpm ui/webui/tmp/rpms/dbus-glib-*.rpm ${ANACONDA_WEBUI_DEPS_RPMS}
+scripts/makeupdates --add ui/webui/tmp/rpms/*.rpm ${ANACONDA_WEBUI_DEPS_RPMS}
 popd


### PR DESCRIPTION
We need to test the real distro, not what it was like 3 months ago. This will pave the way for gating cockpit changes on anaconda's tests (https://issues.redhat.com/browse/COCKPIT-1062), which is supported through a scenario now.

After this lands, I'll teach cockpit's CI to run anaconda's tests with the PR's cockpit code, to make sure cockpit changes don't break anaconda.