### PR TITLE
Docs changes from bug triage

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -694,6 +694,10 @@ Use systemd-boot as the bootloader. Note that there's no attempt to validate tha
 this will work for your platform or anything; it assumes that if you ask for it,
 you want to try.
 
+Note that this works only for package-based installations, where the bootloader can be chosen at
+install time. For live images, this can work only if the live image was built with systemd-boot
+instead of grub.
+
 .. inst.leavebootorder:
 
 inst.leavebootorder

--- a/docs/common-bugs.rst
+++ b/docs/common-bugs.rst
@@ -329,6 +329,8 @@ Invalid environment block
 
     Actual byte, position, and byte type (start, continuation, ???) vary.
 
+    This is caused by ``efibootmgr`` which prints raw non-UTF-8 data to output.
+
 :Solution: Duplicate of bug `2148480 <https://bugzilla.redhat.com/show_bug.cgi?id=2148480>`_.
 :Example: `rhbz#2238691 <https://bugzilla.redhat.com/show_bug.cgi?id=2238691>`_
 


### PR DESCRIPTION
- Mention that the invalid byte in utf-8 is from `efibootmgr`
- Describe caveats for `inst.sdboot`