### PR TITLE
logging: split image package list message into 8K chunks

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -227,7 +227,9 @@ if __name__ == "__main__":
         sys.exit(0)
 
     log.info("%s %s", sys.argv[0], util.get_anaconda_version_string(build_time_version=True))
-    log.debug("Image packages list: %s", util.get_image_packages_info())
+    # Do not exceed default 8K limit on message length in rsyslog
+    for log_line in util.get_image_packages_info(max_string_chars=8096-100):
+        log.debug("Image packages: %s", log_line)
 
     if opts.updates_url:
         log.info("Using updates from: %s", opts.updates_url)

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -985,8 +985,20 @@ def restorecon(paths, root, skip_nonexistent=False):
         return True
 
 
-def get_image_packages_info():
+def get_image_packages_info(max_string_chars=0):
+    """List of strings containing versions of installer image packages.
+
+    The package version specifications are space separated in the strings.
+
+    :param int max_string_chars: maximum number of character in a string
+    :return [str]
+    """
+    info_lines = []
     if os.path.exists(PACKAGES_LIST_FILE):
-        return ' '.join(line.strip() for line in open(PACKAGES_LIST_FILE).readlines())
-    else:
-        return ''
+        with open(PACKAGES_LIST_FILE) as f:
+            while True:
+                lines = f.readlines(max_string_chars)
+                if not lines:
+                    break
+                info_lines.append(' '.join(line.strip() for line in lines))
+    return info_lines


### PR DESCRIPTION
rsyslogd has default of 8K for message to be passed.

Fixup of commit 113226788499ee7848db551875ab293efd6b3b38.

Currently we would log incomplete/truncated list in /tmp/syslog or virtinstall.log (log forwarded in kstests via virtio) (~8K of ~27K chars).

Although not very nice, I see this as a safer way than trying to configure rsyslogd for bigger messages. Which could be maybe done quite easily for virtio logging (https://github.com/rhinstaller/anaconda/blob/bed2e8bc03a73621bb913a3bba34df1731e0385a/pyanaconda/anaconda_logging.py#L268), but for /tmp/syslog (which used to be the log file where we should find everything) we'd perhaps need to modify /etc/rsyslogd.conf in lorax template.