### PR TITLE
widgets: disable glade in RHEL builds

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -16,9 +16,11 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 # match the requires versions of things).
 
 %if ! 0%{?rhel}
+%bcond_without glade
 %bcond_without live
 %define blivetguiver 2.4.2-3
 %else
+%bcond_with glade
 %bcond_with live
 %endif
 %define cockpitver 275
@@ -55,7 +57,9 @@ BuildRequires: gtk-doc
 BuildRequires: gtk3-devel-docs >= %{gtk3ver}
 BuildRequires: glib2-doc
 BuildRequires: gobject-introspection-devel
+%if %{with glade}
 BuildRequires: glade-devel
+%endif
 BuildRequires: libgnomekbd-devel
 BuildRequires: libxklavier-devel >= %{libxklavierver}
 BuildRequires: make
@@ -326,7 +330,9 @@ installer.
 
 %package widgets-devel
 Summary: Development files for anaconda-widgets
+%if %{with glade}
 Requires: glade
+%endif
 Requires: %{name}-widgets%{?_isa} = %{version}-%{release}
 
 %description widgets-devel
@@ -352,7 +358,7 @@ runtime on NFS/HTTP/FTP servers or local disks.
 
 %build
 # use actual build-time release number, not tarball creation time release number
-%configure ANACONDA_RELEASE=%{release}
+%configure ANACONDA_RELEASE=%{release} %{!?with_glade:--disable-glade}
 %{__make} %{?_smp_mflags}
 
 %install
@@ -488,10 +494,12 @@ rm -rf \
 %{python3_sitearch}/gi/overrides/*
 
 %files widgets-devel
-%{_libdir}/libAnacondaWidgets.so
-%{_libdir}/glade/modules/libAnacondaWidgets.so
 %{_includedir}/*
+%{_libdir}/libAnacondaWidgets.so
+%if %{with glade}
+%{_libdir}/glade/modules/libAnacondaWidgets.so
 %{_datadir}/glade/catalogs/AnacondaWidgets.xml
+%endif
 %{_datadir}/gtk-doc
 
 %files dracut

--- a/widgets/Makefile.am
+++ b/widgets/Makefile.am
@@ -19,7 +19,7 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src python glade doc
+SUBDIRS = src python @GLADE_SUBDIR@ doc
 
 MAINTAINERCLEANFILES = Makefile.in aclocal.m4 config.guess config.h.in config.sub \
 	configure depcomp install-sh ltmain.sh missing py-compile \

--- a/widgets/configure.ac
+++ b/widgets/configure.ac
@@ -62,7 +62,14 @@ AC_ARG_WITH([html-dir],
 HTML_DIR="$with_html_dir"
 AC_SUBST([HTML_DIR])
 
-ANACONDA_PKG_CHECK_MODULES([GLADEUI], [gladeui-2.0 >= 3.10])
+AC_ARG_ENABLE([glade],
+              AS_HELP_STRING([--disable-glade], [Build without glade module]))
+
+AS_IF([test "x$enable_glade" != "xno"],
+      [ANACONDA_PKG_CHECK_MODULES([GLADEUI], [gladeui-2.0 >= 3.10])
+       AC_SUBST(GLADE_SUBDIR, "glade")],
+      [AC_SUBST(GLADE_SUBDIR, "")])
+
 ANACONDA_PKG_CHECK_MODULES([GTK], [gtk+-x11-3.0 >= 3.11.3])
 ANACONDA_PKG_CHECK_MODULES([LIBXKLAVIER], [libxklavier >= 5.2.1])
 ANACONDA_PKG_CHECK_EXISTS([gobject-introspection-1.0 >= 1.30])


### PR DESCRIPTION
* [ ] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.
* [ ] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.
* [ ] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.
* [ ] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
* [ ] **RHEL** rules: If your PR is for a `rhel-*` branch, pay special attention to commit messages. Make sure **all** commit messages include a line linking the commit to a bug, such as `Resolves: rhbz#123456`. For more information, see [the complete rules](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html).

glade is unwanted in RHEL 10: https://github.com/minimization/content-resolver-input/pull/996

ELN scratch build: https://koji.fedoraproject.org/koji/taskinfo?taskID=108369615
