### PR TITLE
Add new substitution members in dnf tests

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -110,7 +110,9 @@ class DNFManagerTestCase(unittest.TestCase):
         self._check_substitutions({
             "arch": "x86_64",
             "basearch": "x86_64",
-            "releasever": "rawhide"
+            "releasever": "rawhide",
+            "releasever_major": "rawhide",
+            "releasever_minor": "",
         })
 
     @patch("pyanaconda.modules.payloads.payload.dnf.dnf_manager.get_os_release_value")
@@ -610,7 +612,9 @@ class DNFManagerTestCase(unittest.TestCase):
         self._check_substitutions({
             "arch": "x86_64",
             "basearch": "x86_64",
-            "releasever": "123"
+            "releasever": "123",
+            "releasever_major": "123",
+            "releasever_minor": "",
         })
 
         # Ignore an undefined release version.
@@ -620,7 +624,9 @@ class DNFManagerTestCase(unittest.TestCase):
         self._check_substitutions({
             "arch": "x86_64",
             "basearch": "x86_64",
-            "releasever": "123"
+            "releasever": "123",
+            "releasever_major": "123",
+            "releasever_minor": "",
         })
 
     @patch("dnf.subject.Subject.get_best_query")


### PR DESCRIPTION
Fixes unit tests. ~~Does not need container rebuild.~~ 

Actually, this needs a container rebuild, or the tests can't succeed. But there is no change that would signal a container rebuild, so the tests fail. Locally they pass with dnf 4.18.0-1. I don't think we want to bump the version, since it's only a test dependency...