### PR TITLE
Add a simple NVMe module for NVMe Fabrics support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/modules/storage/fcoe/Makefile
                  pyanaconda/modules/storage/iscsi/Makefile
                  pyanaconda/modules/storage/nvdimm/Makefile
+                 pyanaconda/modules/storage/nvme/Makefile
                  pyanaconda/modules/storage/partitioning/Makefile
                  pyanaconda/modules/storage/partitioning/automatic/Makefile
                  pyanaconda/modules/storage/partitioning/blivet/Makefile

--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -94,6 +94,11 @@ NVDIMM = DBusObjectIdentifier(
     basename="NVDIMM"
 )
 
+NVME = DBusObjectIdentifier(
+    namespace=STORAGE_NAMESPACE,
+    basename="NVMe"
+)
+
 SNAPSHOT = DBusObjectIdentifier(
     namespace=STORAGE_NAMESPACE,
     basename="Snapshot"

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -34,7 +34,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 from pyanaconda.core.util import join_paths, mkdirChain
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.modules.common.constants.objects import ISCSI, FCOE, ZFCP
+from pyanaconda.modules.common.constants.objects import ISCSI, FCOE, ZFCP, NVME
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.installation import StorageInstallationError
 from pyanaconda.modules.common.task import Task
@@ -295,6 +295,9 @@ class WriteConfigurationTask(Task):
 
         zfcp_proxy = STORAGE.get_proxy(ZFCP)
         zfcp_proxy.WriteConfiguration()
+
+        nvme_proxy = STORAGE.get_proxy(NVME)
+        nvme_proxy.WriteConfiguration()
 
         self._write_dasd_conf(storage, sysroot)
 

--- a/pyanaconda/modules/storage/nvme/Makefile.am
+++ b/pyanaconda/modules/storage/nvme/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018  Red Hat, Inc.
+# Copyright (C) 2023  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -14,11 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = disk_initialization disk_selection bootloader partitioning dasd zfcp fcoe nvdimm \
-    snapshot devicetree checker iscsi nvme
-
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-storage_moduledir = $(pkgpyexecdir)/modules/storage
-storage_module_PYTHON = $(srcdir)/*.py
+nvme_moduledir = $(pkgpyexecdir)/modules/storage/nvme
+nvme_module_PYTHON = $(srcdir)/*.py
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/modules/storage/nvme/__init__.py
+++ b/pyanaconda/modules/storage/nvme/__init__.py
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.modules.storage.nvme.nvme import NVMEModule
+
+__all__ = ["NVMEModule"]

--- a/pyanaconda/modules/storage/nvme/nvme.py
+++ b/pyanaconda/modules/storage/nvme/nvme.py
@@ -1,0 +1,54 @@
+#
+# The NVMe module
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from blivet.nvme import nvme
+
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.signal import Signal
+from pyanaconda.core.dbus import DBus
+from pyanaconda.modules.common.base import KickstartBaseModule
+from pyanaconda.modules.common.constants.objects import NVME
+from pyanaconda.modules.storage.nvme.nvme_interface import NVMEInterface
+
+log = get_module_logger(__name__)
+
+
+class NVMEModule(KickstartBaseModule):
+    """The NVMe module."""
+
+    def __init__(self):
+        super().__init__()
+        self.reload_module()
+
+        self.initiator_changed = Signal()
+
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(NVME.object_path, NVMEInterface(self))
+
+    def reload_module(self):
+        """Reload the NVMe module."""
+        log.debug("Start up the NVMe module.")
+        nvme.startup()
+
+    def write_configuration(self):
+        """Write the configuration to sysroot."""
+        log.debug("Write NVMe configuration.")
+        nvme.write(conf.target.system_root)

--- a/pyanaconda/modules/storage/nvme/nvme_interface.py
+++ b/pyanaconda/modules/storage/nvme/nvme_interface.py
@@ -1,0 +1,35 @@
+#
+# DBus interface for the NVMe module.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from dasbus.server.interface import dbus_interface
+from dasbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.modules.common.base import KickstartModuleInterfaceTemplate
+from pyanaconda.modules.common.constants.objects import NVME
+
+
+@dbus_interface(NVME.interface_name)
+class NVMEInterface(KickstartModuleInterfaceTemplate):
+    """DBus interface for the NVMe module."""
+
+    def WriteConfiguration(self):
+        """Write the configuration to sysroot.
+
+        FIXME: This is just a temporary method.
+        """
+        self.implementation.write_configuration()

--- a/pyanaconda/modules/storage/reset.py
+++ b/pyanaconda/modules/storage/reset.py
@@ -22,6 +22,7 @@ from blivet.errors import UnusableConfigurationError
 from blivet.fcoe import fcoe
 from blivet.i18n import _
 from blivet.iscsi import iscsi
+from blivet.nvme import nvme
 from blivet.zfcp import zfcp
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -73,6 +74,7 @@ class ScanDevicesTask(Task):
 
         iscsi.startup()
         fcoe.startup()
+        nvme.startup()
 
         if arch.is_s390():
             zfcp.startup()

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -37,6 +37,7 @@ from pyanaconda.modules.storage.installation import MountFilesystemsTask, Create
 from pyanaconda.modules.storage.iscsi import ISCSIModule
 from pyanaconda.modules.storage.kickstart import StorageKickstartSpecification
 from pyanaconda.modules.storage.nvdimm import NVDIMMModule
+from pyanaconda.modules.storage.nvme import NVMEModule
 from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
 from pyanaconda.modules.storage.partitioning.factory import PartitioningFactory
 from pyanaconda.modules.storage.partitioning.validate import StorageValidateTask
@@ -99,6 +100,9 @@ class StorageService(KickstartService):
 
         self._nvdimm_module = NVDIMMModule()
         self._add_module(self._nvdimm_module)
+
+        self._nvme_module = NVMEModule()
+        self._add_module(self._nvme_module)
 
         self._dasd_module = DASDModule()
         self._add_module(self._dasd_module)

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvme.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_nvme.py
@@ -1,0 +1,41 @@
+#
+# Copyright (C) 2023  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+import unittest
+
+from unittest.mock import patch
+
+from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.modules.storage.nvme import NVMEModule
+from pyanaconda.modules.storage.nvme.nvme_interface import NVMEInterface
+
+
+class NVMEInterfaceTestCase(unittest.TestCase):
+    """Test DBus interface of the NVMe module."""
+
+    def setUp(self):
+        """Set up the module."""
+        self.nvme_module = NVMEModule()
+        self.nvme_interface = NVMEInterface(self.nvme_module)
+
+    @patch('pyanaconda.modules.storage.nvme.nvme.nvme')
+    def test_write_configuration(self, nvme):
+        """Test WriteConfiguration."""
+        self.nvme_interface.WriteConfiguration()
+        nvme.write.assert_called_once_with(conf.target.system_root)


### PR DESCRIPTION
Port of #5328 to RHEL 9. We don't need any additional changes for RHEL, the NVMe module was added to blivet in 3.4.0 (3.6.0 is now required on RHEL 9, we have some additional fixes for the module not yet build for RHEL, but the public `startup` and `write` methods are available since 9.1) and the libblockdev NVMe plugin dependency is covered by depending on the `libblockdev-plugins-all` meta package.
