### PR TITLE
Rename Organization to Organization ID on subscription screen

### DIFF
--- a/pyanaconda/ui/gui/spokes/subscription.glade
+++ b/pyanaconda/ui/gui/spokes/subscription.glade
@@ -212,7 +212,7 @@
                                                 <child>
                                                   <object class="GtkLabel" id="select_organization_label">
                                                     <property name="can-focus">False</property>
-                                                    <property name="label" translatable="yes">Organization</property>
+                                                    <property name="label" translatable="yes">Organization ID</property>
                                                   </object>
                                                 </child>
                                               </object>
@@ -273,7 +273,7 @@
                                                 <property name="visible">True</property>
                                                 <property name="can-focus">False</property>
                                                 <property name="halign">start</property>
-                                                <property name="label" translatable="yes">Organization</property>
+                                                <property name="label" translatable="yes">Organization ID</property>
                                               </object>
                                               <packing>
                                                 <property name="left-attach">0</property>


### PR DESCRIPTION
This should remove the ambiguity for customers that they should input their assigned RHSM Organization ID, not the name of their organization/company.

Resolves: RHEL-11167