### PR TITLE
workflows: Drop COCKPITUOUS_TOKEN from trigger-webui.yml

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -59,5 +59,5 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/cockpit-dev/github-token
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
           bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui


### PR DESCRIPTION
cockpit-project/bots#5569 changed the allowlist
from a GitHub team to a hardcoded Python list, so we don't need the cockpituous token privilege with its `read:org` any more.

