### PR TITLE
Users step

### DIFF
--- a/ui/webui/src/apis/users.js
+++ b/ui/webui/src/apis/users.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+import { _setProperty } from "./helpers.js";
+
+const OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Users";
+const INTERFACE_NAME = "org.fedoraproject.Anaconda.Modules.Users";
+
+const setProperty = (...args) => {
+    return _setProperty(UsersClient, OBJECT_PATH, INTERFACE_NAME, ...args);
+};
+
+export class UsersClient {
+    constructor (address) {
+        if (UsersClient.instance && (!address || UsersClient.instance.address === address)) {
+            return UsersClient.instance;
+        }
+
+        UsersClient.instance?.client.close();
+
+        UsersClient.instance = this;
+
+        this.client = cockpit.dbus(
+            INTERFACE_NAME,
+            { superuser: "try", bus: "none", address }
+        );
+        this.address = address;
+    }
+
+    init () {
+        this.client.addEventListener(
+            "close", () => console.error("Users client closed")
+        );
+    }
+}
+
+/**
+ * @param {Array.<Object>} users An array of user objects
+ */
+export const setUsers = (users) => {
+    return setProperty("Users", cockpit.variant("aa{sv}", users));
+};

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -39,6 +39,7 @@ import { getDefaultScenario } from "./storage/InstallationScenario.jsx";
 import { MountPointMapping, getPageProps as getMountPointMappingProps } from "./storage/MountPointMapping.jsx";
 import { DiskEncryption, getStorageEncryptionState, getPageProps as getDiskEncryptionProps } from "./storage/DiskEncryption.jsx";
 import { InstallationLanguage, getPageProps as getInstallationLanguageProps } from "./localization/InstallationLanguage.jsx";
+import { Accounts, getPageProps as getAccountsProps } from "./users/Accounts.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
 import { ReviewConfiguration, ReviewConfigurationConfirmModal, getPageProps as getReviewConfigurationProps } from "./review/ReviewConfiguration.jsx";
 import { exitGui } from "../helpers/exit.js";
@@ -142,6 +143,11 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
                 },
                 ...getDiskEncryptionProps({ storageScenarioId })
             }]
