### PR TITLE
Revert "Disable geolocation on the Fedora Workstation live image"

### DIFF
--- a/data/profile.d/fedora-workstation.conf
+++ b/data/profile.d/fedora-workstation.conf
@@ -22,9 +22,3 @@ hidden_spokes =
     NetworkSpoke
     PasswordSpoke
     UserSpoke
-
-[Localization]
-# disable localization for the Fedora Workstation live image to avoid
-# it clashing with Gnome Initial Setup setting the Live environmment and
-# installation language first
-use_geolocation = False


### PR DESCRIPTION
This reverts commit 3fd3a2c0a5b9be3b372da4d586133c433b1b4868.

Resolves: rhbz#2242212

