### PR TITLE
logging: log content of /root/lorax-packages if available

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -226,6 +226,7 @@ if __name__ == "__main__":
         sys.exit(0)
 
     log.info("%s %s", sys.argv[0], util.get_anaconda_version_string(build_time_version=True))
+    log.debug("Image packages list: %s", util.get_image_packages_info())
 
     if opts.updates_url:
         log.info("Using updates from: %s", opts.updates_url)

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -242,6 +242,8 @@ PW_ASCII_CHARS = string.digits + string.ascii_letters + string.punctuation + " "
 # screenshots
 SCREENSHOTS_DIRECTORY = "/tmp/anaconda-screenshots"
 
+PACKAGES_LIST_FILE = "/root/lorax-packages.log"
+
 CMDLINE_FILES = [
     "/proc/cmdline",
     "/run/install/cmdline",

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -40,7 +40,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.path import make_directories, open_with_perm, join_paths
 from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, \
-    IPMI_ABORTED, X_TIMEOUT
+    IPMI_ABORTED, X_TIMEOUT, PACKAGES_LIST_FILE
 from pyanaconda.core.live_user import get_live_user
 from pyanaconda.errors import RemovedModuleError
 
@@ -972,3 +972,10 @@ def restorecon(paths, root, skip_nonexistent=False):
         return False
     else:
         return True
+
+
+def get_image_packages_info():
+    if os.path.exists(PACKAGES_LIST_FILE):
+        return ' '.join(line.strip() for line in open(PACKAGES_LIST_FILE).readlines())
+    else:
+        return ''


### PR DESCRIPTION
Attaching log grabbed from the run of kickstart tests on this PR (the message would go to anaconda.log):
[virt-install.log](https://github.com/rhinstaller/anaconda/files/12893543/virt-install.log)
Showing a snippet from it:
```
11:33:24,436 DEBUG anaconda:anaconda: core.configuration.profile: Detecting a profile for ID=fedora, VARIANT_ID=None.
11:33:24,436 INFO anaconda:anaconda: core.configuration.profile: The 'fedora' profile is detected.
11:33:24,436 INFO anaconda:anaconda: core.configuration.anaconda: Load the 'fedora' profile configuration.
11:33:24,440 INFO anaconda:anaconda: main: /sbin/anaconda 999999999-1.fc40
11:33:24,441 DEBUG anaconda:anaconda: main: Image packages list: ModemManager-glib-1.20.6-3.fc39.x86_64 NetworkManager-1.44.2-1.fc40.x86_64 NetworkManager-libnm-1.44.2-1.fc40.x86_64 NetworkManager-team-1.44.2-1.fc40.x86_64 NetworkManager-wifi-1.44.2-1.fc40.x86_64 abattis-cantarell-vf-fonts-0.301-10.fc39.noarch adwaita-cursor-theme-45.0-1.fc40.noarch adwaita-icon-theme-45.0-1.fc40.noarch alsa-lib-1.2.10-3.fc40.x86_64 alternatives-1.25-1.fc39.x86_64 amd-gpu-firmware-20230919-1.fc40.noarch anaconda-999999999-1.fc40.x86_64 anaconda-core-999999999-1.fc40.x86_64 anaconda-dracut-999999999-1.fc40.x86_64 anaconda-gui-999999999-1.fc40.x86_64 anaconda-install-env-deps-999999999-1.fc40.x86_64 anaconda-install-img-deps-999999999-1.fc40.x86_64 anaconda-tui-999999999-1.fc40.x86_64 anaconda-user-help-26.2-6.fc39.noarch anaconda-widgets-999999999-1.fc40.x86_64 at-spi2-atk-2.50.0-1.fc40.x86_64 at-spi2-core-2.50.0-1.fc40.x86_64 atheros-firmware-20230919-1.fc40.noarch atk-2.50.0-1.fc40.x86_64 atmel-firmware-1.3-30.fc39.noarch attr-2.5.1-9.fc40.x86_64 audit-3.1.2-4.fc40.x86_64 audit-libs-3.1.2-4.fc40.x86_64 augeas-libs-1.13.0-5.fc39.x86_64 authselect-1.4.3-1.fc40.x86_64 authselect-libs-1.4.3-1.fc40.x86_64 avahi-glib-0.8-24.fc39.x86_64 avahi-libs-0.8-24.fc39.x86_64 b43-openfwwf-5.2-30.fc38.noarch basesystem-11-18.fc39.noarch bash-5.2.15-5.fc39.x86_64 bind-libs-9.18.19-1.fc40.x86_64 bind-license-9.18.19-1.fc40.noarch bind-utils-9.18.19-1.fc40.x86_64 biosdevname-0.7.3-12.fc39.x86_64 blivet-data-3.8.2-1.fc40.noarch blivet-gui-runtime-2.4.2-4.fc40.noarch bluez-libs-5.70-1.fc40.x86_64 boost-regex-1.81.0-9.fc40.x86_64 brcmfmac-firmware-20230919-1.fc40.noarch bridge-utils-1.7.1-7.fc39.x86_64 brlapi-0.8.5-5.fc40.x86_64 brltty-6.6-5.fc40.x86_64 btrfs-progs-6.5.1-1.fc40.x86_64 bubblewrap-0.7.0-2.fc39.x86_64 bzip2-1.0.8-16.fc39.x86_64 bzip2-libs-1.0.8-16.fc39.x86_64 ca-certificates-2023.2.62_v7.0.401-4.fc40.noarch cairo-1.18.0-1.fc40.x86_64 cairo-gobject-1.18.0-1.fc40.x86_64 cdparanoia-libs-10.2-42.fc39.x86_64 checkpolicy-3.5-3.fc39.x86_64 chkconfig-1.25-1.fc39.x86_64 chrony-4.4-1.fc40.x86_64 color-filesystem-1-31.fc39.noarch colord-1.4.6-6.fc40.x86_64 colord-libs-1.4.6-6.fc40.x86_64 containers-common-1-96.fc40.noarch coreutils-9.4-1.fc40.x86_64 coreutils-common-9.4-1.fc40.x86_64 cpio-2.14-4.fc39.x86_64 cracklib-2.9.11-2.fc39.x86_64 cracklib-dicts-2.9.11-2.fc39.x86_64 createrepo_c-1.0.0-2.fc40.x86_64 createrepo_c-libs-1.0.0-2.fc40.x86_64 crypto-policies-20230920-1.git570ea89.fc40.noarch crypto-policies-scripts-20230920-1.git570ea89.fc40.noarch cryptsetup-2.6.1-3.fc39.x86_64 cryptsetup-libs-2.6.1-3.fc39.x86_64 ctags-6.0.0-3.fc39.x86_64 cups-libs-2.4.7-1.fc40.x86_64 curl-8.4.0-1.fc40.x86_64 cxl-libs-78-1.fc39.x86_64 cyrus-sasl-lib-2.1.28-11.fc39.x86_64 daxctl-libs-78-1.fc39.x86_64 dbus-1.14.10-1.fc40.x86_64 dbus-broker-33-2.fc39.x86_64 dbus-common-1.14.10-1.fc40.noarch dbus-daemon-1.14.10-1.fc40.x86_64 dbus-libs-1.14.10-1.fc40.x86_64 dbus-tools-1.14.10-1.fc40.x86_64 dbus-x11-1.14.10-1.fc40.x86_64 dconf-0.40.0-9.fc39.x86_64 default-fonts-core-sans-4.0-9.fc40.noarch device-mapper-1.02.196-1.fc39.x86_64 device-mapper-event-1.02.196-1.fc39.x86_64 device-mapper-event-libs-1.02.196-1.fc39.x86_64 device-mapper-libs-1.02.196-1.fc39.x86_64 device-mapper-multipath-0.9.6-1.fc40.x86_64 device-mapper-multipath-libs-0.9.6-1.fc40.x86_64 device-mapper-persistent-data-1.0.6-2.fc40.x86_64 diffutils-3.10-3.fc39.x86_64 dmidecode-3.5-1.fc40.x86_64 dnf-4.17.0-6.fc40.noarch dnf-data-4.17.0-6.fc40.noarch dosfstools-4.2-8.fc40.x86_64 dracut-059-14.fc40.x86_64 dracut-config-generic-059-14.fc40.x86_64 dracut-live-059-14.fc40.x86_64 dracut-network-059-14.fc40.x86_64 dracut-squash-059-14.fc40.x86_64 drpm-0.5.2-3.fc39.x86_64 duktape-2.7.0-5.fc39.x86_64 dump-0.4-0.53.b47.fc39.x86_64 dvb-firmware-20230919-1.fc40.noarch e2fsprogs-1.47.0-2.fc39.x86_64 e2fsprogs-libs-1.47.0-2.fc39.x86_64 efi-filesystem-5-9.fc39.noarch efibootmgr-18-4.fc39.x86_64 efivar-libs-38-8.fc39.x86_64 elfutils-debuginfod-client-0.189-6.fc40.x86_64 elfutils-default-yama-scope-0.189-6.fc40.noarch elfutils-libelf-0.189-6.fc40.x86_64 elfutils-libs-0.189-6.fc40.x86_64 enchant2-2.6.1-1.fc40.x86_64 ethtool-6.5-1.fc40.x86_64 expat-2.5.0-3.fc39.x86_64 f2fs-tools-1.16.0-2.fc39.x86_64 fcoe-utils-1.0.34-5.gitb233050.fc39.x86_64 fdk-aac-free-2.0.0-11.fc39.x86_64 fedora-gpg-keys-40-0.2.noarch fedora-logos-38.1.0-2.fc39.noarch fedora-release-40-0.14.noarch fedora-release-common-40-0.14.noarch fedora-release-identity-basic-40-0.14.noarch fedora-repos-40-0.2.noarch fedora-repos-rawhide-40-0.2.noarch file-5.45-1.fc40.x86_64 file-libs-5.45-1.fc40.x86_64 filesystem-3.18-6.fc39.x86_64 findutils-4.9.0-6.fc40.x86_64 flac-libs-1.4.3-2.fc39.x86_64 flatpak-libs-1.15.4-3.fc39.x86_64 fontconfig-2.14.2-5.fc40.x86_64 fonts-filesystem-2.0.5-12.fc39.noarch fpaste-0.4.4.0-1.fc40.noarch freetype-2.13.1-2.fc39.x86_64 fribidi-1.0.13-2.fc39.x86_64 fstrm-0.6.1-8.fc39.x86_64 ftp-0.17-93.fc39.x86_64 fuse-2.9.9-17.fc39.x86_64 fuse-common-3.16.1-2.fc40.x86_64 fuse-libs-2.9.9-17.fc39.x86_64 fuse3-libs-3.16.1-2.fc40.x86_64 gawk-5.2.2-2.fc39.x86_64 gcr-libs-4.1.0-2.fc39.x86_64 gdb-13.2-11.fc40.x86_64 gdb-gdbserver-13.2-11.fc40.x86_64 gdb-headless-13.2-11.fc40.x86_64 gdbm-libs-1.23-4.fc39.x86_64 gdisk-1.0.9-6.fc39.x86_64 gdk-pixbuf2-2.42.10-5.fc39.x86_64 gdk-pixbuf2-modules-2.42.10-5.fc39.x86_64 geoclue2-2.7.0-3.fc40.x86_64 geoclue2-libs-2.7.0-3.fc40.x86_64 geocode-glib-3.26.4-8.fc40.x86_64 gettext-envsubst-0.22-2.fc39.x86_64 gettext-libs-0.22-2.fc39.x86_64 gettext-runtime-0.22-2.fc39.x86_64 glib-networking-2.78.0-1.fc40.x86_64 glib2-2.78.0-3.fc40.x86_64 glibc-2.38.9000-12.fc40.x86_64 glibc-all-langpacks-2.38.9000-12.fc40.x86_64 glibc-common-2.38.9000-12.fc40.x86_64 glibc-gconv-extra-2.38.9000-12.fc40.x86_64 gmp-6.2.1-5.fc39.x86_64 gnome-control-center-filesystem-45.0-2.fc40.noarch gnome-desktop3-44.0-9.fc40.x86_64 gnome-desktop4-44.0-9.fc40.x86_64 gnome-kiosk-45.0-1.fc40.x86_64 gnome-settings-daemon-45.0-1.fc40.x86_64 gnupg2-2.4.3-2.fc39.x86_64 gnutls-3.8.1-1.fc40.x86_64 gobject-introspection-1.78.1-1.fc40.x86_64 google-noto-fonts-common-20230801-3.fc40.noarch google-noto-sans-arabic-vf-fonts-20230801-3.fc40.noarch google-noto-sans-cjk-fonts-2.004-5.fc40.noarch google-noto-sans-ethiopic-vf-fonts-20230801-3.fc40.noarch google-noto-sans-georgian-vf-fonts-20230801-3.fc40.noarch google-noto-sans-gurmukhi-vf-fonts-20230801-3.fc40.noarch google-noto-sans-hebrew-vf-fonts-20230801-3.fc40.noarch google-noto-sans-khmer-vf-fonts-20230801-3.fc40.noarch google-noto-sans-mono-vf-fonts-20230801-3.fc40.noarch google-noto-sans-sinhala-vf-fonts-20230801-3.fc40.noarch google-noto-sans-thai-vf-fonts-20230801-3.fc40.noarch google-noto-sans-vf-fonts-20230801-3.fc40.noarch gpgme-1.22.0-1.fc40.x86_64 graphene-1.10.6-6.fc39.x86_64 graphite2-1.3.14-12.fc39.x86_64 grep-3.11-5.fc40.x86_64 grub2-common-2.06-104.fc40.noarch grub2-efi-ia32-2.06-104.fc40.x86_64 grub2-efi-ia32-cdboot-2.06-104.fc40.x86_64 grub2-efi-x64-2.06-104.fc40.x86_64 grub2-efi-x64-cdboot-2.06-104.fc40.x86_64 grub2-pc-modules-2.06-104.fc40.noarch grub2-tools-2.06-104.fc40.x86_64 grub2-tools-efi-2.06-104.fc40.x86_64 grub2-tools-extra-2.06-104.fc40.x86_64 grub2-tools-minimal-2.06-104.fc40.x86_64 grubby-8.40-72.fc40.x86_64 gsettings-desktop-schemas-45.0-1.fc40.x86_64 gsm-1.0.22-3.fc39.x86_64 gssdp-1.6.2-3.fc39.x86_64 gssproxy-0.9.1-6.fc39.x86_64 gstreamer1-1.22.6-1.fc40.x86_64 gstreamer1-plugins-bad-free-1.22.5-1.fc39.x86_64 gstreamer1-plugins-base-1.22.5-1.fc39.x86_64 gtk-update-icon-cache-3.24.38-3.fc39.x86_64 gtk3-3.24.38-3.fc39.x86_64 gtk4-4.12.3-1.fc40.x86_64 gupnp-1.6.5-1.fc39.x86_64 gupnp-igd-1.6.0-2.fc39.x86_64 gzip-1.12-6.fc39.x86_64 harfbuzz-8.2.1-2.fc40.x86_64 harfbuzz-icu-8.2.1-2.fc40.x86_64 hdparm-9.65-2.fc39.x86_64 hexedit-1.6-4.fc39.x86_64 hfsplus-tools-540.1.linux3-29.fc39.x86_64 hicolor-icon-theme-0.17-16.fc39.noarch highway-1.0.7-1.fc40.x86_64 hunspell-1.7.2-5.fc39.x86_64 hunspell-en-US-0.20201207-7.fc39.noarch hunspell-filesystem-1.7.2-5.fc39.x86_64 hwdata-0.375-1.fc40.noarch hyphen-2.8.8-21.fc39.x86_64 ibus-libs-1.5.29~rc1-4.fc40.x86_64 iio-sensor-proxy-3
11:33:24,444 INFO anaconda:anaconda: core.util: Reporting the IPMI event: 7
11:33:24,496 WARNING anaconda:anaconda: misc: /usr/lib64/python3.12/site-packages/pyanaconda/core/users.py:31: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13#012  import crypt  # pylint: disable=deprecated-module
11:33:24,570 INFO anaconda:program: Running... losetup --list
11:33:24,585 INFO anaconda:anaconda: startup_utils: check_memory(): total:2091, needed:320
11:33:24,586 DEBUG anaconda:anaconda: startup_utils: Don't set up proxy variables.
11:33:24,586 INFO anaconda:program: Running... auditctl -e 0
11:33:24,596 NOTICE audit:CONFIG_CHANGE op=set audit_enabled=0 old=1 auid=4294967295 ses=4294967295 subj=system_u:system_r:kernel_t:s0 res=1
11:33:24,596 NOTICE audit:SYSCALL arch=c000003e syscall=44 success=yes exit=60 a0=3 a1=7fff8de33c30 a2=3c a3=0 items=0 ppid=2517 pid=2555 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts0 ses=4294967295 comm="auditctl" exe="/usr/sbin/auditctl" subj=system_u:system_r:kernel_t:s0 key=(null)
11:33:24,596 NOTICE audit:PROCTITLE proctitle=617564697463746C002D650030
11:33:24,596 NOTICE kernel:audit: type=1305 audit(1697196804.595:264): op=set audit_enabled=0 old=1 auid=4294967295 ses=4294967295 subj=system_u:system_r:kernel_t:s0 res=1
11:33:24,596 INFO anaconda:program: enabled 0
11:33:24,596 INFO anaconda:program: failure 1
11:33:24,597 INFO anaconda:program: pid 0
```