### PR TITLE
Make pylint work again

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -473,7 +473,11 @@ tests-pylint:
 # For a weird reason when pylint is not in TESTS included for automake (during configure)
 # it won't allow us to use makefile check to start the tests.
 # Unfortunately, we removed pylint from the TESTS because we don't want it to run as default
-	$(srcdir)/tests/pylint/runpylint | tee $(srcdir)/tests/pylint/runpylint.log
+	set -o pipefail ; \
+	$(srcdir)/tests/pylint/runpylint | tee $(srcdir)/tests/pylint/runpylint.log ; \
+	rc=$$? ; \
+	$(MAKE) grab-logs ; \
+	exit $$rc
 
 tests-unit-only:
 	@mkdir -p $(USER_SITE_PACKAGES)

--- a/anaconda.py
+++ b/anaconda.py
@@ -36,9 +36,11 @@ def exitHandler(rebootData):
     from pyanaconda.core.process_watchers import WatchProcesses
     WatchProcesses.unwatch_all_processes()
 
+    # pylint: disable=used-before-assignment
     if flags.usevnc:
         vnc.shutdownServer()
 
+    # pylint: disable=used-before-assignment
     if "nokill" in kernel_arguments:
         util.vtActivate(1)
         print("anaconda halting due to nokill flag.")
@@ -67,7 +69,7 @@ def exitHandler(rebootData):
 
     # Tear down the storage module.
     storage_proxy = STORAGE.get_proxy()
-    from pyanaconda.modules.common.task import sync_run_task
+    from pyanaconda.modules.common.task import sync_run_task  # pylint: disable=redefined-outer-name
 
     for task_path in storage_proxy.TeardownWithTasks():
         task_proxy = STORAGE.get_proxy(task_path)
@@ -148,7 +150,7 @@ def setup_environment():
     if "DISPLAY" in os.environ:
         flags.preexisting_x11 = True
     else:
-        os.environ["DISPLAY"] = ":%s" % constants.X_DISPLAY_NUMBER
+        os.environ["DISPLAY"] = ":%s" % constants.X_DISPLAY_NUMBER  # pylint: disable=used-before-assignment
 
     # We mostly don't run from bash, so it won't load the file for us, and libreport will then
     # show vi instead of nano. Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1889674

--- a/dockerfile/anaconda-ci/requirements.txt
+++ b/dockerfile/anaconda-ci/requirements.txt
@@ -16,7 +16,7 @@ jinja2
 
 # pylint and its supporting libs
 pylint == 3.0.3
-astroid == 3.0.2
+astroid == 3.0.3
 
 # ruff for fast linting
 ruff == 0.1.14

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -70,6 +70,7 @@ TESTS = \
 	glade_tests/glade_tests.sh \
 	shellcheck/run_shellcheck.sh \
 	ruff/run_ruff.sh \
+	pylint/runpylint \
 	unit_tests/unit_tests.sh
 
 clean-local:


### PR DESCRIPTION
Resolves:
- Running pylint standalone in container is possible
- New detections are all resolved
- Pylint runs among other ci tests, same as before

TODO:
- [x] `E0602(undefined-variable):ui/webui/test/check-basic:227,16: TestBasic.testJsErrorHandling: Undefined variable 'time'`
- [x] `E1101(no-member):ui/webui/test/helpers/storage.py:414,8: StorageMountPointMapping.select_mountpoint: Instance of 'StorageMountPointMapping' has no 'set_partitioning' member`
- [X] Squash commits in make, it's easier to understand as one change

~~I'm rather stumped by the last two finds listed above, there's no clear reason how these actually work.~~

After this is done, we can make another PR where we either make pylint into another gh test alongside unit tests, or put it back with them as it was. I left out this part intentionally, so that we can have the fixes without the other decisions.