### PR TITLE
webui: make stepping back in tests more robust wrt hidden steps

### DIFF
--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -301,7 +301,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         # Go back to the Disk Configuration page and re-enter the review screen.
         # This should create again a new partitioning object and apply it
         # no matter how many partitioning objects were created before
-        i.reach_on_sidebar(i.steps.DISK_ENCRYPTION, parent_step=i.steps.DISK_CONFIGURATION)
+        i.reach_on_sidebar(i.steps.DISK_ENCRYPTION)
         i.reach(i.steps.REVIEW)
         new_applied_partitioning = s.dbus_get_applied_partitioning()
         new_created_partitioning = s.dbus_get_created_partitioning()
@@ -960,7 +960,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         r.check_disk_row(disk, 3, f"{vgname}-home, 8.12 GB: mount, /home")
         r.check_disk_row(disk, 4, f"{vgname}-swap, 902 MB: mount, swap")
 
-        i.reach_on_sidebar(i.steps.CUSTOM_MOUNT_POINT, parent_step=i.steps.DISK_CONFIGURATION)
+        i.reach_on_sidebar(i.steps.CUSTOM_MOUNT_POINT)
 
         # remove the /home row and check that row 3 is now swap
         s.remove_mountpoint_row(3)

--- a/ui/webui/test/check-storage
+++ b/ui/webui/test/check-storage
@@ -301,8 +301,7 @@ class TestStorage(anacondalib.VirtInstallMachineCase, StorageHelpers):
         # Go back to the Disk Configuration page and re-enter the review screen.
         # This should create again a new partitioning object and apply it
         # no matter how many partitioning objects were created before
-        i.back()
-        i.back()
+        i.reach_on_sidebar(i.steps.DISK_ENCRYPTION, parent_step=i.steps.DISK_CONFIGURATION)
         i.reach(i.steps.REVIEW)
         new_applied_partitioning = s.dbus_get_applied_partitioning()
         new_created_partitioning = s.dbus_get_created_partitioning()
@@ -376,6 +375,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         s = Storage(b, m)
         r = Review(b)
 
+
         disk = "/dev/vda"
         dev = "vda"
         btrfsname = "btrfstest"
@@ -428,9 +428,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         applied_partitioning = s.dbus_get_applied_partitioning()
 
         # When adding a new partition a new partitioning should be created
-        i.back()
-        i.back(previous_page=i.steps.CUSTOM_MOUNT_POINT)
-        i.back()
+        i.reach_on_sidebar(i.steps.INSTALLATION_METHOD)
 
         m.execute(f"sgdisk --new=0:0:0 {disk}")
         s.rescan_disks()
@@ -800,9 +798,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         r.check_disk_row(dev, 3, "home, 15.0 GB: mount, /home")
         r.check_disk_row_not_present(dev, f"unused")
 
-        i.back()
-        i.back(previous_page=i.steps.CUSTOM_MOUNT_POINT)
-        i.back()
+        i.reach_on_sidebar(i.steps.INSTALLATION_METHOD)
 
         # Checks for nested btrfs subvolume
         tmp_mount = "/tmp/btrfs-mount-test"
@@ -964,8 +960,7 @@ class TestStorageMountPoints(anacondalib.VirtInstallMachineCase, StorageHelpers)
         r.check_disk_row(disk, 3, f"{vgname}-home, 8.12 GB: mount, /home")
         r.check_disk_row(disk, 4, f"{vgname}-swap, 902 MB: mount, swap")
 
-        i.back()
-        i.back(previous_page=i.steps.CUSTOM_MOUNT_POINT)
+        i.reach_on_sidebar(i.steps.CUSTOM_MOUNT_POINT, parent_step=i.steps.DISK_CONFIGURATION)
 
         # remove the /home row and check that row 3 is now swap
         s.remove_mountpoint_row(3)

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -40,6 +40,10 @@ class InstallerSteps(UserDict):
     _steps_jump[REVIEW] = PROGRESS
     _steps_jump[PROGRESS] = []
 
+    _parent_steps = {}
+    _parent_steps[DISK_ENCRYPTION] = DISK_CONFIGURATION
+    _parent_steps[CUSTOM_MOUNT_POINT] = DISK_CONFIGURATION
+
     _steps_callbacks = {}
     _steps_callbacks[ACCOUNTS] = create_user
 
@@ -139,9 +143,9 @@ class Installer():
         self.browser.click(f"#{step}")
 
     @log_step()
-    def reach_on_sidebar(self, target_page, parent_step=None):
-        if parent_step:
-            self.click_step_on_sidebar(parent_step)
+    def reach_on_sidebar(self, target_page):
+        if target_page in self.steps._parent_steps:
+            self.click_step_on_sidebar(self.steps._parent_steps[target_page])
         self.click_step_on_sidebar(target_page)
         self.wait_current_page(target_page)
 

--- a/ui/webui/test/helpers/installer.py
+++ b/ui/webui/test/helpers/installer.py
@@ -138,6 +138,13 @@ class Installer():
         step = step or self.get_current_page()
         self.browser.click(f"#{step}")
 
+    @log_step()
+    def reach_on_sidebar(self, target_page, parent_step=None):
+        if parent_step:
+            self.click_step_on_sidebar(parent_step)
+        self.click_step_on_sidebar(target_page)
+        self.wait_current_page(target_page)
+
     def get_current_page(self):
         return self.browser.eval_js('window.location.hash;').replace('#/', '') or self.steps[0]
 


### PR DESCRIPTION
See the commit message.

In general I think we should pass (or detect) hidden steps to the `Installer` class and update next(), back(), and reach() to use this information. That way we wouldn't need to parametrize them (https://github.com/rhinstaller/anaconda/blob/bed2e8bc03a73621bb913a3bba34df1731e0385a/ui/webui/test/check-basic#L100) and potentially we should be able to run a test on various variants (eg boot iso / live).

For the context this is a followup of `Create Account` step added recently, which is hidden on Workstation/live.

Perhaps at some point we would also want to generate the _parent_steps, maybe even all the other info from a single source of truth, but I think for now it is feasible to update it manually.