### PR TITLE
infra: Pin pocketlint version

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -35,7 +35,7 @@ RUN echo dnf update -y && \
 RUN pip-3.6 install \
   "pylint==2.5.3" \
   "astroid==2.4.2" \
-  pocketlint \
+  "pocketlint==0.24" \
   copr \
   coverage \
   pycodestyle \


### PR DESCRIPTION
Pocketlint has a new verion which is required for python 2.14 but unfortunately not backward compatible.

https://github.com/rhinstaller/pocketlint/pull/49

To solve this let's pin also pocketlint version next to pylint version.