### PR TITLE
infra: Pin pocketlint version

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -38,7 +38,7 @@ RUN set -e; \
 RUN pip install \
   "pylint==2.8.3" \
   "astroid==2.5.6" \
-  pocketlint \
+  "pocketlint==0.24" \
   coverage \
   pycodestyle \
   dogtail \


### PR DESCRIPTION
Pocketlint has a new verion which is required for python 2.14 but unfortunately not backward compatible.

https://github.com/rhinstaller/pocketlint/pull/49

To solve this let's pin also pocketlint version next to pylint version.