### PR TITLE
infra: remove noarch from install-env-deps and install-img-deps

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -181,7 +181,6 @@ for live installations.
 
 %package install-env-deps
 Summary: Installation environment specific dependencies
-BuildArchitectures: noarch
 Requires: udisks2-iscsi
 Requires: libblockdev-plugins-all >= %{libblockdevver}
 %if ! 0%{?rhel}
@@ -230,7 +229,6 @@ dependencies as well.
 
 %package install-img-deps
 Summary: Installation image specific dependencies
-BuildArchitectures: noarch
 # This package must have no weak dependencies.
 # Pull in most stuff with the -env- metapackage
 Requires: anaconda-install-env-deps = %{version}-%{release}


### PR DESCRIPTION
See their content, it's arch dependent.

