### PR TITLE
spec: Remove dependency on jfsutils

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -212,7 +212,6 @@ Recommends: kdump-anaconda-addon
 Requires: btrfs-progs
 Requires: ntfs-3g
 Requires: ntfsprogs
-Requires: jfsutils
 Requires: f2fs-tools
 %endif
 Requires: xfsprogs


### PR DESCRIPTION
Blivet will remove support for JFS in the next upstream release so we can drop the dependency here.

Related: https://github.com/storaged-project/blivet/pull/1163
