### PR TITLE
Rename Organization to Organization ID on subscription screen

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.glade
+++ b/pyanaconda/ui/gui/spokes/subscription.glade
@@ -224,7 +224,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
                                                 <property name="halign">start</property>
-                                                <property name="label" translatable="yes">Organization</property>
+                                                <property name="label" translatable="yes">Organization ID</property>
                                               </object>
                                               <packing>
                                                 <property name="left_attach">0</property>


### PR DESCRIPTION
This should remove the ambiguity for customers that they should input their assigned RHSM Organization ID, not the name of their organization/company.

Resolves: RHEL-11168