### PR TITLE
 infra: trigger anaconda Web UI integration tests on specific file changes

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -1,0 +1,63 @@
+# This workflow checks if the PR affects Anaconda (changes to pyanaconda folder),
+# polls the packit COPR until it has the current PR version
+# available, and then test-triggers an "anaconda PR" scenario.
+#
+# This workflow is inspired from:
+# https://github.com/cockpit-project/cockpit/blob/main/.github/workflows/trigger-anaconda.yml
+
+name: Anaconda Web UI
+on:
+  pull_request_target:
+    # All file changes that might affect the Web UI
+    paths:
+      - 'pyanaconda/**'
+      - '!pyanaconda/gui/**'
+      - '!pyanaconda/tui/**'
+      - 'anaconda.py'
+      - 'data/anaconda.conf'
+      - 'data/conf.d/**/'
+      - 'data/profile.d/**'
+jobs:
+  trigger:
+    runs-on: ubuntu-22.04
+    # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
+    environment: gh-cockpituous
+    container: registry.fedoraproject.org/fedora:rawhide
+    # this polls for a COPR build, which can take long
+    timeout-minutes: 120
+
+    steps:
+      - name: Install dependencies
+        run: |
+          dnf install -y git-core dnf-plugins-core || {
+            sleep 60
+            dnf install -y git-core dnf-plugins-core
+          }
+
+      # Naively this should wait for github.event.pull_request.head.sha, but
+      # that breaks on non-current branches, which packit merges to main with
+      # an unpredictable SHA; so instead, wait until COPR has a build which is
+      # newer than the PR push time. This assumes that this workflow always runs earlier
+      # than the COPR srpm build finishes.
+      - name: Wait for packit COPR build
+        run: |
+          set -ex
+          PUSH_TIME=$(date --utc +%Y%m%d%H%M%S -d '${{ github.event.pull_request.head.repo.pushed_at }}')
+          COPR_NAME="${{ github.event.pull_request.base.user.login }}-${{ github.event.pull_request.base.repo.name }}-${{ github.event.number }}"
+          for _ in $(seq 60); do
+              sleep 60;
+              if dnf copr enable -y packit/$COPR_NAME &&
+                 out=$(dnf info --refresh --repo='copr:*anaconda*' anaconda) &&
+                 stamp=$(echo "$out" | awk '/^Release/ { split($3, v, "."); print substr(v[2], 0, 14)}' | head -1) &&
+                 [ "$stamp" -gt "$PUSH_TIME" ]; then
+                  exit 0
+              fi
+          done
+          exit 1
+
+      - name: Trigger anaconda run
+        run: |
+          git clone --depth=1 https://github.com/cockpit-project/bots
+          mkdir -p ~/.config/cockpit-dev
+          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/cockpit-dev/github-token
+          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui


### PR DESCRIPTION
We want to make sure to not break the Web UI with changes which affect it, ie. API changes.
    
Add a workflow which runs if the PR affects Anaconda (changes to pyanaconda),
polls the packit COPR until it has the current PR version available, and then test-triggers a "anaconda PR" scenario.


---
Tested that @ https://github.com/KKoukiou/anaconda/pull/1. The tests did not run because my fork that not have the webhook for cockpit tests setup but it worked to the point of triggering the tests, so it should be good.