### PR TITLE
storage: Handle live images and inst.sdboot

### DIFF
--- a/pyanaconda/modules/storage/bootloader/systemd.py
+++ b/pyanaconda/modules/storage/bootloader/systemd.py
@@ -150,3 +150,11 @@ class SystemdBoot(BootLoader):
 
     def write_config_images(self, config):
         return True
+
+    def is_valid_stage1_device(self, device, early=False):
+        valid = True
+        if conf.system.provides_liveuser:
+            raise BootLoaderError("systemd-boot cannot be utilized on live media with grub.")
+        else:
+            valid = super().is_valid_stage1_device(device, early)
+        return valid


### PR DESCRIPTION
Live images are already installed with grub2 and cannot be changed on the fly to systemd-boot (well at least without a lot of extra work). In case the user passed one of the systemd-boot options to anaconda, we should be a bit more graceful than failing to run the updateloader entries script as currently happens.

This change, when run on non webUI installs results in a popup notifying the user there is an error in the bootloader configuration and asking if they would like to ignore it.

Resolves: rhbz#2234638

