### PR TITLE
WIP: Ensure that /boot partition is not required

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -481,6 +481,7 @@ class DeviceTreeViewer(ABC):
         data.required_filesystem_type = spec.fstype or ""
         data.encryption_allowed = spec.encrypted
         data.logical_volume_allowed = spec.lv
+        data.is_required = bool(spec.is_required)
 
         return data
 

--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -135,7 +135,8 @@ class Platform(object):
         """
         return PartSpec(
             mountpoint="/boot",
-            size=Size("1GiB")
+            size=Size("1GiB"),
+            is_required=False
         )
 
 
@@ -429,7 +430,8 @@ class S390(Platform):
         return PartSpec(
             mountpoint="/boot",
             size=Size("1GiB"),
-            lv=False
+            lv=False,
+            is_required=False
         )
 
 


### PR DESCRIPTION
In the general case, if we have a single operating system, there's no need to create the /boot partition as long as our hardware is recent. New machines don't have the old restrictions that required the creation of the /boot partition.

This new attribute will be used in the front-end to guide the users who are doing manual mount point assignment.

Relevant to: rhbz#2234640

