### PR TITLE
consolidated s390 device configuration

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -46,6 +46,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define subscriptionmanagerver 1.26
 %define utillinuxver 2.15.1
 %define rpmostreever 2023.2
+%define s390utilscorever 2.31.0
 
 BuildRequires: libtool
 BuildRequires: gettext-devel >= %{gettextver}
@@ -125,7 +126,7 @@ Requires: NetworkManager-team
 %endif
 %ifarch s390 s390x
 Requires: openssh
-Requires: s390utils-core
+Requires: s390utils-core >= %{s390utilscorever}
 %endif
 Requires: NetworkManager >= %{nmver}
 Requires: NetworkManager-libnm >= %{nmver}

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -125,6 +125,7 @@ Requires: NetworkManager-team
 %endif
 %ifarch s390 s390x
 Requires: openssh
+Requires: s390utils-core
 %endif
 Requires: NetworkManager >= %{nmver}
 Requires: NetworkManager-libnm >= %{nmver}

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -27,7 +27,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define dasbusver 1.3
 %define dbusver 1.2.3
 %define dnfver 3.6.0
-%define dracutver 034-7
+%define dracutver 102-3
 %define fcoeutilsver 1.0.12-3.20100323git
 %define gettextver 0.19.8
 %define gtk3ver 3.22.17
@@ -127,6 +127,7 @@ Requires: NetworkManager-team
 %ifarch s390 s390x
 Requires: openssh
 Requires: s390utils-core >= %{s390utilscorever}
+Requires: dracut-network >= %{dracutver}
 %endif
 Requires: NetworkManager >= %{nmver}
 Requires: NetworkManager-libnm >= %{nmver}

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -29,6 +29,7 @@ dist_systemd_DATA = anaconda.service \
                     anaconda-nm-config.service \
                     anaconda-nm-disable-autocons.service \
                     anaconda-pre.service \
+                    anaconda-s390-device-config-import.service \
                     anaconda-fips.service
 
 dist_generator_SCRIPTS = anaconda-generator

--- a/data/systemd/anaconda-s390-device-config-import.service
+++ b/data/systemd/anaconda-s390-device-config-import.service
@@ -1,0 +1,21 @@
+[Unit]
+# This service is to be run before anaconda starts and log data before anaconda changes them
+# Import persistent config of any s390 devices (dasd, zfcp, znet) from
+# initrd to retain user choices made with rd.dasd, rd.zfcp, rd.znet.
+Description=pre-anaconda s390 device persistent config import
+ConditionArchitecture=s390x
+Requires=basic.target
+After=basic.target
+Before=anaconda.target
+Wants=rsyslog.service
+Wants=systemd-udev-settle.service
+Wants=plymouth-quit.service plymouth-quit-wait.service
+Wants=systemd-logind.service
+
+[Service]
+Type=oneshot
+ExecStart=-/sbin/chzdev --import /run/zdev.initrd.config --persistent --yes --no-root-update --force --verbose
+StandardInput=tty
+StandardOutput=journal+console
+StandardError=journal+console
+TimeoutSec=0

--- a/data/systemd/anaconda.target
+++ b/data/systemd/anaconda.target
@@ -12,6 +12,7 @@ Wants=anaconda-direct.service anaconda.service
 Wants=anaconda-sshd.service
 Wants=anaconda-pre.service
 Wants=anaconda-fips.service
+Wants=anaconda-s390-device-config-import.service
 Wants=systemd-logind.service
 Wants=brltty.service
 Wants=rhsm.service

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -37,7 +37,6 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-copy-cmdline.sh \
                       anaconda-copy-dhclient.sh \
                       anaconda-copy-prefixdevname.sh \
-                      anaconda-copy-s390ccwconf.sh \
                       anaconda-ifcfg.sh \
                       anaconda-set-kernel-hung-timeout.sh \
                       anaconda-error-reporting.sh \