+        },
+        {
+            component: Accounts,
+            data: {},
+            ...getAccountsProps()
         },
         {
             component: ReviewConfiguration,

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -146,7 +146,9 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
         },
         {
             component: Accounts,
-            data: {},
+            data: {
+                passwordPolicies: runtimeData.passwordPolicies,
+            },
             ...getAccountsProps()
         },
         {

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -189,10 +189,14 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
     const firstStepId = stepsOrder.filter(step => !step.isHidden)[0].id;
     const currentStepId = path[0] || firstStepId;
 
+    const isStepFollowedBy = (earlierStepId, laterStepId) => {
+        const earlierStepIdx = flattenedStepsIds.findIndex(s => s === earlierStepId);
+        const laterStepIdx = flattenedStepsIds.findIndex(s => s === laterStepId);
+        return earlierStepIdx < laterStepIdx;
+    };
+
     const canJumpToStep = (stepId, currentStepId) => {
-        const stepIdx = flattenedStepsIds.findIndex(s => s === stepId);
-        const currentStepIdx = flattenedStepsIds.findIndex(s => s === currentStepId);
-        return stepIdx <= currentStepIdx;
+        return stepId === currentStepId || isStepFollowedBy(stepId, currentStepId);
     };
 
     const createSteps = (stepsOrder) => {
@@ -235,8 +239,10 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
             setIsFormValid(false);
         }
 
-        // Reset the applied partitioning when going back from review page
-        if (prevStep.prevId === "installation-review") {
+        // Reset the applied partitioning when going back from a step after creating partitioning to a step
+        // before creating partitioning.
+        if ((prevStep.prevId === "accounts" || isStepFollowedBy("accounts", prevStep.prevId)) &&
+            isStepFollowedBy(newStep.id, "accounts")) {
             setIsFormDisabled(true);
             resetPartitioning()
                     .then(

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -39,7 +39,7 @@ import { getDefaultScenario } from "./storage/InstallationScenario.jsx";
 import { MountPointMapping, getPageProps as getMountPointMappingProps } from "./storage/MountPointMapping.jsx";
 import { DiskEncryption, getStorageEncryptionState, getPageProps as getDiskEncryptionProps } from "./storage/DiskEncryption.jsx";
 import { InstallationLanguage, getPageProps as getInstallationLanguageProps } from "./localization/InstallationLanguage.jsx";
-import { Accounts, getPageProps as getAccountsProps } from "./users/Accounts.jsx";
+import { Accounts, getPageProps as getAccountsProps, getAccountsState } from "./users/Accounts.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
 import { ReviewConfiguration, ReviewConfigurationConfirmModal, getPageProps as getReviewConfigurationProps } from "./review/ReviewConfiguration.jsx";
 import { exitGui } from "../helpers/exit.js";
@@ -64,6 +64,7 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
     const [stepNotification, setStepNotification] = useState();
     const [storageEncryption, setStorageEncryption] = useState(getStorageEncryptionState());
     const [storageScenarioId, setStorageScenarioId] = useState(window.sessionStorage.getItem("storage-scenario-id") || getDefaultScenario().id);
+    const [accounts, setAccounts] = useState(getAccountsState());
     const [showWizard, setShowWizard] = useState(true);
     const osRelease = useContext(OsReleaseContext);
     const isBootIso = useContext(SystemTypeContext) === "BOOT_ISO";
@@ -147,6 +148,8 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
         {
             component: Accounts,
             data: {
+                accounts,
+                setAccounts,
                 passwordPolicies: runtimeData.passwordPolicies,
             },
             ...getAccountsProps()
@@ -270,6 +273,7 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
                 stepsOrder={stepsOrder}
                 storageEncryption={storageEncryption}
                 storageScenarioId={storageScenarioId}
+                accounts={accounts}
               />}
               hideClose
               mainAriaLabel={`${title} content`}
@@ -296,6 +300,7 @@ const Footer = ({
     stepsOrder,
     storageEncryption,
     storageScenarioId,
+    accounts,
 }) => {
     const [nextWaitsConfirmation, setNextWaitsConfirmation] = useState(false);
     const [quitWaitsConfirmation, setQuitWaitsConfirmation] = useState(false);
@@ -346,6 +351,8 @@ const Footer = ({
                     setStepNotification();
                 },
             });
+        } else if (activeStep.id === "accounts") {
+            onNext();
         } else {
             onNext();
         }

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -155,7 +155,7 @@ export const AnacondaWizard = ({ dispatch, storageData, localizationData, runtim
                 setAccounts,
                 passwordPolicies: runtimeData.passwordPolicies,
             },
-            ...getAccountsProps()
+            ...getAccountsProps({ isBootIso })
         },
         {
             component: ReviewConfiguration,

--- a/ui/webui/src/components/AnacondaWizard.jsx
+++ b/ui/webui/src/components/AnacondaWizard.jsx
@@ -39,7 +39,7 @@ import { getDefaultScenario } from "./storage/InstallationScenario.jsx";
 import { MountPointMapping, getPageProps as getMountPointMappingProps } from "./storage/MountPointMapping.jsx";
 import { DiskEncryption, getStorageEncryptionState, getPageProps as getDiskEncryptionProps } from "./storage/DiskEncryption.jsx";
 import { InstallationLanguage, getPageProps as getInstallationLanguageProps } from "./localization/InstallationLanguage.jsx";
-import { Accounts, getPageProps as getAccountsProps, getAccountsState } from "./users/Accounts.jsx";
+import { Accounts, getPageProps as getAccountsProps, getAccountsState, accountsToDbusUsers } from "./users/Accounts.jsx";
 import { InstallationProgress } from "./installation/InstallationProgress.jsx";
 import { ReviewConfiguration, ReviewConfigurationConfirmModal, getPageProps as getReviewConfigurationProps } from "./review/ReviewConfiguration.jsx";
 import { exitGui } from "../helpers/exit.js";
@@ -51,6 +51,9 @@ import {
     applyStorage,
     resetPartitioning,
 } from "../apis/storage_partitioning.js";
+import {
+    setUsers,
+} from "../apis/users.js";
 import { SystemTypeContext, OsReleaseContext } from "./Common.jsx";
 
 const _ = cockpit.gettext;
@@ -358,6 +361,7 @@ const Footer = ({
                 },
             });
         } else if (activeStep.id === "accounts") {
+            setUsers(accountsToDbusUsers(accounts));
             onNext();
         } else {
             onNext();

--- a/ui/webui/src/components/Password.jsx
+++ b/ui/webui/src/components/Password.jsx
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React, { useState, useEffect, useMemo } from "react";
+import { debounce } from "throttle-debounce";
+
+import {
+    Button,
+    FormGroup,
+    FormHelperText,
+    HelperText,
+    HelperTextItem,
+    InputGroup,
+    InputGroupItem,
+    TextInput,
+} from "@patternfly/react-core";
+
+// eslint-disable-next-line camelcase
+import { password_quality } from "cockpit-components-password.jsx";
+import {
+    ExclamationCircleIcon,
+    ExclamationTriangleIcon,
+    CheckCircleIcon,
+    EyeIcon,
+    EyeSlashIcon
+} from "@patternfly/react-icons";
+
+const _ = cockpit.gettext;
+
+export const ruleLength = {
+    id: "length",
+    text: (policy) => cockpit.format(_("Must be at least $0 characters"), policy["min-length"].v),
+    check: (policy, password) => password.length >= policy["min-length"].v,
+    isError: true,
+};
+
+/* Calculate the password quality levels based on the password policy
+ * If the policy specifies a 'is-strict' rule anything bellow the minimum specified by the policy
+ * is considered invalid
+ * @param {int} minQualility - the minimum quality level
+ * @return {array} - the password strengh levels
+ */
+const getStrengthLevels = (minQualility, isStrict) => {
+    const levels = [{
+        id: "weak",
+        label: _("Weak"),
+        variant: "error",
+        icon: <ExclamationCircleIcon />,
+        lower_bound: 0,
+        higher_bound: minQualility - 1,
+        valid: !isStrict,
+    }];
+
+    if (minQualility <= 69) {
+        levels.push({
+            id: "medium",
+            label: _("Medium"),
+            variant: "warning",
+            icon: <ExclamationTriangleIcon />,
+            lower_bound: minQualility,
+            higher_bound: 69,
+            valid: true,
+        });
+    }
+
+    levels.push({
+        id: "strong",
+        label: _("Strong"),
+        variant: "success",
+        icon: <CheckCircleIcon />,
+        lower_bound: Math.max(70, minQualility),
+        higher_bound: 100,
+        valid: true,
+    });
+
+    return levels;
+};
+
+const getRuleResults = (rules, policy, password) => {
+    return rules.map(rule => {
+        return {
+            id: rule.id,
+            text: rule.text(policy, password),
+            isSatisfied: password.length > 0 ? rule.check(policy, password) : null,
+            isError: rule.isError
+        };
+    });
+};
+
+const rulesSatisfied = ruleResults => ruleResults.every(r => r.isSatisfied || !r.isError);
+
+const passwordStrengthLabel = (idPrefix, strength, strengthLevels) => {
+    const level = strengthLevels.filter(l => l.id === strength)[0];
+    if (level) {
+        return (
+            <HelperText>
+                <HelperTextItem id={idPrefix + "-password-strength-label"} variant={level.variant} icon={level.icon}>
+                    {level.label}
+                </HelperTextItem>
+            </HelperText>
+        );
+    }
+};
+
+export const PasswordFormFields = ({
+    idPrefix,
+    policy,
+    initialPassword,
+    passwordLabel,
+    onChange,
+    initialConfirmPassword,
+    confirmPasswordLabel,
+    onConfirmChange,
+    rules,
+    setIsValid,
+}) => {
+    const [passwordHidden, setPasswordHidden] = useState(true);
+    const [confirmHidden, setConfirmHidden] = useState(true);
+    const [_password, _setPassword] = useState(initialPassword);
+    const [_confirmPassword, _setConfirmPassword] = useState(initialConfirmPassword);
+    const [password, setPassword] = useState(initialPassword);
+    const [confirmPassword, setConfirmPassword] = useState(initialConfirmPassword);
+    const [passwordStrength, setPasswordStrength] = useState("");
+
+    useEffect(() => {
+        debounce(300, () => { setPassword(_password); onChange(_password) })();
+    }, [_password, onChange]);
+
+    useEffect(() => {
+        debounce(300, () => { setConfirmPassword(_confirmPassword); onConfirmChange(_confirmPassword) })();
+    }, [_confirmPassword, onConfirmChange]);
+
+    const ruleResults = useMemo(() => {
+        return getRuleResults(rules, policy, password);
+    }, [policy, password, rules]);
+
+    const ruleConfirmMatches = useMemo(() => {
+        return password.length > 0 ? password === confirmPassword : null;
+    }, [password, confirmPassword]);
+
+    const ruleHelperItems = ruleResults.map(rule => {
+        let variant = rule.isSatisfied === null ? "indeterminate" : rule.isSatisfied ? "success" : "error";
+        if (!rule.isError) {
+            if (rule.isSatisfied || rule.isSatisfied === null) {
+                return null;
+            }
+            variant = "warning";
+        }
+        return (
+            <HelperTextItem
+              key={rule.id}
+              id={idPrefix + "-password-rule-" + rule.id}
+              isDynamic
+              variant={variant}
+              component="li"
+            >
+                {rule.text}
+            </HelperTextItem>
+        );
+    });
+
+    const ruleConfirmVariant = ruleConfirmMatches === null ? "indeterminate" : ruleConfirmMatches ? "success" : "error";
+
+    const strengthLevels = useMemo(() => {
+        return policy && getStrengthLevels(policy["min-quality"].v, policy["is-strict"].v);
+    }, [policy]);
+
+    useEffect(() => {
+        const updatePasswordStrength = async () => {
+            const _passwordStrength = await getPasswordStrength(password, strengthLevels);
+            setPasswordStrength(_passwordStrength);
+        };
+        updatePasswordStrength();
+    }, [password, strengthLevels]);
+
+    useEffect(() => {
+        setIsValid(
+            rulesSatisfied(ruleResults) &&
+            ruleConfirmMatches &&
+            isValidStrength(passwordStrength, strengthLevels)
+        );
+    }, [setIsValid, ruleResults, ruleConfirmMatches, passwordStrength, strengthLevels]);
+
+    return (
+        <>
+            <FormGroup
+              label={passwordLabel}
+              labelInfo={rulesSatisfied(ruleResults) && passwordStrengthLabel(idPrefix, passwordStrength, strengthLevels)}
+            >
+                <InputGroup>
+                    <InputGroupItem isFill>
+                        <TextInput
+                          type={passwordHidden ? "password" : "text"}
+                          value={_password}
+                          onChange={(_event, val) => _setPassword(val)}
+                          id={idPrefix + "-password-field"}
+                        />
+                    </InputGroupItem>
+                    <InputGroupItem>
+                        <Button
+                          variant="control"
+                          onClick={() => setPasswordHidden(!passwordHidden)}
+                          aria-label={passwordHidden ? _("Show password") : _("Hide password")}
+                        >
+                            {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                        </Button>
+                    </InputGroupItem>
+                </InputGroup>
+                <FormHelperText>
+                    <HelperText component="ul" aria-live="polite" id={idPrefix + "-password-field-helper"}>
+                        {ruleHelperItems}
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+            <FormGroup
+              label={confirmPasswordLabel}
+            >
+                <InputGroup>
+                    <InputGroupItem isFill><TextInput
+                      type={confirmHidden ? "password" : "text"}
+                      value={_confirmPassword}
+                      onChange={(_event, val) => _setConfirmPassword(val)}
+                      id={idPrefix + "-password-confirm-field"}
+                    />
+                    </InputGroupItem>
+                    <InputGroupItem>
+                        <Button
+                          variant="control"
+                          onClick={() => setConfirmHidden(!confirmHidden)}
+                          aria-label={confirmHidden ? _("Show confirmed password") : _("Hide confirmed password")}
+                        >
+                            {confirmHidden ? <EyeIcon /> : <EyeSlashIcon />}
+                        </Button>
+                    </InputGroupItem>
+                </InputGroup>
+                <FormHelperText>
+                    <HelperText component="ul" aria-live="polite" id="password-confirm-field-helper">
+                        <HelperTextItem
+                          id={idPrefix + "-password-rule-match"}
+                          isDynamic
+                          variant={ruleConfirmVariant}
+                          component="li"
+                        >
+                            {_("Passphrases must match")}
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>
+            </FormGroup>
+        </>
+    );
+};
+
+const getPasswordStrength = async (password, strengthLevels) => {
+    // In case of unacceptable password just return 0
+    const force = true;
+    const quality = await password_quality(password, force);
+    const level = strengthLevels.filter(l => l.lower_bound <= quality.value && l.higher_bound >= quality.value)[0];
+    return level.id;
+};
+
+const isValidStrength = (strength, strengthLevels) => {
+    const level = strengthLevels.filter(l => l.id === strength)[0];
+
+    return level ? level.valid : false;
+};

--- a/ui/webui/src/components/app.jsx
+++ b/ui/webui/src/components/app.jsx
@@ -36,6 +36,7 @@ import { StorageClient, initDataStorage, startEventMonitorStorage } from "../api
 import { PayloadsClient } from "../apis/payloads";
 import { RuntimeClient, initDataRuntime, startEventMonitorRuntime } from "../apis/runtime";
 import { NetworkClient, initDataNetwork, startEventMonitorNetwork } from "../apis/network.js";
+import { UsersClient } from "../apis/users";
 
 import { setCriticalErrorAction } from "../actions/miscellaneous-actions.js";
 
@@ -78,6 +79,7 @@ export const Application = () => {
                 new RuntimeClient(address),
                 new BossClient(address),
                 new NetworkClient(address),
+                new UsersClient(address),
             ];
             clients.forEach(c => c.init());
 

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -16,80 +16,26 @@
  */
 
 import cockpit from "cockpit";
-import React, { useState, useEffect, useMemo } from "react";
-import { debounce } from "throttle-debounce";
+import React, { useState, useEffect } from "react";
 
 import {
-    Button,
     Checkbox,
     EmptyState,
+    EmptyStateHeader,
     EmptyStateIcon,
+    EmptyStateFooter,
     Form,
-    FormGroup,
-    FormHelperText,
-    HelperText,
-    HelperTextItem,
-    InputGroup,
     Spinner,
-    TextInput,
     TextContent,
     TextVariants,
-    Text, EmptyStateHeader, EmptyStateFooter, InputGroupItem,
+    Text,
 } from "@patternfly/react-core";
-
-// eslint-disable-next-line camelcase
-import { password_quality } from "cockpit-components-password.jsx";
-import EyeIcon from "@patternfly/react-icons/dist/esm/icons/eye-icon";
-import EyeSlashIcon from "@patternfly/react-icons/dist/esm/icons/eye-slash-icon";
-import ExclamationCircleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon";
-import ExclamationTriangleIcon from "@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon";
-import CheckCircleIcon from "@patternfly/react-icons/dist/esm/icons/check-circle-icon";
 
 import "./DiskEncryption.scss";
 
+import { PasswordFormFields } from "../Password.jsx";
+
 const _ = cockpit.gettext;
-
-/* Calculate the password quality levels based on the password policy
- * If the policy specifies a 'is-strict' rule anything bellow the minimum specified by the policy
- * is considered invalid
- * @param {int} minQualility - the minimum quality level
- * @return {array} - the password strengh levels
- */
-const getStrengthLevels = (minQualility, isStrict) => {
-    const levels = [{
-        id: "weak",
-        label: _("Weak"),
-        variant: "error",
-        icon: <ExclamationCircleIcon />,
-        lower_bound: 0,
-        higher_bound: minQualility - 1,
-        valid: !isStrict,
-    }];
-
-    if (minQualility <= 69) {
-        levels.push({
-            id: "medium",
-            label: _("Medium"),
-            variant: "warning",
-            icon: <ExclamationTriangleIcon />,
-            lower_bound: minQualility,
-            higher_bound: 69,
-            valid: true,
-        });
-    }
-
-    levels.push({
-        id: "strong",
-        label: _("Strong"),
-        variant: "success",
-        icon: <CheckCircleIcon />,
-        lower_bound: Math.max(70, minQualility),
-        higher_bound: 100,
-        valid: true,
-    });
-
-    return levels;
-};
 
 const rules = [
     {
@@ -106,198 +52,9 @@ const rules = [
     },
 ];
 
-const getRuleResults = (rules, policy, password) => {
-    return rules.map(rule => {
-        return {
-            id: rule.id,
-            text: rule.text(policy, password),
-            isSatisfied: password.length > 0 ? rule.check(policy, password) : null,
-            isError: rule.isError
-        };
-    });
-};
-
-const rulesSatisfied = ruleResults => ruleResults.every(r => r.isSatisfied || !r.isError);
-
 export function getStorageEncryptionState (password = "", confirmPassword = "", encrypt = false) {
     return { password, confirmPassword, encrypt };
 }
-
-const passwordStrengthLabel = (idPrefix, strength, strengthLevels) => {
-    const level = strengthLevels.filter(l => l.id === strength)[0];
-    if (level) {
-        return (
-            <HelperText>
-                <HelperTextItem id={idPrefix + "-password-strength-label"} variant={level.variant} icon={level.icon}>
-                    {level.label}
-                </HelperTextItem>
-            </HelperText>
-        );
-    }
-};
-
-const PasswordFormFields = ({
-    idPrefix,
-    policy,
-    initialPassword,
-    passwordLabel,
-    onChange,
-    initialConfirmPassword,
-    confirmPasswordLabel,
-    onConfirmChange,
-    rules,
-    setIsValid,
-}) => {
-    const [passwordHidden, setPasswordHidden] = useState(true);
-    const [confirmHidden, setConfirmHidden] = useState(true);
-    const [_password, _setPassword] = useState(initialPassword);
-    const [_confirmPassword, _setConfirmPassword] = useState(initialConfirmPassword);
-    const [password, setPassword] = useState(initialPassword);
-    const [confirmPassword, setConfirmPassword] = useState(initialConfirmPassword);
-    const [passwordStrength, setPasswordStrength] = useState("");
-
-    useEffect(() => {
-        debounce(300, () => { setPassword(_password); onChange(_password) })();
-    }, [_password, onChange]);
-
-    useEffect(() => {
-        debounce(300, () => { setConfirmPassword(_confirmPassword); onConfirmChange(_confirmPassword) })();
-    }, [_confirmPassword, onConfirmChange]);
-
-    const ruleResults = useMemo(() => {
-        return getRuleResults(rules, policy, password);
-    }, [policy, password, rules]);
-
-    const ruleConfirmMatches = useMemo(() => {
-        return password.length > 0 ? password === confirmPassword : null;
-    }, [password, confirmPassword]);
-
-    const ruleHelperItems = ruleResults.map(rule => {
-        console.log(rule);
-        let variant = rule.isSatisfied === null ? "indeterminate" : rule.isSatisfied ? "success" : "error";
-        if (!rule.isError) {
-            if (rule.isSatisfied || rule.isSatisfied === null) {
-                return null;
-            }
-            variant = "warning";
-        }
-        return (
-            <HelperTextItem
-              key={rule.id}
-              id={idPrefix + "-password-rule-" + rule.id}
-              isDynamic
-              variant={variant}
-              component="li"
-            >
-                {rule.text}
-            </HelperTextItem>
-        );
-    });
-
-    const ruleConfirmVariant = ruleConfirmMatches === null ? "indeterminate" : ruleConfirmMatches ? "success" : "error";
-
-    const strengthLevels = useMemo(() => {
-        return policy && getStrengthLevels(policy["min-quality"].v, policy["is-strict"].v);
-    }, [policy]);
-
-    useEffect(() => {
-        const updatePasswordStrength = async () => {
-            const _passwordStrength = await getPasswordStrength(password, strengthLevels);
-            setPasswordStrength(_passwordStrength);
-        };
-        updatePasswordStrength();
-    }, [password, strengthLevels]);
-
-    useEffect(() => {
-        setIsValid(
-            rulesSatisfied(ruleResults) &&
-            ruleConfirmMatches &&
-            isValidStrength(passwordStrength, strengthLevels)
-        );
-    }, [setIsValid, ruleResults, ruleConfirmMatches, passwordStrength, strengthLevels]);
-
-    return (
-        <>
-            <FormGroup
-              label={passwordLabel}
-              labelInfo={rulesSatisfied(ruleResults) && passwordStrengthLabel(idPrefix, passwordStrength, strengthLevels)}
-            >
-                <InputGroup>
-                    <InputGroupItem isFill>
-                        <TextInput
-                          type={passwordHidden ? "password" : "text"}
-                          value={_password}
-                          onChange={(_event, val) => _setPassword(val)}
-                          id={idPrefix + "-password-field"}
-                        />
-                    </InputGroupItem>
-                    <InputGroupItem>
-                        <Button
-                          variant="control"
-                          onClick={() => setPasswordHidden(!passwordHidden)}
-                          aria-label={passwordHidden ? _("Show password") : _("Hide password")}
-                        >
-                            {passwordHidden ? <EyeIcon /> : <EyeSlashIcon />}
-                        </Button>
-                    </InputGroupItem>
-                </InputGroup>
-                <FormHelperText>
-                    <HelperText component="ul" aria-live="polite" id={idPrefix + "-password-field-helper"}>
-                        {ruleHelperItems}
-                    </HelperText>
-                </FormHelperText>
-            </FormGroup>
-            <FormGroup
-              label={confirmPasswordLabel}
-            >
-                <InputGroup>
-                    <InputGroupItem isFill><TextInput
-                      type={confirmHidden ? "password" : "text"}
-                      value={_confirmPassword}
-                      onChange={(_event, val) => _setConfirmPassword(val)}
-                      id={idPrefix + "-password-confirm-field"}
-                    />
-                    </InputGroupItem>
-                    <InputGroupItem>
-                        <Button
-                          variant="control"
-                          onClick={() => setConfirmHidden(!confirmHidden)}
-                          aria-label={confirmHidden ? _("Show confirmed password") : _("Hide confirmed password")}
-                        >
-                            {confirmHidden ? <EyeIcon /> : <EyeSlashIcon />}
-                        </Button>
-                    </InputGroupItem>
-                </InputGroup>
-                <FormHelperText>
-                    <HelperText component="ul" aria-live="polite" id="password-confirm-field-helper">
-                        <HelperTextItem
-                          id={idPrefix + "-password-rule-match"}
-                          isDynamic
-                          variant={ruleConfirmVariant}
-                          component="li"
-                        >
-                            {_("Passphrases must match")}
-                        </HelperTextItem>
-                    </HelperText>
-                </FormHelperText>
-            </FormGroup>
-        </>
-    );
-};
-
-const getPasswordStrength = async (password, strengthLevels) => {
-    // In case of unacceptable password just return 0
-    const force = true;
-    const quality = await password_quality(password, force);
-    const level = strengthLevels.filter(l => l.lower_bound <= quality.value && l.higher_bound >= quality.value)[0];
-    return level.id;
-};
-
-const isValidStrength = (strength, strengthLevels) => {
-    const level = strengthLevels.filter(l => l.id === strength)[0];
-
-    return level ? level.valid : false;
-};
 
 const CheckDisksSpinner = (
     <EmptyState id="installation-destination-next-spinner">

--- a/ui/webui/src/components/storage/DiskEncryption.jsx
+++ b/ui/webui/src/components/storage/DiskEncryption.jsx
@@ -33,24 +33,16 @@ import {
 
 import "./DiskEncryption.scss";
 
-import { PasswordFormFields } from "../Password.jsx";
+import { PasswordFormFields, ruleLength } from "../Password.jsx";
 
 const _ = cockpit.gettext;
 
-const rules = [
-    {
-        id: "length",
-        text: (policy) => cockpit.format(_("Must be at least $0 characters"), policy["min-length"].v),
-        check: (policy, password) => password.length >= policy["min-length"].v,
-        isError: true,
-    },
-    {
-        id: "ascii",
-        text: (policy) => _("The passphrase you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts when typing it."),
-        check: (policy, password) => password.length > 0 && /^[\x20-\x7F]*$/.test(password),
-        isError: false,
-    },
-];
+const ruleAscii = {
+    id: "ascii",
+    text: (policy) => _("The passphrase you have provided contains non-ASCII characters. You may not be able to switch between keyboard layouts when typing it."),
+    check: (policy, password) => password.length > 0 && /^[\x20-\x7F]*$/.test(password),
+    isError: false,
+};
 
 export function getStorageEncryptionState (password = "", confirmPassword = "", encrypt = false) {
     return { password, confirmPassword, encrypt };
@@ -100,7 +92,7 @@ export const DiskEncryption = ({
           passwordLabel={_("Passphrase")}
           initialConfirmPassword={confirmPassword}
           confirmPasswordLabel={_("Confirm passphrase")}
-          rules={rules}
+          rules={[ruleLength, ruleAscii]}
           onChange={setPassword}
           onConfirmChange={setConfirmPassword}
           setIsValid={setIsFormValid}

--- a/ui/webui/src/components/storage/DiskEncryption.scss
+++ b/ui/webui/src/components/storage/DiskEncryption.scss
@@ -1,4 +1,4 @@
-// Span disk encryption password fields to take slightly more width than the default
+// Limit the width of input fields
 #disk-encryption-encrypt-devices ~ .pf-v5-c-check__body {
   width: min(60ch, 100%);
 }

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -51,6 +51,7 @@ export const accountsToDbusUsers = (accounts) => {
         gecos: cockpit.variant("s", accounts.fullName || ""),
         password: cockpit.variant("s", accounts.password || ""),
         "is-crypted": cockpit.variant("b", false),
+        groups: cockpit.variant("as", ["wheel"]),
     }];
 };
 

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -27,18 +27,9 @@ import {
 
 import "./Accounts.scss";
 
-import { PasswordFormFields } from "../Password.jsx";
+import { PasswordFormFields, ruleLength } from "../Password.jsx";
 
 const _ = cockpit.gettext;
-
-const rules = [
-    {
-        id: "length",
-        text: (policy) => cockpit.format(_("Must be at least $0 characters"), policy["min-length"].v),
-        check: (policy, password) => password.length >= policy["min-length"].v,
-        isWarning: false,
-    },
-];
 
 const CreateAccount = ({
     idPrefix,
@@ -63,7 +54,7 @@ const CreateAccount = ({
           passwordLabel={_("Passphrase")}
           initialConfirmPassword={confirmPassword}
           confirmPasswordLabel={_("Confirm passphrase")}
-          rules={rules}
+          rules={[ruleLength]}
           onChange={setPassword}
           onConfirmChange={setConfirmPassword}
           setIsValid={setIsPasswordValid}

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -36,15 +36,15 @@ const CreateAccount = ({
     passwordPolicy,
     setIsUserValid,
 }) => {
-    const [fullName, setFullName] = useState();
-    const [userAccount, setUserAccount] = useState();
+    const [fullName, setFullName] = useState("");
+    const [userAccount, setUserAccount] = useState("");
     const [password, setPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");
     const [isPasswordValid, setIsPasswordValid] = useState(false);
 
     useEffect(() => {
-        setIsUserValid(isPasswordValid);
-    }, [setIsUserValid, isPasswordValid]);
+        setIsUserValid(isPasswordValid && userAccount.length > 0);
+    }, [setIsUserValid, isPasswordValid, userAccount]);
 
     const passphraseForm = (
         <PasswordFormFields

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -45,6 +45,15 @@ export function getAccountsState (
     };
 }
 
+export const accountsToDbusUsers = (accounts) => {
+    return [{
+        name: cockpit.variant("s", accounts.userAccount || ""),
+        gecos: cockpit.variant("s", accounts.fullName || ""),
+        password: cockpit.variant("s", accounts.password || ""),
+        "is-crypted": cockpit.variant("b", false),
+    }];
+};
+
 const CreateAccount = ({
     idPrefix,
     passwordPolicy,

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with This program; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React, { useState, useEffect } from "react";
+
+import {
+    Form,
+    FormGroup,
+    TextInput,
+    Title,
+} from "@patternfly/react-core";
+
+import "./Accounts.scss";
+
+const _ = cockpit.gettext;
+
+const CreateAccount = ({
+    idPrefix,
+}) => {
+    const [fullName, setFullName] = useState();
+    const [userAccount, setUserAccount] = useState();
+    const [password, setPassword] = useState();
+    const [confirmPassword, setConfirmPassword] = useState();
+
+    return (
+        <Form
+          isHorizontal
+          id={idPrefix + "-create-account"}
+        >
+            <Title
+              headingLevel="h2"
+              id={idPrefix + "-create-account-title"}
+            >
+                {_("Create account")}
+            </Title>
+            {_("This account will have administration priviledge with sudo.")}
+            <FormGroup
+              label={_("Full name")}
+              fieldId={idPrefix + "-create-account-full-name"}
+            >
+                <TextInput
+                  id={idPrefix + "-create-account-full-name"}
+                  value={fullName}
+                  onChange={(_event, val) => setFullName(val)}
+                />
+            </FormGroup>
+            <FormGroup
+              label={_("User account")}
+              fieldId={idPrefix + "-create-account-user-account"}
+            >
+                <TextInput
+                  id={idPrefix + "-create-account-user-account"}
+                  value={userAccount}
+                  onChange={(_event, val) => setUserAccount(val)}
+                />
+            </FormGroup>
+            <FormGroup
+              label={_("Password")}
+              fieldId={idPrefix + "-create-account-password"}
+            >
+                <TextInput
+                  id={idPrefix + "-create-account-password"}
+                  value={password}
+                  onChange={(_event, val) => setPassword}
+                />
+            </FormGroup>
+            <FormGroup
+              label={_("Confirm password")}
+              fieldId={idPrefix + "-create-account-confirm-password"}
+            >
+                <TextInput
+                  id={idPrefix + "-create-account-confirm-password"}
+                  value={confirmPassword}
+                  onChange={(_event, val) => setConfirmPassword}
+                />
+            </FormGroup>
+        </Form>
+    );
+};
+
+export const Accounts = ({
+    idPrefix,
+    setIsFormValid,
+}) => {
+    useEffect(() => {
+        setIsFormValid(true);
+    }, [setIsFormValid]);
+
+    return (
+        <>
+            <CreateAccount
+              idPrefix={idPrefix}
+            />
+        </>
+    );
+};
+
+export const getPageProps = () => {
+    return ({
+        id: "accounts",
+        label: _("Create Account"),
+        title: null,
+    });
+};

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -27,15 +27,48 @@ import {
 
 import "./Accounts.scss";
 
+import { PasswordFormFields } from "../Password.jsx";
+
 const _ = cockpit.gettext;
+
+const rules = [
+    {
+        id: "length",
+        text: (policy) => cockpit.format(_("Must be at least $0 characters"), policy["min-length"].v),
+        check: (policy, password) => password.length >= policy["min-length"].v,
+        isWarning: false,
+    },
+];
 
 const CreateAccount = ({
     idPrefix,
+    passwordPolicy,
+    setIsUserValid,
 }) => {
     const [fullName, setFullName] = useState();
     const [userAccount, setUserAccount] = useState();
-    const [password, setPassword] = useState();
-    const [confirmPassword, setConfirmPassword] = useState();
+    const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const [isPasswordValid, setIsPasswordValid] = useState(false);
+
+    useEffect(() => {
+        setIsUserValid(isPasswordValid);
+    }, [setIsUserValid, isPasswordValid]);
+
+    const passphraseForm = (
+        <PasswordFormFields
+          idPrefix={idPrefix + "-create-account-password-form"}
+          policy={passwordPolicy}
+          initialPassword={password}
+          passwordLabel={_("Passphrase")}
+          initialConfirmPassword={confirmPassword}
+          confirmPasswordLabel={_("Confirm passphrase")}
+          rules={rules}
+          onChange={setPassword}
+          onConfirmChange={setConfirmPassword}
+          setIsValid={setIsPasswordValid}
+        />
+    );
 
     return (
         <Form
@@ -69,26 +102,7 @@ const CreateAccount = ({
                   onChange={(_event, val) => setUserAccount(val)}
                 />
             </FormGroup>
-            <FormGroup
-              label={_("Password")}
-              fieldId={idPrefix + "-create-account-password"}
-            >
-                <TextInput
-                  id={idPrefix + "-create-account-password"}
-                  value={password}
-                  onChange={(_event, val) => setPassword}
-                />
-            </FormGroup>
-            <FormGroup
-              label={_("Confirm password")}
-              fieldId={idPrefix + "-create-account-confirm-password"}
-            >
-                <TextInput
-                  id={idPrefix + "-create-account-confirm-password"}
-                  value={confirmPassword}
-                  onChange={(_event, val) => setConfirmPassword}
-                />
-            </FormGroup>
+            {passphraseForm}
         </Form>
     );
 };
@@ -96,15 +110,19 @@ const CreateAccount = ({
 export const Accounts = ({
     idPrefix,
     setIsFormValid,
+    passwordPolicies,
 }) => {
+    const [isUserValid, setIsUserValid] = useState();
     useEffect(() => {
-        setIsFormValid(true);
-    }, [setIsFormValid]);
+        setIsFormValid(isUserValid);
+    }, [setIsFormValid, isUserValid]);
 
     return (
         <>
             <CreateAccount
               idPrefix={idPrefix}
+              passwordPolicy={passwordPolicies.user}
+              setIsUserValid={setIsUserValid}
             />
         </>
     );

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -31,15 +31,31 @@ import { PasswordFormFields, ruleLength } from "../Password.jsx";
 
 const _ = cockpit.gettext;
 
+export function getAccountsState (
+    fullName = "",
+    userAccount = "",
+    password = "",
+    confirmPassword = "",
+) {
+    return {
+        fullName,
+        userAccount,
+        password,
+        confirmPassword,
+    };
+}
+
 const CreateAccount = ({
     idPrefix,
     passwordPolicy,
     setIsUserValid,
+    accounts,
+    setAccounts,
 }) => {
-    const [fullName, setFullName] = useState("");
-    const [userAccount, setUserAccount] = useState("");
-    const [password, setPassword] = useState("");
-    const [confirmPassword, setConfirmPassword] = useState("");
+    const [fullName, setFullName] = useState(accounts.fullName);
+    const [userAccount, setUserAccount] = useState(accounts.userAccount);
+    const [password, setPassword] = useState(accounts.password);
+    const [confirmPassword, setConfirmPassword] = useState(accounts.confirmPassword);
     const [isPasswordValid, setIsPasswordValid] = useState(false);
 
     useEffect(() => {
@@ -60,6 +76,10 @@ const CreateAccount = ({
           setIsValid={setIsPasswordValid}
         />
     );
+
+    useEffect(() => {
+        setAccounts(ac => ({ ...ac, fullName, userAccount, password, confirmPassword }));
+    }, [setAccounts, fullName, userAccount, password, confirmPassword]);
 
     return (
         <Form
@@ -102,6 +122,8 @@ export const Accounts = ({
     idPrefix,
     setIsFormValid,
     passwordPolicies,
+    accounts,
+    setAccounts,
 }) => {
     const [isUserValid, setIsUserValid] = useState();
     useEffect(() => {
@@ -114,6 +136,8 @@ export const Accounts = ({
               idPrefix={idPrefix}
               passwordPolicy={passwordPolicies.user}
               setIsUserValid={setIsUserValid}
+              accounts={accounts}
+              setAccounts={setAccounts}
             />
         </>
     );

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -153,10 +153,11 @@ export const Accounts = ({
     );
 };
 
-export const getPageProps = () => {
+export const getPageProps = ({ isBootIso }) => {
     return ({
         id: "accounts",
         label: _("Create Account"),
+        isHidden: !isBootIso,
         title: null,
     });
 };

--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -74,7 +74,7 @@ const CreateAccount = ({
 
     const passphraseForm = (
         <PasswordFormFields
-          idPrefix={idPrefix + "-create-account-password-form"}
+          idPrefix={idPrefix}
           policy={passwordPolicy}
           initialPassword={password}
           passwordLabel={_("Passphrase")}
@@ -94,31 +94,31 @@ const CreateAccount = ({
     return (
         <Form
           isHorizontal
-          id={idPrefix + "-create-account"}
+          id={idPrefix}
         >
             <Title
               headingLevel="h2"
-              id={idPrefix + "-create-account-title"}
+              id={idPrefix + "-title"}
             >
                 {_("Create account")}
             </Title>
             {_("This account will have administration priviledge with sudo.")}
             <FormGroup
               label={_("Full name")}
-              fieldId={idPrefix + "-create-account-full-name"}
+              fieldId={idPrefix + "-full-name"}
             >
                 <TextInput
-                  id={idPrefix + "-create-account-full-name"}
+                  id={idPrefix + "-full-name"}
                   value={fullName}
                   onChange={(_event, val) => setFullName(val)}
                 />
             </FormGroup>
             <FormGroup
               label={_("User account")}
-              fieldId={idPrefix + "-create-account-user-account"}
+              fieldId={idPrefix + "-user-account"}
             >
                 <TextInput
-                  id={idPrefix + "-create-account-user-account"}
+                  id={idPrefix + "-user-account"}
                   value={userAccount}
                   onChange={(_event, val) => setUserAccount(val)}
                 />
@@ -143,7 +143,7 @@ export const Accounts = ({
     return (
         <>
             <CreateAccount
-              idPrefix={idPrefix}
+              idPrefix={idPrefix + "-create-account"}
               passwordPolicy={passwordPolicies.user}
               setIsUserValid={setIsUserValid}
               accounts={accounts}

--- a/ui/webui/src/components/users/Accounts.scss
+++ b/ui/webui/src/components/users/Accounts.scss
@@ -1,4 +1,10 @@
-// Span disk encryption password fields to take slightly more width than the default
+// Limit the width of input fields
 #accounts-create-account {
   width: min(60ch, 100%);
+}
+
+// FIXME: Undo when fixed upstream: https://github.com/patternfly/patternfly/issues/6032
+#accounts-create-account .pf-v5-c-form__group-label.pf-m-info {
+  flex-direction: column;
+  align-items: flex-start;
 }

--- a/ui/webui/src/components/users/Accounts.scss
+++ b/ui/webui/src/components/users/Accounts.scss
@@ -1,0 +1,4 @@
+// Span disk encryption password fields to take slightly more width than the default
+#accounts-create-account {
+  width: min(60ch, 100%);
+}

--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -65,6 +65,7 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
 
         # Test going back
         steps = [
+            i.steps.ACCOUNTS,
             i.steps.DISK_CONFIGURATION,
             i.steps.DISK_ENCRYPTION,
             i.steps.DISK_CONFIGURATION,

--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -21,6 +21,7 @@ from installer import Installer
 from language import Language
 from review import Review
 from storage import Storage
+from users import create_user
 from testlib import nondestructive, test_main, wait, Error  # pylint: disable=import-error
 from utils import pretend_live_iso, get_pretty_name
 
@@ -44,7 +45,8 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         # Do not start the installation in non-destructive tests as this performs non revertible changes
         # with the pages basically empty of common elements (as those are provided by the top-level installer widget)
         # we at least iterate over them to check this works as expected
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # Ensure that the 'actual' UI process is running/
         self.assertIn("/usr/libexec/webui-desktop", m.execute("ps aux"))
@@ -61,7 +63,8 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         # Test that clicking on current step does not break navigation
         i.click_step_on_sidebar()
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # Test going back
         steps = [

--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -21,7 +21,7 @@ from installer import Installer
 from language import Language
 from review import Review
 from storage import Storage
-from users import create_user
+from users import dbus_reset_users
 from testlib import nondestructive, test_main, wait, Error  # pylint: disable=import-error
 from utils import pretend_live_iso, get_pretty_name
 
@@ -45,8 +45,8 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         # Do not start the installation in non-destructive tests as this performs non revertible changes
         # with the pages basically empty of common elements (as those are provided by the top-level installer widget)
         # we at least iterate over them to check this works as expected
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # Ensure that the 'actual' UI process is running/
         self.assertIn("/usr/libexec/webui-desktop", m.execute("ps aux"))
@@ -63,8 +63,8 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         # Test that clicking on current step does not break navigation
         i.click_step_on_sidebar()
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # Test going back
         steps = [

--- a/ui/webui/test/check-basic
+++ b/ui/webui/test/check-basic
@@ -93,7 +93,7 @@ class TestBasic(anacondalib.VirtInstallMachineCase):
         b.wait_visible(f"#installation-back-btn:not([aria-disabled={True}]")
 
         # For live media in the review screen language details should still be displayed
-        i.reach(i.steps.REVIEW)
+        i.reach(i.steps.REVIEW, hidden_steps=[i.steps.ACCOUNTS])
         r.check_language("English (United States)")
 
     def testAboutModal(self):

--- a/ui/webui/test/check-progress
+++ b/ui/webui/test/check-progress
@@ -20,7 +20,6 @@ import anacondalib
 from installer import Installer
 from progress import Progress
 from storage import Storage
-from users import create_user
 from utils import add_public_key, get_pretty_name
 from testlib import test_main  # pylint: disable=import-error
 
@@ -41,8 +40,7 @@ class TestInstallationProgress(anacondalib.VirtInstallMachineCase):
 
         i.open()
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self, cleanup=False)})
+        i.reach(i.steps.REVIEW)
         i.begin_installation()
 
         # the warning can take longer to show up than the regular wait_in_text() timeout

--- a/ui/webui/test/check-progress
+++ b/ui/webui/test/check-progress
@@ -20,6 +20,7 @@ import anacondalib
 from installer import Installer
 from progress import Progress
 from storage import Storage
+from users import create_user
 from utils import add_public_key, get_pretty_name
 from testlib import test_main  # pylint: disable=import-error
 
@@ -40,7 +41,8 @@ class TestInstallationProgress(anacondalib.VirtInstallMachineCase):
 
         i.open()
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self, cleanup=False)})
         i.begin_installation()
 
         # the warning can take longer to show up than the regular wait_in_text() timeout

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -22,6 +22,7 @@ from storage import Storage  # pylint: disable=import-error
 from review import Review
 from language import Language
 from progress import Progress
+from users import create_user
 from utils import add_public_key
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
@@ -40,7 +41,9 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         # After clicking 'Next' on the storage step, partitioning is done, thus changing the available space on the disk
         # Since this is a non-destructive test we need to make sure the we reset partitioning to how it was before the test started
         self.addCleanup(s.dbus_reset_partitioning)
-        i.reach(i.steps.REVIEW)
+
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # check language is shown
         r.check_language("English (United States)")
@@ -71,7 +74,8 @@ class TestReview(anacondalib.VirtInstallMachineCase):
 
         i.open()
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
         i.begin_installation(should_fail=True, confirm_erase=False)
 
     def testUnknownLanguage(self):
@@ -85,7 +89,8 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         # Set language to Macedonian that is now in the installer translated languages
         # Go to review page after it
         l.dbus_set_language("mk_MK.UTF-8")
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # test the macedonian language selected
         r.check_language("mk_MK.UTF-8")

--- a/ui/webui/test/check-review
+++ b/ui/webui/test/check-review
@@ -22,7 +22,7 @@ from storage import Storage  # pylint: disable=import-error
 from review import Review
 from language import Language
 from progress import Progress
-from users import create_user
+from users import dbus_reset_users
 from utils import add_public_key
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
@@ -42,8 +42,8 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         # Since this is a non-destructive test we need to make sure the we reset partitioning to how it was before the test started
         self.addCleanup(s.dbus_reset_partitioning)
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # check language is shown
         r.check_language("English (United States)")
@@ -74,8 +74,8 @@ class TestReview(anacondalib.VirtInstallMachineCase):
 
         i.open()
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
         i.begin_installation(should_fail=True, confirm_erase=False)
 
     def testUnknownLanguage(self):
@@ -89,8 +89,8 @@ class TestReview(anacondalib.VirtInstallMachineCase):
         # Set language to Macedonian that is now in the installer translated languages
         # Go to review page after it
         l.dbus_set_language("mk_MK.UTF-8")
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # test the macedonian language selected
         r.check_language("mk_MK.UTF-8")

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -30,13 +30,10 @@ from utils import pretend_live_iso
 @nondestructive
 class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
     efi = False
-    encryption_id_prefix = "disk-encryption"
 
-    def set_valid_password(self, password="abcdefgh"):
-        p = Password(self.browser, self.encryption_id_prefix)
-
-        p.set_password(password)
-        p.set_password_confirm(password)
+    def set_valid_password(self, password_ui, password="abcdefgh"):
+        password_ui.set_password(password)
+        password_ui.set_password_confirm(password)
 
     def testLocalStandardDisks(self):
         b = self.browser
@@ -136,7 +133,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b = self.browser
         i = Installer(b, self.machine)
         s = Storage(b, self.machine)
-        p = Password(b, self.encryption_id_prefix)
+        p = Password(b, s.encryption_id_prefix)
 
         i.open()
         # Language selection
@@ -221,7 +218,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b = self.browser
         i = Installer(b, self.machine)
         s = Storage(b, self.machine)
-        p = Password(b, self.encryption_id_prefix)
+        p = Password(b, s.encryption_id_prefix)
 
         i.open()
         # Language selection
@@ -248,7 +245,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         s.check_encryption_selected(encrypt)
 
         # Set valid password
-        self.set_valid_password()
+        self.set_valid_password(p)
 
         # Verify that the password is saved when moving forward and back
         i.next()

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -165,7 +165,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         )
 
         # No password set
-        s.check_pw_rule("min-chars", "indeterminate")
+        s.check_pw_rule("length", "indeterminate")
         s.check_pw_rule("match", "indeterminate")
         i.check_next_disabled()
 
@@ -173,21 +173,21 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         s.set_password("abcd")
         s.check_pw_strength(None)
         i.check_next_disabled()
-        s.check_pw_rule("min-chars", "error")
+        s.check_pw_rule("length", "error")
         s.check_pw_rule("match", "error")
 
         # Make the pw 8 chars long
         s.set_password("efgh", append=True, value_check=False)
         i.check_next_disabled()
         s.check_password("abcdefgh")
-        s.check_pw_rule("min-chars", "success")
+        s.check_pw_rule("length", "success")
         s.check_pw_rule("match", "error")
         s.check_pw_strength("weak")
 
         # Non-ASCII password
         s.set_password(8 * "š")
         s.check_password(8 * "š")
-        s.check_pw_rule("min-chars", "success")
+        s.check_pw_rule("length", "success")
         s.check_pw_rule("match", "error")
         s.check_pw_rule("ascii", "warning")
         s.check_pw_strength("weak")
@@ -201,7 +201,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         s.check_pw_rule("match", "error")
         s.set_password_confirm("abcdefgh")
         s.check_pw_rule("match", "success")
-        s.check_pw_rule("min-chars", "success")
+        s.check_pw_rule("length", "success")
         s.check_pw_strength("weak")
         s.check_password("abcdefgh")
         s.check_password_confirm("abcdefgh")

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -20,6 +20,7 @@ import anacondalib
 from installer import Installer
 from storage import Storage
 from review import Review
+from password import Password
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 from storagelib import StorageHelpers  # pylint: disable=import-error
 from utils import pretend_live_iso
@@ -28,12 +29,13 @@ from utils import pretend_live_iso
 @nondestructive
 class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
     efi = False
+    encryption_id_prefix = "disk-encryption"
 
     def set_valid_password(self, password="abcdefgh"):
-        s = Storage(self.browser, self.machine)
+        p = Password(self.browser, self.encryption_id_prefix)
 
-        s.set_password(password)
-        s.set_password_confirm(password)
+        p.set_password(password)
+        p.set_password_confirm(password)
 
     def testLocalStandardDisks(self):
         b = self.browser
@@ -133,6 +135,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b = self.browser
         i = Installer(b, self.machine)
         s = Storage(b, self.machine)
+        p = Password(b, self.encryption_id_prefix)
 
         i.open()
         # Language selection
@@ -165,51 +168,51 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         )
 
         # No password set
-        s.check_pw_rule("length", "indeterminate")
-        s.check_pw_rule("match", "indeterminate")
+        p.check_pw_rule("length", "indeterminate")
+        p.check_pw_rule("match", "indeterminate")
         i.check_next_disabled()
 
         # Set pw which is too short
-        s.set_password("abcd")
-        s.check_pw_strength(None)
+        p.set_password("abcd")
+        p.check_pw_strength(None)
         i.check_next_disabled()
-        s.check_pw_rule("length", "error")
-        s.check_pw_rule("match", "error")
+        p.check_pw_rule("length", "error")
+        p.check_pw_rule("match", "error")
 
         # Make the pw 8 chars long
-        s.set_password("efgh", append=True, value_check=False)
+        p.set_password("efgh", append=True, value_check=False)
         i.check_next_disabled()
-        s.check_password("abcdefgh")
-        s.check_pw_rule("length", "success")
-        s.check_pw_rule("match", "error")
-        s.check_pw_strength("weak")
+        p.check_password("abcdefgh")
+        p.check_pw_rule("length", "success")
+        p.check_pw_rule("match", "error")
+        p.check_pw_strength("weak")
 
         # Non-ASCII password
-        s.set_password(8 * "š")
-        s.check_password(8 * "š")
-        s.check_pw_rule("length", "success")
-        s.check_pw_rule("match", "error")
-        s.check_pw_rule("ascii", "warning")
-        s.check_pw_strength("weak")
+        p.set_password(8 * "š")
+        p.check_password(8 * "š")
+        p.check_pw_rule("length", "success")
+        p.check_pw_rule("match", "error")
+        p.check_pw_rule("ascii", "warning")
+        p.check_pw_strength("weak")
 
         # Valid ASCII password
-        s.set_password("abcdefgh")
-        s.check_password("abcdefgh")
+        p.set_password("abcdefgh")
+        p.check_password("abcdefgh")
 
         # Set the password confirm
-        s.set_password_confirm("abcdefg")
-        s.check_pw_rule("match", "error")
-        s.set_password_confirm("abcdefgh")
-        s.check_pw_rule("match", "success")
-        s.check_pw_rule("length", "success")
-        s.check_pw_strength("weak")
-        s.check_password("abcdefgh")
-        s.check_password_confirm("abcdefgh")
+        p.set_password_confirm("abcdefg")
+        p.check_pw_rule("match", "error")
+        p.set_password_confirm("abcdefgh")
+        p.check_pw_rule("match", "success")
+        p.check_pw_rule("length", "success")
+        p.check_pw_strength("weak")
+        p.check_password("abcdefgh")
+        p.check_password_confirm("abcdefgh")
         i.check_next_disabled(disabled=False)
 
         # Check setting strong password
-        s.set_password("Rwce82ybF7dXtCzFumanchu!!!!!!!!")
-        s.check_pw_strength("strong")
+        p.set_password("Rwce82ybF7dXtCzFumanchu!!!!!!!!")
+        p.check_pw_strength("strong")
 
     # Test moving back after partitioning is applied,
     # the partitioning should be reset.
@@ -217,6 +220,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         b = self.browser
         i = Installer(b, self.machine)
         s = Storage(b, self.machine)
+        p = Password(b, self.encryption_id_prefix)
 
         i.open()
         # Language selection
@@ -248,8 +252,8 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         # Verify that the password is saved when moving forward and back
         i.next()
         i.back()
-        s.check_password("abcdefgh")
-        s.check_password_confirm("abcdefgh")
+        p.check_password("abcdefgh")
+        p.check_password_confirm("abcdefgh")
 
         i.back()
         # Storage Configuration

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -19,9 +19,9 @@ import anacondalib
 
 from installer import Installer
 from storage import Storage
+from users import dbus_reset_users
 from review import Review
 from password import Password
-from users import create_user
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 from storagelib import StorageHelpers  # pylint: disable=import-error
 from utils import pretend_live_iso
@@ -282,8 +282,8 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
 
         # Go to Review step
         i.open()
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # Read partitioning data after we went to Review step
         new_applied_partitioning = s.dbus_get_applied_partitioning()
@@ -417,8 +417,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
             "mount-point-mapping-table",
         )
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
 
         # verify review screen
@@ -544,8 +544,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s.select_mountpoint_row_mountpoint(3, "/home")
         s.check_mountpoint_row(3, "/home", f"{dev2}1", False, "xfs")
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # verify review screen
         disk = "vda"
@@ -631,8 +631,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         b.wait_in_text(f"{selector} .pf-v5-c-select__toggle-text", "luks")
         s.check_mountpoint_row_format_type(2, "xfs")
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         r.check_in_disk_row(dev1, 2, "luks-")
 
@@ -678,8 +678,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s.select_mountpoint_row_device(2, "encryptedraid")
         s.check_mountpoint_row_format_type(2, "xfs")
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         r.check_disk(dev, "16.1 GB vda (0x1af4)")
 
@@ -731,8 +731,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         b.wait_in_text(f"{selector} .pf-v5-c-select__toggle-text", "luks")
         s.check_mountpoint_row_format_type(2, "xfs")
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         r.check_disk(dev, "16.1 GB vda (0x1af4)")
 
@@ -792,8 +792,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s.select_mountpoint_row_reformat(1)
         s.check_mountpoint_row_reformat(1, True)
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (0x1af4)")
@@ -955,8 +955,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s.select_mountpoint_row_reformat(1)
         s.check_mountpoint_row_reformat(1, True)
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # verify review screen
         disk = "vda"
@@ -1045,8 +1045,8 @@ class TestStorageMountPointsEFI(anacondalib.VirtInstallMachineCase):
         s.select_mountpoint_row_device(3, f"{dev}3")
         s.check_mountpoint_row_format_type(3, "xfs")
 
-        # Create user on the first pass through users step
-        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+        i.reach(i.steps.REVIEW)
 
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (0x1af4)")

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -21,6 +21,7 @@ from installer import Installer
 from storage import Storage
 from review import Review
 from password import Password
+from users import create_user
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 from storagelib import StorageHelpers  # pylint: disable=import-error
 from utils import pretend_live_iso
@@ -281,7 +282,8 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
 
         # Go to Review step
         i.open()
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # Read partitioning data after we went to Review step
         new_applied_partitioning = s.dbus_get_applied_partitioning()
@@ -415,7 +417,9 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
             "mount-point-mapping-table",
         )
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
+
 
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (0x1af4)")
@@ -540,7 +544,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s.select_mountpoint_row_mountpoint(3, "/home")
         s.check_mountpoint_row(3, "/home", f"{dev2}1", False, "xfs")
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # verify review screen
         disk = "vda"
@@ -626,7 +631,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         b.wait_in_text(f"{selector} .pf-v5-c-select__toggle-text", "luks")
         s.check_mountpoint_row_format_type(2, "xfs")
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         r.check_in_disk_row(dev1, 2, "luks-")
 
@@ -672,7 +678,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s.select_mountpoint_row_device(2, "encryptedraid")
         s.check_mountpoint_row_format_type(2, "xfs")
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         r.check_disk(dev, "16.1 GB vda (0x1af4)")
 
@@ -724,7 +731,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         b.wait_in_text(f"{selector} .pf-v5-c-select__toggle-text", "luks")
         s.check_mountpoint_row_format_type(2, "xfs")
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         r.check_disk(dev, "16.1 GB vda (0x1af4)")
 
@@ -784,7 +792,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s.select_mountpoint_row_reformat(1)
         s.check_mountpoint_row_reformat(1, True)
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (0x1af4)")
@@ -946,7 +955,8 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s.select_mountpoint_row_reformat(1)
         s.check_mountpoint_row_reformat(1, True)
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # verify review screen
         disk = "vda"
@@ -1035,7 +1045,8 @@ class TestStorageMountPointsEFI(anacondalib.VirtInstallMachineCase):
         s.select_mountpoint_row_device(3, f"{dev}3")
         s.check_mountpoint_row_format_type(3, "xfs")
 
-        i.reach(i.steps.REVIEW)
+        # Create user on the first pass through users step
+        i.reach(i.steps.REVIEW, step_callbacks={i.steps.ACCOUNTS: lambda: create_user(self)})
 
         # verify review screen
         r.check_disk(dev, "16.1 GB vda (0x1af4)")

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -307,7 +307,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         self.assertEqual(len(created_partitioning) + 11, len(new_created_partitioning))
         self.assertEqual(new_applied_partitioning, new_created_partitioning[-1])
 
-        # The applied partitioning should be reset when going back at any step from review page
+        # The applied partitioning should be reset also when going back to installation method
         i.click_step_on_sidebar(i.steps.INSTALLATION_METHOD)
         new_applied_partitioning = s.dbus_get_applied_partitioning()
         self.assertEqual(new_applied_partitioning, "")

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -295,9 +295,10 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         for _ in range(10):
             s.dbus_create_partitioning("AUTOMATIC")
 
-        # Go back to the previous page and re-enter the review screen.
+        # Go back to the Disk Configuration page and re-enter the review screen.
         # This should create again a new partitioning object and apply it
         # no matter how many partitioning objects were created before
+        i.back()
         i.back()
         i.reach(i.steps.REVIEW)
         new_applied_partitioning = s.dbus_get_applied_partitioning()
@@ -422,6 +423,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         applied_partitioning = s.dbus_get_applied_partitioning()
 
         # When adding a new partition a new partitioning should be created
+        i.back()
         i.back(previous_page=i.steps.CUSTOM_MOUNT_POINT)
         i.back()
 
@@ -788,6 +790,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         r.check_disk_row(dev, 3, "home, 15.0 GB: mount, /home")
         r.check_disk_row_not_present(dev, f"unused")
 
+        i.back()
         i.back(previous_page=i.steps.CUSTOM_MOUNT_POINT)
         i.back()
 
@@ -950,6 +953,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         r.check_disk_row(disk, 3, f"{vgname}-home, 8.12 GB: mount, /home")
         r.check_disk_row(disk, 4, f"{vgname}-swap, 902 MB: mount, swap")
 
+        i.back()
         i.back(previous_page=i.steps.CUSTOM_MOUNT_POINT)
 
         # remove the /home row and check that row 3 is now swap

--- a/ui/webui/test/check-users
+++ b/ui/webui/test/check-users
@@ -18,8 +18,7 @@
 import anacondalib
 
 from installer import Installer
-from password import Password
-from users import Users, CREATE_ACCOUNT_ID_PREFIX
+from users import Users, CREATE_ACCOUNT_ID_PREFIX, create_user
 from testlib import nondestructive, test_main  # pylint: disable=import-error
 
 @nondestructive
@@ -30,25 +29,17 @@ class TestUsers(anacondalib.VirtInstallMachineCase):
     def testBasic(self):
         b = self.browser
         i = Installer(b, self.machine)
-        p = Password(b, CREATE_ACCOUNT_ID_PREFIX)
         u = Users(b, self.machine)
 
         i.open()
 
         i.reach(i.steps.ACCOUNTS)
-
-        password = "password"
-        p.set_password(password)
-        p.set_password_confirm(password)
-        u.set_user_account("tester")
-
+        create_user(self)
         b.assert_pixels(
             "#app",
             "users-step-basic",
             ignore=["#betanag-icon"],
         )
-
-        self.addCleanup(u.dbus_clear_users)
         i.reach(i.steps.REVIEW)
 
         users = u.dbus_get_users()

--- a/ui/webui/test/check-users
+++ b/ui/webui/test/check-users
@@ -1,0 +1,60 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+import anacondalib
+
+from installer import Installer
+from password import Password
+from users import Users, CREATE_ACCOUNT_ID_PREFIX
+from testlib import nondestructive, test_main  # pylint: disable=import-error
+
+@nondestructive
+class TestUsers(anacondalib.VirtInstallMachineCase):
+    def setUp(self):
+        super().setUp()
+
+    def testBasic(self):
+        b = self.browser
+        i = Installer(b, self.machine)
+        p = Password(b, CREATE_ACCOUNT_ID_PREFIX)
+        u = Users(b, self.machine)
+
+        i.open()
+
+        i.reach(i.steps.ACCOUNTS)
+
+        password = "password"
+        p.set_password(password)
+        p.set_password_confirm(password)
+        u.set_user_account("tester")
+
+        b.assert_pixels(
+            "#app",
+            "users-step-basic",
+            ignore=["#betanag-icon"],
+        )
+
+        self.addCleanup(u.dbus_clear_users)
+        i.reach(i.steps.REVIEW)
+
+        users = u.dbus_get_users()
+        self.assertIn('"groups" as 1 "wheel"', users)
+        self.assertIn('"is-crypted" b false', users)
+        self.assertIn('"password" s "password"', users)
+
+if __name__ == '__main__':
+    test_main()

--- a/ui/webui/test/check-users
+++ b/ui/webui/test/check-users
@@ -34,7 +34,7 @@ class TestUsers(anacondalib.VirtInstallMachineCase):
         i.open()
 
         i.reach(i.steps.ACCOUNTS)
-        create_user(self)
+        create_user(b, self.machine)
         b.assert_pixels(
             "#app",
             "users-step-basic",

--- a/ui/webui/test/end2end/storage_encryption.py
+++ b/ui/webui/test/end2end/storage_encryption.py
@@ -38,11 +38,11 @@ class StorageEncryption(End2EndTest):
         self._storage.set_encryption_selected(True)
         self._storage.check_encryption_selected(True)
 
-        self._storage.set_password(self.luks_pass)
-        self._storage.check_password(self.luks_pass)
-        self._storage.set_password_confirm(self.luks_pass)
-        self._storage.check_password_confirm(self.luks_pass)
-        self._storage.check_pw_strength('weak')
+        self._storage_password.set_password(self.luks_pass)
+        self._storage_password.check_password(self.luks_pass)
+        self._storage_password.set_password_confirm(self.luks_pass)
+        self._storage_password.check_password_confirm(self.luks_pass)
+        self._storage_password.check_pw_strength('weak')
 
     @log_step()
     def post_install_step(self):

--- a/ui/webui/test/end2end/wizard_navigation.py
+++ b/ui/webui/test/end2end/wizard_navigation.py
@@ -45,6 +45,8 @@ class WizardNavigation(End2EndTest):
         self._installer.next()
         self.configure_storage_encryption()
         self._installer.next()
+        self.check_users_screen()
+        self._installer.next()
         # Finish installation
         self.check_review_screen()
         self._installer.begin_installation()

--- a/ui/webui/test/helpers/end2end.py
+++ b/ui/webui/test/helpers/end2end.py
@@ -30,6 +30,8 @@ from language import Language
 from storage import Storage
 from review import Review
 from progress import Progress
+from password import Password
+from users import create_user
 from utils import add_public_key
 from testlib import MachineCase  # pylint: disable=import-error
 from machine_install import VirtInstallMachine
@@ -44,6 +46,7 @@ class End2EndTest(MachineCase):
         self._installer = Installer(self.browser, self.machine)
         self._language = Language(self.browser, self.machine)
         self._storage = Storage(self.browser, self.machine)
+        self._storage_password = Password(self.browser, self._storage.encryption_id_prefix)
         self._review = Review(self.browser)
         self._progress = Progress(self.browser)
         self.__installation_finished = False
@@ -75,6 +78,9 @@ class End2EndTest(MachineCase):
     def check_review_screen(self):
         pass
 
+    def check_users_screen(self):
+        create_user(self.browser, self.machine)
+
     def monitor_progress(self):
         self._progress.wait_done()
 
@@ -100,6 +106,8 @@ class End2EndTest(MachineCase):
         self.configure_storage_disks()
         self._installer.next()
         self.configure_storage_encryption()
+        self._installer.next()
+        self.check_users_screen()
         self._installer.next()
         self.check_review_screen()
         self._installer.begin_installation()

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -18,6 +18,8 @@ from collections import UserDict
 from time import sleep
 from step_logger import log_step
 
+from users import create_user
+
 
 class InstallerSteps(UserDict):
     WELCOME = "installation-language"
@@ -37,6 +39,9 @@ class InstallerSteps(UserDict):
     _steps_jump[ACCOUNTS] = REVIEW
     _steps_jump[REVIEW] = PROGRESS
     _steps_jump[PROGRESS] = []
+
+    _steps_callbacks = {}
+    _steps_callbacks[ACCOUNTS] = create_user
 
 class Installer():
     def __init__(self, browser, machine):
@@ -60,7 +65,7 @@ class Installer():
         else:
             self.wait_current_page(self.steps._steps_jump[current_page])
 
-    def reach(self, target_page, hidden_steps=None, step_callbacks={}):
+    def reach(self, target_page, hidden_steps=None):
         hidden_steps = hidden_steps or []
         path = []
         prev_pages = [target_page]
@@ -75,8 +80,8 @@ class Installer():
             next_page = path.pop()
             if next_page not in hidden_steps:
                 self.next(next_page=next_page)
-                if next_page in step_callbacks:
-                    step_callbacks[next_page]()
+                if next_page in self.steps._steps_callbacks:
+                    self.steps._steps_callbacks[next_page](self.browser, self.machine)
 
     @log_step()
     def next(self, should_fail=False, next_page=""):

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -60,7 +60,7 @@ class Installer():
         else:
             self.wait_current_page(self.steps._steps_jump[current_page])
 
-    def reach(self, target_page, hidden_steps=None):
+    def reach(self, target_page, hidden_steps=None, step_callbacks={}):
         hidden_steps = hidden_steps or []
         path = []
         prev_pages = [target_page]
@@ -75,6 +75,8 @@ class Installer():
             next_page = path.pop()
             if next_page not in hidden_steps:
                 self.next(next_page=next_page)
+                if next_page in step_callbacks:
+                    step_callbacks[next_page]()
 
     @log_step()
     def next(self, should_fail=False, next_page=""):

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -60,7 +60,8 @@ class Installer():
         else:
             self.wait_current_page(self.steps._steps_jump[current_page])
 
-    def reach(self, target_page):
+    def reach(self, target_page, hidden_steps=None):
+        hidden_steps = hidden_steps or []
         path = []
         prev_pages = [target_page]
         current_page = self.get_current_page()
@@ -72,7 +73,8 @@ class Installer():
 
         while self.get_current_page() != target_page:
             next_page = path.pop()
-            self.next(next_page=next_page)
+            if next_page not in hidden_steps:
+                self.next(next_page=next_page)
 
     @log_step()
     def next(self, should_fail=False, next_page=""):

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -25,14 +25,16 @@ class InstallerSteps(UserDict):
     CUSTOM_MOUNT_POINT = "mount-point-mapping"
     DISK_CONFIGURATION = "disk-configuration"
     DISK_ENCRYPTION = "disk-encryption"
+    ACCOUNTS = "accounts"
     REVIEW = "installation-review"
     PROGRESS = "installation-progress"
 
     _steps_jump = {}
     _steps_jump[WELCOME] = INSTALLATION_METHOD
     _steps_jump[INSTALLATION_METHOD] = [DISK_ENCRYPTION, CUSTOM_MOUNT_POINT]
-    _steps_jump[DISK_ENCRYPTION] = REVIEW
-    _steps_jump[CUSTOM_MOUNT_POINT] = REVIEW
+    _steps_jump[DISK_ENCRYPTION] = ACCOUNTS
+    _steps_jump[CUSTOM_MOUNT_POINT] = ACCOUNTS
+    _steps_jump[ACCOUNTS] = REVIEW
     _steps_jump[REVIEW] = PROGRESS
     _steps_jump[PROGRESS] = []
 

--- a/ui/webui/test/helpers/password.py
+++ b/ui/webui/test/helpers/password.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+HELPERS_DIR = os.path.dirname(__file__)
+sys.path.append(HELPERS_DIR)
+
+from step_logger import log_step
+
+class Password():
+    def __init__(self, browser, id_prefix):
+        self.browser = browser
+        self.id_prefix = id_prefix
+
+    @log_step(snapshot_before=True)
+    def check_pw_rule(self, rule, value):
+        sel = f"#{self.id_prefix}-password-rule-" + rule
+        cls_value = "pf-m-" + value
+        self.browser.wait_visible(sel)
+        self.browser.wait_attr_contains(sel, "class", cls_value)
+
+    @log_step(snapshot_before=True)
+    def set_password(self, password, append=False, value_check=True):
+        sel = f"#{self.id_prefix}-password-field"
+        self.browser.set_input_text(sel, password, append=append, value_check=value_check)
+
+    @log_step(snapshot_before=True)
+    def check_password(self, password):
+        sel = f"#{self.id_prefix}-password-field"
+        self.browser.wait_val(sel, password)
+
+    @log_step(snapshot_before=True)
+    def set_password_confirm(self, password):
+        sel = f"#{self.id_prefix}-password-confirm-field"
+        self.browser.set_input_text(sel, password)
+
+    @log_step(snapshot_before=True)
+    def check_password_confirm(self, password):
+        sel = f"#{self.id_prefix}-password-confirm-field"
+        self.browser.wait_val(sel, password)
+
+    @log_step(snapshot_before=True)
+    def check_pw_strength(self, strength):
+        sel = f"#{self.id_prefix}-password-strength-label"
+
+        if strength is None:
+            self.browser.wait_not_present(sel)
+            return
+
+        variant = ""
+        if strength == "weak":
+            variant = "error"
+        elif strength == "medium":
+            variant = "warning"
+        elif strength == "strong":
+            variant = "success"
+
+        self.browser.wait_attr_contains(sel, "class", "pf-m-" + variant)

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -117,13 +117,15 @@ class StorageDestination():
 
 
 class StorageEncryption():
+    encryption_id_prefix = "disk-encryption"
+
     def __init__(self, browser, machine):
         self.browser = browser
         self.machine = machine
 
     @log_step(snapshot_before=True)
     def check_encryption_selected(self, selected):
-        sel = "#disk-encryption-encrypt-devices"
+        sel = f"#{self.encryption_id_prefix}-encrypt-devices"
         if selected:
             self.browser.wait_visible(sel + ':checked')
         else:
@@ -131,7 +133,7 @@ class StorageEncryption():
 
     @log_step(snapshot_before=True)
     def set_encryption_selected(self, selected):
-        sel = "#disk-encryption-encrypt-devices"
+        sel = f"#{self.encryption_id_prefix}-encrypt-devices"
         self.browser.set_checked(sel, selected)
 
 

--- a/ui/webui/test/helpers/storage.py
+++ b/ui/webui/test/helpers/storage.py
@@ -134,51 +134,6 @@ class StorageEncryption():
         sel = "#disk-encryption-encrypt-devices"
         self.browser.set_checked(sel, selected)
 
-    @log_step(snapshot_before=True)
-    def check_pw_rule(self, rule, value):
-        sel = "#disk-encryption-password-rule-" + rule
-        cls_value = "pf-m-" + value
-        self.browser.wait_visible(sel)
-        self.browser.wait_attr_contains(sel, "class", cls_value)
-
-    @log_step(snapshot_before=True)
-    def set_password(self, password, append=False, value_check=True):
-        sel = "#disk-encryption-password-field"
-        self.browser.set_input_text(sel, password, append=append, value_check=value_check)
-
-    @log_step(snapshot_before=True)
-    def check_password(self, password):
-        sel = "#disk-encryption-password-field"
-        self.browser.wait_val(sel, password)
-
-    @log_step(snapshot_before=True)
-    def set_password_confirm(self, password):
-        sel = "#disk-encryption-password-confirm-field"
-        self.browser.set_input_text(sel, password)
-
-    @log_step(snapshot_before=True)
-    def check_password_confirm(self, password):
-        sel = "#disk-encryption-password-confirm-field"
-        self.browser.wait_val(sel, password)
-
-    @log_step(snapshot_before=True)
-    def check_pw_strength(self, strength):
-        sel = "#disk-encryption-password-strength-label"
-
-        if strength is None:
-            self.browser.wait_not_present(sel)
-            return
-
-        variant = ""
-        if strength == "weak":
-            variant = "error"
-        elif strength == "medium":
-            variant = "warning"
-        elif strength == "strong":
-            variant = "success"
-
-        self.browser.wait_attr_contains(sel, "class", "pf-m-" + variant)
-
 
 class StorageUtils(StorageDestination):
     def __init__(self, browser, machine):

--- a/ui/webui/test/helpers/users.py
+++ b/ui/webui/test/helpers/users.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import sys
+
+HELPERS_DIR = os.path.dirname(__file__)
+sys.path.append(HELPERS_DIR)
+
+from step_logger import log_step
+
+
+USERS_SERVICE = "org.fedoraproject.Anaconda.Modules.Users"
+USERS_INTERFACE = USERS_SERVICE
+USERS_OBJECT_PATH = "/org/fedoraproject/Anaconda/Modules/Users"
+
+CREATE_ACCOUNT_ID_PREFIX = "accounts-create-account"
+
+
+class UsersDBus():
+    def __init__(self, machine):
+        self.machine = machine
+        self._bus_address = self.machine.execute("cat /run/anaconda/bus.address")
+
+    def dbus_get_users(self):
+        ret = self.machine.execute(f'busctl --address="{self._bus_address}" \
+            get-property  \
+            {USERS_SERVICE} \
+            {USERS_OBJECT_PATH} \
+            {USERS_INTERFACE} Users')
+
+        return ret
+
+    def dbus_clear_users(self):
+        self.machine.execute(f'busctl --address="{self._bus_address}" \
+            set-property  \
+            {USERS_SERVICE} \
+            {USERS_OBJECT_PATH} \
+            {USERS_INTERFACE} Users aa{{sv}} 0')
+
+
+class Users(UsersDBus):
+    def __init__(self, browser, machine):
+        self.browser = browser
+
+        UsersDBus.__init__(self, machine)
+
+    @log_step(snapshot_before=True)
+    def set_user_account(self, user_account, append=False, value_check=True):
+        sel = "#accounts-create-account-user-account"
+        self.browser.set_input_text(sel, user_account, append=append, value_check=value_check)

--- a/ui/webui/test/helpers/users.py
+++ b/ui/webui/test/helpers/users.py
@@ -21,6 +21,7 @@ import sys
 HELPERS_DIR = os.path.dirname(__file__)
 sys.path.append(HELPERS_DIR)
 
+from password import Password
 from step_logger import log_step
 
 
@@ -63,3 +64,16 @@ class Users(UsersDBus):
     def set_user_account(self, user_account, append=False, value_check=True):
         sel = "#accounts-create-account-user-account"
         self.browser.set_input_text(sel, user_account, append=append, value_check=value_check)
+
+
+def create_user(test, cleanup=True):
+    p = Password(test.browser, CREATE_ACCOUNT_ID_PREFIX)
+    u = Users(test.browser, test.machine)
+
+    password = "password"
+    p.set_password(password)
+    p.set_password_confirm(password)
+    u.set_user_account("tester")
+
+    if cleanup:
+        test.addCleanup(u.dbus_clear_users)

--- a/ui/webui/test/helpers/users.py
+++ b/ui/webui/test/helpers/users.py
@@ -66,14 +66,15 @@ class Users(UsersDBus):
         self.browser.set_input_text(sel, user_account, append=append, value_check=value_check)
 
 
-def create_user(test, cleanup=True):
-    p = Password(test.browser, CREATE_ACCOUNT_ID_PREFIX)
-    u = Users(test.browser, test.machine)
+def create_user(browser, machine):
+    p = Password(browser, CREATE_ACCOUNT_ID_PREFIX)
+    u = Users(browser, machine)
 
     password = "password"
     p.set_password(password)
     p.set_password_confirm(password)
     u.set_user_account("tester")
 
-    if cleanup:
-        test.addCleanup(u.dbus_clear_users)
+
+def dbus_reset_users(machine):
+    UsersDBus(machine).dbus_clear_users()


### PR DESCRIPTION
This is a draft pull request for https://issues.redhat.com/browse/INSTALLER-3205.
I have some questions (some related to specific commits, so it might make sense to follow the PR with the commits) and items for follow up steps.

- [x] Figure out where to keep the new UI state. In the draft I picked a structure in wizard - see some reasoning and options in the commit message [webui: keep the state of Create Account UI](https://github.com/rhinstaller/anaconda/pull/5280/commits/1f9f776cf58b3afc88526102770a83bed693bec6).
- [x] [REQUIRED IN THIS PR] Strength indicator update / redesign. As can be seen on the screenshot the current indicator (following PF example) does not scale for horizontal forms (compare users and disk encryption sshots). https://github.com/patternfly/patternfly/issues/6032
- [ ] Add user name validation. Currently only non-zero length is required. The rules in Gtk UI are pretty numerous and seem to need review (and maybe compare with gnome tools).
- [ ] [~~REQUIRED IN THIS PR~~] Add account settings to the review screen (perhaps also when root account part is finished).
- [ ] Crypt user password before passing it to backend (as in Gtk UI).
- [x] [REQUIRED IN THIS PR] Add tests, remove hack [webui: FIXME do not require user temporarily](https://github.com/rhinstaller/anaconda/pull/5280/commits/5511082b0a200e9bff71c39c76d37e9eb2135c09). The tests will need nontrivial update for a new mandatory step with required user interaction.
- [x] [REQUIRED IN THIS PR] run only for non-workstation case 
- [ ] make sure the tests work both for workstation / non-workstation (live/non-live) case - this would involve replacing back() back() with something like reach_back(STEP_ID)
- [x] better prefixId setting in the components
- [ ] add thorough user screen test (going back and forth, rule checkers, pwd strength,...) - perhaps when also root accout part is added
- [x] Fix e2e tests
- [ ] Add the hint to the description.

![Screenshot from 2023-10-25 15-39-02](https://github.com/rhinstaller/anaconda/assets/1220237/5e4fa487-c234-4abf-a0f2-14a121e266f3)


The strenght indicator does not scale for isHorizontal Form
![Screenshot from 2023-10-25 15-39-19](https://github.com/rhinstaller/anaconda/assets/1220237/2c97acc2-bdbf-4f8d-a41a-976f1345ee69)
![Screenshot from 2023-10-25 15-39-29](https://github.com/rhinstaller/anaconda/assets/1220237/bbf54491-53c5-4b96-a81b-d4c4d1a7d2c1)
Compare to disk encryption:
![Screenshot from 2023-10-25 15-39-40](https://github.com/rhinstaller/anaconda/assets/1220237/4b7e032d-c17d-4bdb-9e0d-a1dae60ba464)
