### PR TITLE
payload/rpmostree: Add support for bootupd

### DIFF
--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -142,6 +142,34 @@ class InstallBootloaderTask(Task):
             raise BootloaderInstallationError(str(e)) from None
 
 
+class InstallBootloaderTaskViaBootupd(Task):
+    """Installation task for the bootloader via bootupd"""
+
+    def __init__(self, storage, sysroot):
+        """Create a new task."""
+        super().__init__()
+        self._storage = storage
+        self._sysroot = sysroot
+
+    @property
+    def name(self):
+        return "Install the bootloader"
+
+    def run(self):
+        """Run the task.
+
+        :raise: BootloaderInstallationError if the installation fails
+        """
+        rc = execWithRedirect(
+            "bootupctl",
+            ["backend", "install", "--auto", "--with-static-configs",
+             "--device", self._storage.root_device, self._sysroot],
+            root=self._sysroot)
+        if rc:
+            raise BootloaderInstallationError(
+                "failed to write boot loader configuration")
+
+
 class CreateBLSEntriesTask(Task):
     """The installation task that creates BLS entries."""
 


### PR DESCRIPTION
The https://github.com/coreos/bootupd project was created to fill the gap in bootloader management for ostree-based systems.

When it was created, it was just integrated into Fedora CoreOS and derivatives; this left the Atomic Desktops (Silverblue etc.) as unfixed, and it was never used by RHEL for Edge.

This PR is aiming to circle back and close that gap.  We detect if bootupd is in the target root; if it is, then we should act as if `bootloader --location=none` had been specified, and just run bootupd to perform the installation.

The other hacks we have around the grub config are no longer necessary in this mode.
