### PR TITLE
Validate user account value

### DIFF
--- a/ui/webui/src/components/users/Accounts.jsx
+++ b/ui/webui/src/components/users/Accounts.jsx
@@ -17,10 +17,13 @@
 
 import cockpit from "cockpit";
 import React, { useState, useEffect } from "react";
+import { debounce } from "throttle-debounce";
 
 import {
     Form,
     FormGroup,
+    FormHelperText,
+    HelperText,
     TextInput,
     Title,
 } from "@patternfly/react-core";
@@ -55,6 +58,33 @@ export const accountsToDbusUsers = (accounts) => {
     }];
 };
 
+const reservedNames = [
+    "root",
+    "bin",
+    "daemon",
+    "adm",
+    "lp",
+    "sync",
+    "shutdown",
+    "halt",
+    "mail",
+    "operator",
+    "games",
+    "ftp",
+    "nobody",
+    "home",
+    "system",
+];
+
+const isUserAccountWithInvalidCharacters = (userAccount) => {
+    return (
+        userAccount === "." ||
+        userAccount === ".." ||
+        userAccount.match(/^[0-9]+$/) ||
+        !userAccount.match(/^[A-Za-z0-9._][A-Za-z0-9._-]{0,30}([A-Za-z0-9._-]|\$)?$/)
+    );
+};
+
 const CreateAccount = ({
     idPrefix,
     passwordPolicy,
@@ -63,14 +93,39 @@ const CreateAccount = ({
     setAccounts,
 }) => {
     const [fullName, setFullName] = useState(accounts.fullName);
+    const [_userAccount, _setUserAccount] = useState(accounts.userAccount);
     const [userAccount, setUserAccount] = useState(accounts.userAccount);
+    const [userAccountInvalidHint, setUserAccountInvalidHint] = useState("");
+    const [isUserAccountValid, setIsUserAccountValid] = useState(null);
     const [password, setPassword] = useState(accounts.password);
     const [confirmPassword, setConfirmPassword] = useState(accounts.confirmPassword);
     const [isPasswordValid, setIsPasswordValid] = useState(false);
 
     useEffect(() => {
-        setIsUserValid(isPasswordValid && userAccount.length > 0);
-    }, [setIsUserValid, isPasswordValid, userAccount]);
+        debounce(300, () => setUserAccount(_userAccount))();
+    }, [_userAccount, setUserAccount]);
+
+    useEffect(() => {
+        setIsUserValid(isPasswordValid && isUserAccountValid);
+    }, [setIsUserValid, isPasswordValid, isUserAccountValid]);
+
+    useEffect(() => {
+        let valid = true;
+        setUserAccountInvalidHint("");
+        if (userAccount.length === 0) {
+            valid = null;
+        } else if (userAccount.length > 32) {
+            valid = false;
+            setUserAccountInvalidHint(_("The user name is too long"));
+        } else if (reservedNames.includes(userAccount)) {
+            valid = false;
+            setUserAccountInvalidHint(_("Sorry, that user name is not available. Please try another."));
+        } else if (isUserAccountWithInvalidCharacters(userAccount)) {
+            valid = false;
+            setUserAccountInvalidHint(cockpit.format(_("The user name should usually only consist of lower case letters from a-z, digits and the following characters: $0"), "-_"));
+        }
+        setIsUserAccountValid(valid);
+    }, [userAccount]);
 
     const passphraseForm = (
         <PasswordFormFields
@@ -119,9 +174,15 @@ const CreateAccount = ({
             >
                 <TextInput
                   id={idPrefix + "-user-account"}
-                  value={userAccount}
-                  onChange={(_event, val) => setUserAccount(val)}
+                  value={_userAccount}
+                  onChange={(_event, val) => _setUserAccount(val)}
+                  validated={isUserAccountValid === null ? "default" : isUserAccountValid ? "success" : "error"}
                 />
+                <FormHelperText>
+                    <HelperText component="ul" aria-live="polite" id={idPrefix + "-full-name-helper"}>
+                        {userAccountInvalidHint}
+                    </HelperText>
+                </FormHelperText>
             </FormGroup>
             {passphraseForm}
         </Form>

--- a/ui/webui/test/check-users
+++ b/ui/webui/test/check-users
@@ -18,8 +18,10 @@
 import anacondalib
 
 from installer import Installer
-from users import Users, CREATE_ACCOUNT_ID_PREFIX, create_user
-from testlib import nondestructive, test_main  # pylint: disable=import-error
+from password import Password
+from review import Review
+from users import Users, CREATE_ACCOUNT_ID_PREFIX, create_user, dbus_reset_users
+from testlib import nondestructive, test_main, sit  # pylint: disable=import-error
 
 @nondestructive
 class TestUsers(anacondalib.VirtInstallMachineCase):
@@ -30,6 +32,8 @@ class TestUsers(anacondalib.VirtInstallMachineCase):
         b = self.browser
         i = Installer(b, self.machine)
         u = Users(b, self.machine)
+
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
 
         i.open()
 
@@ -46,6 +50,102 @@ class TestUsers(anacondalib.VirtInstallMachineCase):
         self.assertIn('"groups" as 1 "wheel"', users)
         self.assertIn('"is-crypted" b false', users)
         self.assertIn('"password" s "password"', users)
+
+    def testAccessAndValidation(self):
+        b = self.browser
+        i = Installer(b, self.machine)
+        p = Password(b, CREATE_ACCOUNT_ID_PREFIX)
+        u = Users(b, self.machine)
+
+        self.addCleanup(lambda: dbus_reset_users(self.machine))
+
+        i.open()
+
+        i.reach(i.steps.ACCOUNTS)
+
+        # Fill in valid values
+        password = "password"
+        full_name = "Full Tester"
+        user_account = "tester"
+
+        p.set_password(password)
+        p.set_password_confirm(password)
+        u.set_full_name(full_name)
+        u.set_user_account(user_account)
+
+        p.check_password(password)
+        p.check_password_confirm(password)
+        u.check_full_name(full_name)
+        u.check_user_account(user_account)
+
+        # Test that you can move forward and going back keeps values
+        i.next()
+        i.back()
+        p.check_password(password)
+        p.check_password_confirm(password)
+        u.check_full_name(full_name)
+        u.check_user_account(user_account)
+
+        # Test that moving back and forward keeps values
+        i.back()
+        i.next()
+        p.check_password(password)
+        p.check_password_confirm(password)
+        u.check_full_name(full_name)
+        u.check_user_account(user_account)
+
+        # Test full name validation
+        u.set_full_name("")
+        i.check_next_disabled(disabled=False)
+        u.set_full_name(full_name)
+
+        # Test account validation
+        u.set_user_account("")
+        i.check_next_disabled()
+        u.set_user_account(user_account)
+
+        # Test password validation
+        # No password set
+        p.set_password("")
+        p.set_password_confirm("")
+        p.check_pw_rule("length", "indeterminate")
+        p.check_pw_rule("match", "indeterminate")
+        i.check_next_disabled()
+        # Start which pw which is too short
+        p.set_password("abcd")
+        p.check_pw_strength(None)
+        i.check_next_disabled()
+        p.check_pw_rule("length", "error")
+        p.check_pw_rule("match", "error")
+        # Make the pw 6 chars long
+        p.set_password("ef", append=True, value_check=False)
+        i.check_next_disabled()
+        p.check_password("abcdef")
+        p.check_pw_rule("length", "success")
+        p.check_pw_rule("match", "error")
+        p.check_pw_strength("weak")
+        # Set the password confirm
+        p.set_password_confirm("abcde")
+        p.check_pw_rule("match", "error")
+        p.set_password_confirm("abcdef")
+        p.check_pw_rule("match", "success")
+        p.check_pw_rule("length", "success")
+        p.check_pw_strength("weak")
+        i.check_next_disabled(disabled=False)
+
+        # Test password strength
+        p.set_password("Rwce82ybF7dXtCzFumanchu!!!!!!!!")
+        p.check_pw_strength("strong")
+
+        # Test review values
+        p.set_password(password)
+        p.set_password_confirm(password)
+        u.set_full_name(full_name)
+        u.set_user_account(user_account)
+        r = Review(b)
+        i.reach(i.steps.REVIEW)
+        r.check_account(f"{full_name} ({user_account})")
+
 
 if __name__ == '__main__':
     test_main()

--- a/ui/webui/test/check-users
+++ b/ui/webui/test/check-users
@@ -51,6 +51,22 @@ class TestUsers(anacondalib.VirtInstallMachineCase):
         self.assertIn('"is-crypted" b false', users)
         self.assertIn('"password" s "password"', users)
 
+    @staticmethod
+    def _test_user_account(user, installer, valid, invalid):
+        installer.check_next_disabled(disabled=False)
+
+        n_valid = len(valid) - 1
+        n_invalid = len(invalid) - 1
+
+        # Set valid and invalid value in turns and check the next button
+        for i in range(max(n_valid, n_invalid)):
+            i_valid = min(i, n_valid)
+            i_invalid = min(i, n_invalid)
+            user.set_user_account(invalid[i_invalid])
+            installer.check_next_disabled()
+            user.set_user_account(valid[i_valid])
+            installer.check_next_disabled(disabled=False)
+
     def testAccessAndValidation(self):
         b = self.browser
         i = Installer(b, self.machine)
@@ -100,8 +116,35 @@ class TestUsers(anacondalib.VirtInstallMachineCase):
         u.set_full_name(full_name)
 
         # Test account validation
-        u.set_user_account("")
-        i.check_next_disabled()
+        # FIXME this should be tested by unit tests?
+        invalid_user_accounts = [
+            "",
+            # reserved
+            "root", "system", "daemon", "home",
+            "33333",
+            ".",
+            "..",
+            "-tester",
+            "123",
+            "$",
+            "$tester",
+            "tester?",
+            "longer_than_32_characteeeeeeeeeeeeeeeeeeers",
+        ]
+        valid_user_accounts = [
+            "tester-",
+            "...",
+            "12.3",
+            "tester1",
+            "tester$",
+            "test-er",
+            "test_er",
+            "test.er",
+            "_tester",
+            ".tester",
+            "_",
+        ]
+        self._test_user_account(u, i, valid_user_accounts, invalid_user_accounts)
         u.set_user_account(user_account)
 
         # Test password validation

--- a/ui/webui/test/helpers/users.py
+++ b/ui/webui/test/helpers/users.py
@@ -65,6 +65,21 @@ class Users(UsersDBus):
         sel = "#accounts-create-account-user-account"
         self.browser.set_input_text(sel, user_account, append=append, value_check=value_check)
 
+    @log_step(snapshot_before=True)
+    def check_user_account(self, user_account):
+        sel = "#accounts-create-account-user-account"
+        self.browser.wait_val(sel, user_account)
+
+    @log_step(snapshot_before=True)
+    def set_full_name(self, full_name, append=False, value_check=True):
+        sel = "#accounts-create-account-full-name"
+        self.browser.set_input_text(sel, full_name, append=append, value_check=value_check)
+
+    @log_step(snapshot_before=True)
+    def check_full_name(self, full_name):
+        sel = "#accounts-create-account-full-name"
+        self.browser.wait_val(sel, full_name)
+
 
 def create_user(browser, machine):
     p = Password(browser, CREATE_ACCOUNT_ID_PREFIX)


### PR DESCRIPTION
The PR is addressing part of https://issues.redhat.com/browse/INSTALLER-3781

There are 3 types of hints/messages for invalid values in the PR - the behavior should be the same as in Gnome Users settings in rawhide (using the same messages including the interpunction). Valid values are the same as in the current Gtk UI (but the Gtk UI has different hints/messages, a bit more fine grained).

Please note that I replaced "username" with "user name" in the validation messages after creating the screenshots (the tests were failing on it).

![Screenshot from 2023-11-09 11-57-42](https://github.com/rhinstaller/anaconda/assets/1220237/d658b35a-76d9-4eb3-ac84-94eab7870ac9)
![Screenshot from 2023-11-09 11-57-50](https://github.com/rhinstaller/anaconda/assets/1220237/93cfcc4d-7c1f-46fb-9b18-c98626ff74d2)
![Screenshot from 2023-11-09 12-47-41](https://github.com/rhinstaller/anaconda/assets/1220237/a87ba834-f050-44f1-a99a-5c11ec5f07d4)
![Screenshot from 2023-11-09 11-58-24](https://github.com/rhinstaller/anaconda/assets/1220237/03e9583c-93f3-416c-822d-27e21245f356)
![Screenshot from 2023-11-09 11-59-17](https://github.com/rhinstaller/anaconda/assets/1220237/ab958b24-fa41-4526-824f-3bd8260e0c71)
