### PR TITLE
storage: Allow systemd-boot only for package installations

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -225,6 +225,11 @@ class EFISystemdBoot(EFIBase, SystemdBoot):
         """ Full path to EFI configuration file. """
         return join_paths(self.efi_config_dir, self._config_file)
 
+    def check(self):
+        """Verify the bootloader configuration."""
+        # Force the resolution order to run the systemd-boot check.
+        return SystemdBoot.check(self) and EFIBase.check(self)
+
     def write_config(self):
         """ Write the config settings to config file (ex: grub.cfg) not needed for systemd. """
         config_path = join_paths(conf.target.system_root, self.efi_config_file)

--- a/pyanaconda/modules/storage/bootloader/systemd.py
+++ b/pyanaconda/modules/storage/bootloader/systemd.py
@@ -15,7 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-
+from pyanaconda.core.constants import PAYLOAD_TYPE_DNF
+from pyanaconda.modules.common.constants.services import PAYLOADS
 from pyanaconda.modules.storage.bootloader.base import BootLoader, BootLoaderError
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
@@ -74,6 +75,30 @@ class SystemdBoot(BootLoader):
     def config_file(self):
         """ Full path to configuration file. """
         return "%s/%s" % (self.config_dir, self._config_file)
+
+
+    def check(self):
+        """Verify the bootloader configuration."""
+        if self._get_payload_type() != PAYLOAD_TYPE_DNF:
+            self.errors.append(_(
+                "Systemd-boot cannot be utilized with the current type of payload. "
+                "Choose an installation media that supports package installation."
+            ))
+            return False
+
+        return super().check()
+
+    @staticmethod
+    def _get_payload_type():
+        """Get the type of the active payload."""
+        payloads_proxy = PAYLOADS.get_proxy()
+        object_path = payloads_proxy.ActivePayload
+
+        if not object_path:
+            return None
+
+        object_proxy = PAYLOADS.get_proxy(object_path)
+        return object_proxy.Type
 
     # copy console update from grub2.py
     def write_config_console(self, config):
@@ -147,14 +172,5 @@ class SystemdBoot(BootLoader):
             raise BootLoaderError(_("bootctl failed to install UEFI boot loader. "
                                     "More information may be found in the log files stored in /tmp"))
 
-
     def write_config_images(self, config):
         return True
-
-    def is_valid_stage1_device(self, device, early=False):
-        valid = True
-        if conf.system.provides_liveuser:
-            raise BootLoaderError("systemd-boot cannot be utilized on live media with grub.")
-        else:
-            valid = super().is_valid_stage1_device(device, early)
-        return valid

--- a/pyanaconda/modules/storage/bootloader/systemd.py
+++ b/pyanaconda/modules/storage/bootloader/systemd.py
@@ -150,3 +150,11 @@ class SystemdBoot(BootLoader):
 
     def write_config_images(self, config):
         return True
+
+    def is_valid_stage1_device(self, device, early=False):
+        valid = True
+        if conf.system.provides_liveuser:
+            raise BootLoaderError("systemd-boot cannot be utilized on live media with grub.")
+        else:
+            valid = super().is_valid_stage1_device(device, early)
+        return valid


### PR DESCRIPTION
**This is an alternative to pull requests https://github.com/rhinstaller/anaconda/pull/5172 and https://github.com/rhinstaller/anaconda/pull/5296.**

The installer is not able to verify requirements of the selected bootloader with
other types of payload, like live images and rpmostree installations. Let's
allow systemd-boot only for package installations for now and deal with other
use cases later.

Resolves: rhbz#2234638