### PR TITLE
bootloader: Create an installation task for collecting kernel arguments

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -738,21 +738,13 @@ class BootLoader(object):
     def timeout(self, seconds):
         self._timeout = seconds
 
-    def prepare(self, storage):
-        """Prepare the bootloader for the installation.
-
-        FIXME: Move this function into a task.
-        """
+    def prepare(self):
+        """Prepare the bootloader for the installation."""
         bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
         self._update_flags(bootloader_proxy)
         self._apply_password(bootloader_proxy)
         self._apply_timeout(bootloader_proxy)
         self._apply_zipl_secure_boot(bootloader_proxy)
-        self._set_extra_boot_args(bootloader_proxy)
-        self._set_storage_boot_args(storage)
-        self._preserve_some_boot_args()
-        self._set_graphical_boot_args()
-        self._set_security_boot_args()
 
     def _update_flags(self, bootloader_proxy):
         """Update flags."""
@@ -790,8 +782,20 @@ class BootLoader(object):
         log.debug("Applying ZIPL Secure Boot: %s", secure_boot)
         self.secure = secure_boot
 
-    def _set_extra_boot_args(self, bootloader_proxy):
+    def collect_arguments(self, storage):
+        """Collect kernel arguments for the installation.
+
+        FIXME: Move this code out of this class.
+        """
+        self._set_extra_boot_args()
+        self._set_storage_boot_args(storage)
+        self._preserve_some_boot_args()
+        self._set_graphical_boot_args()
+        self._set_security_boot_args()
+
+    def _set_extra_boot_args(self):
         """Set the extra boot args."""
+        bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
         self.boot_args.update(bootloader_proxy.ExtraArguments)
 
     def _set_storage_boot_args(self, storage):

--- a/pyanaconda/modules/storage/bootloader/bootloader.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader.py
@@ -36,7 +36,7 @@ from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.storage.bootloader.bootloader_interface import BootloaderInterface
 from pyanaconda.modules.storage.bootloader.installation import ConfigureBootloaderTask, \
     InstallBootloaderTask, FixZIPLBootloaderTask, FixBTRFSBootloaderTask, RecreateInitrdsTask, \
-    CreateRescueImagesTask, CreateBLSEntriesTask
+    CreateRescueImagesTask, CreateBLSEntriesTask, CollectKernelArgumentsTask
 from pyanaconda.modules.storage.constants import BootloaderMode, ZIPLSecureBoot
 from pyanaconda.modules.storage.storage_subscriber import StorageSubscriberModule
 
@@ -468,6 +468,10 @@ class BootloaderModule(StorageSubscriberModule):
                 payload_type=payload_type,
                 kernel_versions=kernel_versions,
                 sysroot=conf.target.system_root
+            ),
+            CollectKernelArgumentsTask(
+                storage=self.storage,
+                mode=self.bootloader_mode
             ),
             InstallBootloaderTask(
                 storage=self.storage,

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -142,14 +142,15 @@ class InstallBootloaderTask(Task):
             return
 
         try:
+            self._collect_kernel_arguments()
             self._install_boot_loader()
         except BootLoaderError as e:
             log.exception("Bootloader installation has failed: %s", e)
             raise BootloaderInstallationError(str(e)) from None
 
-    def _install_boot_loader(self):
-        """Do the final write of the bootloader."""
-        log.debug("Installing the boot loader.")
+    def _collect_kernel_arguments(self):
+        """Collect kernel arguments."""
+        log.debug("Collecting the kernel arguments.")
 
         stage1_device = self._bootloader.stage1_device
         log.info("boot loader stage1 target device is %s", stage1_device.name)
@@ -157,10 +158,13 @@ class InstallBootloaderTask(Task):
         stage2_device = self._bootloader.stage2_device
         log.info("boot loader stage2 target device is %s", stage2_device.name)
 
-        # Prepare the bootloader for the installation.
-        self._bootloader.prepare(self._storage)
+        self._bootloader.collect_arguments(self._storage)
 
-        # Install the bootloader.
+    def _install_boot_loader(self):
+        """Do the final write of the bootloader."""
+        log.debug("Installing the boot loader.")
+
+        self._bootloader.prepare()
         self._bootloader.write()
 
 

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -37,7 +37,7 @@ log = get_module_logger(__name__)
 
 __all__ = ["ConfigureBootloaderTask", "InstallBootloaderTask", "FixBTRFSBootloaderTask",
            "FixZIPLBootloaderTask", "RecreateInitrdsTask", "CreateRescueImagesTask",
-           "CreateBLSEntriesTask"]
+           "CreateBLSEntriesTask", "CollectKernelArgumentsTask"]
 
 
 class CreateRescueImagesTask(Task):
@@ -105,6 +105,50 @@ class ConfigureBootloaderTask(Task):
         )
 
 
+class CollectKernelArgumentsTask(Task):
+    """Installation task for collecting the kernel arguments."""
+
+    def __init__(self, storage, mode):
+        """Create a new task."""
+        super().__init__()
+        self._storage = storage
+        self._mode = mode
+
+    @property
+    def name(self):
+        """Name of the task."""
+        return "Collect kernel arguments"
+
+    @property
+    def _bootloader(self):
+        """Representation of the bootloader."""
+        return self._storage.bootloader
+
+    def run(self):
+        """Run the task."""
+        if conf.target.is_directory:
+            log.debug("The bootloader installation is disabled for dir installations.")
+            return
+
+        if self._mode == BootloaderMode.DISABLED:
+            log.debug("The bootloader installation is disabled.")
+            return
+
+        if self._mode == BootloaderMode.SKIPPED:
+            log.debug("The bootloader installation is skipped.")
+            return
+
+        log.debug("Collecting the kernel arguments.")
+
+        stage1_device = self._bootloader.stage1_device
+        log.info("boot loader stage1 target device is %s", stage1_device.name)
+
+        stage2_device = self._bootloader.stage2_device
+        log.info("boot loader stage2 target device is %s", stage2_device.name)
+
+        self._bootloader.collect_arguments(self._storage)
+
+
 class InstallBootloaderTask(Task):
     """Installation task for the bootloader."""
 
