### PR TITLE
storage: fix check for reqpart.addBoot availability

### DIFF
--- a/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
@@ -99,7 +99,7 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
         :param storage: an instance of the Blivet's storage object
         :param data: an instance of kickstart data
         """
-        if not data.reqpart.reqpart:
+        if not data.reqpart.addBoot:
             return
 
         log.debug("Looking for platform-specific requirements.")


### PR DESCRIPTION
This mistake was preventing /boot from not being required in the custom partitioning.