--- a/dracut/anaconda-copy-s390ccwconf.sh
+++ b/dracut/anaconda-copy-s390ccwconf.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Copy over s390 config /etc/ccw.conf for anaconda before pivot
-[ -e /etc/ccw.conf ] && cp /etc/ccw.conf /run/install

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -48,7 +48,6 @@ install() {
     inst "$moddir/anaconda-diskroot" "/sbin/anaconda-diskroot"
     inst_hook pre-pivot 50 "$moddir/anaconda-copy-ks.sh"
     inst_hook pre-pivot 50 "$moddir/anaconda-copy-cmdline.sh"
-    inst_hook pre-pivot 50 "$moddir/anaconda-copy-s390ccwconf.sh"
     inst_hook pre-pivot 90 "$moddir/anaconda-copy-dhclient.sh"
     inst_hook pre-pivot 91 "$moddir/anaconda-copy-prefixdevname.sh"
     inst_hook pre-pivot 95 "$moddir/anaconda-set-kernel-hung-timeout.sh"

--- a/pyanaconda/modules/network/utils.py
+++ b/pyanaconda/modules/network/utils.py
@@ -35,8 +35,6 @@ log = get_module_logger(__name__)
 def get_s390_settings(devname):
     cfg = {
         'SUBCHANNELS': '',
-        'NETTYPE': '',
-        'OPTIONS': ''
     }
 
     subchannels = []
@@ -45,23 +43,6 @@ def get_s390_settings(devname):
     if not subchannels:
         return cfg
     cfg['SUBCHANNELS'] = ','.join(subchannels)
-
-    # Example of the ccw.conf file content:
-    # qeth,0.0.0900,0.0.0901,0.0.0902,layer2=0,portname=FOOBAR,portno=0
-    #
-    # SUBCHANNELS="0.0.0900,0.0.0901,0.0.0902"
-    # NETTYPE="qeth"
-    # OPTIONS="layer2=1 portname=FOOBAR portno=0"
-    if not os.path.exists('/run/install/ccw.conf'):
-        return cfg
-    with open('/run/install/ccw.conf') as f:
-        # pylint: disable=redefined-outer-name
-        for line in f:
-            if cfg['SUBCHANNELS'] in line:
-                items = line.strip().split(',')
-                cfg['NETTYPE'] = items[0]
-                cfg['OPTIONS'] = " ".join(i for i in items[1:] if '=' in i)
-                break
 
     return cfg
 

--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
@@ -116,17 +116,20 @@ class NMClientTestCase(unittest.TestCase):
         assert get_ports_from_connections(nm_client, "team", [TEAM1_UUID]) == \
             set([("ens11", "ens11", ENS11_UUID)])
 
+    @patch("pyanaconda.modules.network.nm_client._get_dracut_znet_argument_from_connection")
     @patch("pyanaconda.modules.network.nm_client.get_connections_available_for_iface")
     @patch("pyanaconda.modules.network.nm_client.get_ports_from_connections")
     @patch("pyanaconda.modules.network.nm_client.is_s390")
     def test_get_dracut_arguments_from_connection(self, is_s390, get_ports_from_connections_mock,
-                                                  get_connections_available_for_iface):
+                                                  get_connections_available_for_iface,
+                                                  _get_dracut_znet_argument_from_connection):
         nm_client = Mock()
 
         CON_UUID = "44755f4c-ee12-45b4-ba5e-e10f83de51af"
 
         # IPv4 config auto, IPv6 config auto, mac address specified
         is_s390.return_value = False
+        _get_dracut_znet_argument_from_connection.return_value = ""
         ip4_config_attrs = {
             "get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
         }
@@ -162,6 +165,8 @@ class NMClientTestCase(unittest.TestCase):
 
         # IPv4 config static, mac address not specified, s390
         is_s390.return_value = True
