### PR TITLE
bootupd: Use --write-uuid

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -515,7 +515,7 @@ class ConfigureBootloader(Task):
                 "backend",
                 "install",
                 "--auto",
-                "--with-static-configs",
+                "--write-uuid",
                 "--device",
                 dev_data.path,
                 "/",

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -777,7 +777,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             exec_mock.assert_has_calls([
                 call(
                     "bootupctl",
-                    ["backend", "install", "--auto", "--with-static-configs", "--device",
+                    ["backend", "install", "--auto", "--write-uuid", "--device",
                      "/dev/btldr-drv", "/"],
                     root=sysroot
                 ),


### PR DESCRIPTION
This is an even newer behavior that takes over handling of the "UUID stamp files", which we want in general instead of using the static labels.

Note `--write-uuid` implies `--with-static-configs`.

This should fix this use case:

```
clearpart --all --initlabel --disklabel=gpt
reqpart --add-boot
part / --grow --fstype xfs
```

Whereas right now we require:

```
clearpart --all --initlabel --disklabel=gpt
reqpart
part /boot --size=1000  --fstype=ext4 --label=boot
part / --grow --fstype xfs
```

Specifically the `--label=boot`.
