### PR TITLE
 Use 'os.uname().machine' to get machine architecture instead of 'uname -i'

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/installation.py
+++ b/pyanaconda/modules/payloads/payload/dnf/installation.py
@@ -360,7 +360,7 @@ class ImportRPMKeysTask(Task):
 
         # Get substitutions for variables.
         # TODO: replace the interpolation with DNF once possible
-        basearch = util.execWithCapture("uname", ["-i"]).strip().replace("'", "")
+        basearch = os.uname().machine
         releasever = util.get_os_release_value("VERSION_ID", sysroot=self._sysroot) or ""
 
         # Import GPG keys to RPM database.

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -196,11 +196,12 @@ class ImportRPMKeysTaskTestCase(unittest.TestCase):
                 call("rpm", ["--import", key_2], root=sysroot),
             ])
 
+    @patch("pyanaconda.modules.payloads.payload.dnf.installation.os.uname")
     @patch("pyanaconda.modules.payloads.payload.dnf.installation.util")
-    def test_import_substitution(self, mock_util):
+    def test_import_substitution(self, mock_util, mock_uname):
         """Import GPG keys with variables."""
         mock_util.execWithRedirect.return_value = 0
-        mock_util.execWithCapture.return_value = "s390x"
+        mock_uname.return_value = Mock(machine='s390x')
         mock_util.get_os_release_value.return_value = "34"
 
         key = "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch"


### PR DESCRIPTION
uname -i returns unknown.

Resolves: rhbz#2248930