@@ -141,31 +185,14 @@ class InstallBootloaderTask(Task):
             log.debug("The bootloader installation is skipped.")
             return
 
+        log.debug("Installing the boot loader.")
+
         try:
-            self._collect_kernel_arguments()
-            self._install_boot_loader()
+            self._bootloader.prepare()
+            self._bootloader.write()
         except BootLoaderError as e:
             log.exception("Bootloader installation has failed: %s", e)
             raise BootloaderInstallationError(str(e)) from None
-
-    def _collect_kernel_arguments(self):
-        """Collect kernel arguments."""
-        log.debug("Collecting the kernel arguments.")
-
-        stage1_device = self._bootloader.stage1_device
-        log.info("boot loader stage1 target device is %s", stage1_device.name)
-
-        stage2_device = self._bootloader.stage2_device
-        log.info("boot loader stage2 target device is %s", stage2_device.name)
-
-        self._bootloader.collect_arguments(self._storage)
-
-    def _install_boot_loader(self):
-        """Do the final write of the bootloader."""
-        log.debug("Installing the boot loader.")
-
-        self._bootloader.prepare()
-        self._bootloader.write()
 
 
 class CreateBLSEntriesTask(Task):

--- a/pyanaconda/modules/storage/bootloader/utils.py
+++ b/pyanaconda/modules/storage/bootloader/utils.py
@@ -27,8 +27,7 @@ from pyanaconda.core.product import get_product_name
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ["configure_boot_loader", "install_boot_loader", "recreate_initrds",
-           "create_rescue_images"]
+__all__ = ["configure_boot_loader", "recreate_initrds", "create_rescue_images"]
 
 
 def create_rescue_images(sysroot, kernel_versions):
@@ -192,27 +191,6 @@ def _write_sysconfig_kernel(sysroot, storage):
     f.write("# DEFAULTKERNEL specifies the default kernel package type\n")
     f.write("DEFAULTKERNEL=%s\n" % kernel)
     f.close()
-
-
-def install_boot_loader(storage):
-    """Do the final write of the boot loader.
-
-    :param storage: an instance of the storage
-    :raise: BootLoaderError if the installation fails
-    """
-    log.debug("Installing the boot loader.")
-
-    stage1_device = storage.bootloader.stage1_device
-    log.info("boot loader stage1 target device is %s", stage1_device.name)
-
-    stage2_device = storage.bootloader.stage2_device
-    log.info("boot loader stage2 target device is %s", stage2_device.name)
-
-    # Prepare the bootloader for the installation.
-    storage.bootloader.prepare(storage)
-
-    # Install the bootloader.
-    storage.bootloader.write()
 
 
 def create_bls_entries(sysroot, storage, kernel_versions):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -51,7 +51,7 @@ from pyanaconda.modules.storage.bootloader import BootloaderModule
 from pyanaconda.modules.storage.bootloader.bootloader_interface import BootloaderInterface
 from pyanaconda.modules.storage.bootloader.installation import ConfigureBootloaderTask, \
     InstallBootloaderTask, FixZIPLBootloaderTask, FixBTRFSBootloaderTask, RecreateInitrdsTask, \
-    CreateRescueImagesTask, CreateBLSEntriesTask
+    CreateRescueImagesTask, CreateBLSEntriesTask, CollectKernelArgumentsTask
 
 
 class BootloaderInterfaceTestCase(unittest.TestCase):
@@ -201,6 +201,7 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
         task_classes = [
             CreateRescueImagesTask,
             ConfigureBootloaderTask,
+            CollectKernelArgumentsTask,
             InstallBootloaderTask,
             CreateBLSEntriesTask
         ]
@@ -374,6 +375,20 @@ class BootloaderTasksTestCase(unittest.TestCase):
         assert image.version == version
         assert image.label == "anaconda"
         assert image.device == storage.root_device
+
+    def test_collect_kernel_arguments(self):
+        """Test the collection of the kernel arguments for the installation."""
+        bootloader = Mock()
+        storage = Mock(bootloader=bootloader)
+
+        CollectKernelArgumentsTask(storage, BootloaderMode.DISABLED).run()
+        bootloader.collect_arguments.assert_not_called()
+
+        CollectKernelArgumentsTask(storage, BootloaderMode.SKIPPED).run()
+        bootloader.collect_arguments.assert_not_called()
+
+        CollectKernelArgumentsTask(storage, BootloaderMode.ENABLED).run()
+        bootloader.collect_arguments.assert_called_once_with(storage)
 
     def test_install(self):
         """Test the installation task for the boot loader."""


### PR DESCRIPTION
Use the `CollectKernelArgumentsTask` task to collect kernel arguments
for the installation. This will be used by the `bootupd` support that needs
to be able to collect kernel arguments without installing the bootloader.
See: https://github.com/rhinstaller/anaconda/pull/5298#issuecomment-1822746719).