+        _get_dracut_znet_argument_from_connection.return_value = \
+            "rd.znet=qeth,0.0.0900,0.0.0901,0.0.0902,layer2=1,portname=FOOBAR,portno=0"
         address_attrs = {
             "get_address.return_value": "10.34.39.44",
             "get_prefix.return_value": 24,
@@ -176,11 +181,6 @@ class NMClientTestCase(unittest.TestCase):
         ip4_config = self._get_mock_objects_from_attrs([ip4_config_attrs])[0]
         wired_setting_attrs = {
             "get_mac_address.return_value": None,
-            "get_s390_nettype.return_value": "qeth",
-            "get_s390_subchannels.return_value": ["0.0.0900", "0.0.0901", "0.0.0902"],
-            "get_property.return_value": {"layer2": "1",
-                                          "portname": "FOOBAR",
-                                          "portno": "0"},
         }
         wired_setting = self._get_mock_objects_from_attrs([wired_setting_attrs])[0]
         cons_attrs = [
@@ -199,6 +199,7 @@ class NMClientTestCase(unittest.TestCase):
 
         # IPv6 config dhcp
         is_s390.return_value = False
+        _get_dracut_znet_argument_from_connection.return_value = ""
         ip6_config_attrs = {
             "get_method.return_value": NM.SETTING_IP6_CONFIG_METHOD_DHCP,
         }
@@ -222,6 +223,7 @@ class NMClientTestCase(unittest.TestCase):
 
         # IPv6 config manual
         is_s390.return_value = False
+        _get_dracut_znet_argument_from_connection.return_value = ""
         address_attrs = {
             "get_address.return_value": "2001::5",
             "get_prefix.return_value": 64,
@@ -253,6 +255,7 @@ class NMClientTestCase(unittest.TestCase):
 
         # IPv4 config auto, team
         is_s390.return_value = False
+        _get_dracut_znet_argument_from_connection.return_value = ""
         ip4_config_attrs = {
             "get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
         }
@@ -279,6 +282,8 @@ class NMClientTestCase(unittest.TestCase):
 
         # IPv4 config auto, vlan, s390, parent specified by interface name
         is_s390.return_value = True
+        _get_dracut_znet_argument_from_connection.return_value = \
+            "rd.znet=qeth,0.0.0900,0.0.0901,0.0.0902,layer2=1,portname=FOOBAR,portno=0"
         ip4_config_attrs = {
             "get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
         }
@@ -300,11 +305,6 @@ class NMClientTestCase(unittest.TestCase):
         # Mock parent connection
         wired_setting_attrs = {
             "get_mac_address.return_value": None,
-            "get_s390_nettype.return_value": "qeth",
-            "get_s390_subchannels.return_value": ["0.0.0900", "0.0.0901", "0.0.0902"],
-            "get_property.return_value": {"layer2": "1",
-                                          "portname": "FOOBAR",
-                                          "portno": "0"},
         }
         wired_setting = self._get_mock_objects_from_attrs([wired_setting_attrs])[0]
         parent_cons_attrs = [
@@ -326,6 +326,7 @@ class NMClientTestCase(unittest.TestCase):
         # IPv4 config auto, vlan, parent specified by connection uuid
         VLAN_PARENT_UUID = "5e6ead30-d133-4c8c-ba59-818c5ced6a7c"
         is_s390.return_value = False
+        _get_dracut_znet_argument_from_connection.return_value = ""
         ip4_config_attrs = {
             "get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
         }
@@ -361,6 +362,8 @@ class NMClientTestCase(unittest.TestCase):
         # IPv4 config auto, vlan, parent specified by connection uuid, s390 (we
         # need the parent connection in s390 case, not only parent iface)
         is_s390.return_value = True
+        _get_dracut_znet_argument_from_connection.return_value = \
+            "rd.znet=qeth,0.0.0900,0.0.0901,0.0.0902,layer2=1,portname=FOOBAR,portno=0"
         ip4_config_attrs = {
             "get_method.return_value": NM.SETTING_IP4_CONFIG_METHOD_AUTO,
         }
@@ -382,11 +385,6 @@ class NMClientTestCase(unittest.TestCase):
         # Mock parent connection
         wired_setting_attrs = {
             "get_mac_address.return_value": None,
-            "get_s390_nettype.return_value": "qeth",
-            "get_s390_subchannels.return_value": ["0.0.0900", "0.0.0901", "0.0.0902"],
-            "get_property.return_value": {"layer2": "1",
-                                          "portname": "FOOBAR",
-                                          "portno": "0"},
         }
         wired_setting = self._get_mock_objects_from_attrs([wired_setting_attrs])[0]
         parent_cons_attrs = [

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
@@ -83,8 +83,7 @@ class DASDInterfaceTestCase(unittest.TestCase):
                 "dev1",
                 fmt=get_format("ext4"),
                 size=Size("10 GiB"),
-                busid="0.0.0201",
-                opts={}
+                busid="0.0.0201"
             )
         )
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
@@ -123,14 +123,15 @@ class DASDTasksTestCase(unittest.TestCase):
         with pytest.raises(StorageDiscoveryError):
             DASDDiscoverTask("x.y.z").run()
 
+    @patch('pyanaconda.modules.storage.dasd.discover.execWithRedirect')
     @patch('pyanaconda.modules.storage.dasd.discover.blockdev')
-    def test_discovery(self, blockdev):
+    def test_discovery(self, blockdev, execWithRedirect):
         """Test the discovery task."""
+        execWithRedirect.return_value = 0
         DASDDiscoverTask("0.0.A100").run()
         blockdev.s390.sanitize_dev_input.assert_called_once_with("0.0.A100")
 
-        sanitized_input = blockdev.s390.sanitize_dev_input.return_value
-        blockdev.s390.dasd_online.assert_called_once_with(sanitized_input)
+        execWithRedirect.assert_called_once()
 
     @patch('pyanaconda.modules.storage.dasd.format.blockdev')
     def test_format(self, blockdev):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -220,8 +220,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             "dev1",
             fmt=get_format("ext4"),
             size=Size("10 GiB"),
-            busid="0.0.0201",
-            opts={}
+            busid="0.0.0201"
         ))
 
         data = self.interface.GetDeviceData("dev1")


### PR DESCRIPTION
Consolidate the persistent and dynamic configuration of s390-specific devices in Linux distributions by delegating the configuration to the existing framework `zdev` from s390-tools.

This pull request completes consolidated s390 device configuration in `anaconda`.
This also fixes a newly discovered bug about missing persistent device configuration if device is enabled outside of anaconda, e.g. using rd.zfcp from dracut.
Some of the commits [see their descriptions] **depend** on certain commits from:
* https://github.com/ibm-s390-linux/s390-tools/pull/158 and thus https://github.com/ibm-s390-linux/s390-tools/releases/tag/v2.31.0.
* https://github.com/dracutdevs/dracut/pull/2534 (see also https://github.com/rhinstaller/anaconda/pull/5250#issuecomment-1887152134 and https://github.com/rhinstaller/anaconda/pull/5250#issuecomment-1887434454)

This PR works together with https://github.com/storaged-project/blivet/pull/1162.

Zdev's job is to perform low-level configuration after which the user gets architecture-independent objects such as block devices, SCSI devices, or network interfaces. Those can and should in turn be configured with existing common code mechanisms. So there's a clear separated layering for configuration duties.

In particular, the s390-specific devices currently are: DASD (traditional disk), ZFCP (scsi), and ZNET representing channel-attached network (QETH incl. OSA and HiperSockets, LCS, CTC). Zdev has a stable command line user interface and abstracts from sysfs and from a persistent configuration representation. Zdev encapsulates configuration details. Systems management code can simply delegate configuration to zdev and thus reduce architecture-specific code.

_This improves user experience, serviceability, maintainability, and reduces test effort._

@jstodola @poncovka @sharkcz

Even though this is a draft pull request, I would appreciate review comments.
It's only a draft until we sorted out the dependencies and merge order of pull requests for different related projects. Some thoughts in the integration process are in https://github.com/rhinstaller/anaconda/pull/5250#issuecomment-1887522104.

I developed and tested this locally with updates.img based on code (anaconda+blivet) branched closely enough for the updates to work with RHEL9.1 products.img (current when I started development).
This is a forward port, which applied pretty much automatically to the new base.