### PR TITLE
fixes for advanced storage: WWID for multipath, path-id for zfcp, generate zfcp kickstart

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -41,7 +41,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define nmver 1.0
 %define pykickstartver 3.47-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.8.1-1
+%define pythonblivetver 1:3.8.2-2
 %define rpmver 4.15.0
 %define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.26

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -177,6 +177,7 @@ class DeviceData(DBusData):
             fcp-lun
             wwpn
             hba-id
+            path-id
 
         :return: a dictionary of attributes
         """

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -162,6 +162,7 @@ class DeviceTreeViewer(ABC):
         data.attrs["fcp-lun"] = self._get_attribute(device, "fcp_lun")
         data.attrs["wwpn"] = self._get_attribute(device, "wwpn")
         data.attrs["hba-id"] = self._get_attribute(device, "hba_id")
+        data.attrs["path-id"] = self._get_attribute(device, "id_path")
 
     def get_format_data(self, device_name):
         """Get the device format data.

--- a/pyanaconda/modules/storage/zfcp/zfcp.py
+++ b/pyanaconda/modules/storage/zfcp/zfcp.py
@@ -84,3 +84,15 @@ class ZFCPModule(KickstartBaseModule):
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
         data.zfcp.zfcp = self._zfcp_data
+        # So far, the data contains explicit zfcp statements from a
+        # kickstart file used as input for the installation. Now, add any
+        # missing entries that come from user interaction with the GUI.
+        for fcpdev in zfcp.fcpdevs:
+            zd = data.zfcp.dataClass()
+            zd.devnum = fcpdev.devnum
+            if "wwpn" in dir(fcpdev):
+                zd.wwpn = fcpdev.wwpn
+            if "fcplun" in dir(fcpdev):
+                zd.fcplun = fcpdev.fcplun
+            if zd not in data.zfcp.dataList():
+                data.zfcp.dataList().append(zd)

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -81,7 +81,7 @@ def create_row(device_data, selected, mutable):
         vendor=device_data.attrs.get("vendor", ""),
         interconnect=device_data.attrs.get("bus", ""),
         serial=device_data.attrs.get("serial", ""),
-        wwid=device_data.attrs.get("path-id", ""),
+        wwid=device_data.attrs.get("path-id", "") or device_data.attrs.get("wwn", ""),
         paths="\n".join(device_data.parents),
         port=device_data.attrs.get("port", ""),
         target=device_data.attrs.get("target", ""),

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -254,7 +254,8 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             size=Size("10 GiB"),
             fcp_lun="0x5719000000000000",
             wwpn="0x5005076300c18154",
-            hba_id="0.0.010a"
+            hba_id="0.0.010a",
+            id_path="ccw-0.0.010a-fc-0x5005076300c18154-lun-0x5719000000000000"
         ))
 
         data = self.interface.GetDeviceData("dev1")
@@ -262,7 +263,8 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         assert data['attrs'] == get_variant(Dict[Str, Str], {
             "fcp-lun": "0x5719000000000000",
             "wwpn": "0x5005076300c18154",
-            "hba-id": "0.0.010a"
+            "hba-id": "0.0.010a",
+            "path-id": "ccw-0.0.010a-fc-0x5005076300c18154-lun-0x5719000000000000"
         })
 
     def test_get_format_data(self):


### PR DESCRIPTION
path-id for zfcp gets its (optional) data from https://github.com/storaged-project/blivet/pull/1161
but that's not a hard dependency

I tested this locally with updates.img from code (anaconda+blivet) branched closely enough for the updates to work with RHEL9.1 products.img (current when I started development).
This is a forward port, which applied pretty much automatically to the new base.

@jstodola @poncovka @sharkcz