### PR TITLE
infra: Disable l10n updates on branch

### DIFF
--- a/.github/workflows/l10n-po-update.yml
+++ b/.github/workflows/l10n-po-update.yml
@@ -25,7 +25,8 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        branch: ['master', 'fedora-39']
+        #branch: ['master', 'fedora-39']
+        branch: ['master']
 
     steps:
       - name: Set up dependencies

--- a/.github/workflows/l10n-po-update.yml.j2
+++ b/.github/workflows/l10n-po-update.yml.j2
@@ -19,7 +19,8 @@ jobs:
       max-parallel: 1
       matrix:
         {% if branched_fedora_version is defined and branched_fedora_version %}
-        branch: ['master', 'fedora-{$ branched_fedora_version $}']
+        #branch: ['master', 'fedora-{$ branched_fedora_version $}']
+        branch: ['master']
         {% else %}
         branch: ['master']
         {% endif %}


### PR DESCRIPTION
Let's not update translations on f39 automatically any more. There are no builds, so there is also no reason to merge them.