### PR TITLE
Boot not required

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -463,6 +463,8 @@ class MountPointConstraintsData(DBusData):
         self._required_filesystem_type = ""
         self._encryption_allowed = False
         self._logical_volume_allowed = False
+        self._required = False
+        self._recommended = False
 
     @property
     def mount_point(self) -> Str:
@@ -511,3 +513,27 @@ class MountPointConstraintsData(DBusData):
     @logical_volume_allowed.setter
     def logical_volume_allowed(self, logical_volume_allowed: Bool):
         self._logical_volume_allowed = logical_volume_allowed
+
+    @property
+    def required(self) -> Bool:
+        """Whether this mount point is required
+
+        :return: bool
+        """
+        return self._required
+
+    @required.setter
+    def required(self, required: Bool):
+        self._required = required
+
+    @property
+    def recommended(self) -> Bool:
+        """Whether this mount point is recommended
+
+        :return: bool
+        """
+        return self._recommended
+
+    @recommended.setter
+    def recommended(self, recommended: Bool):
+        self._recommended = recommended

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -455,10 +455,8 @@ class OSData(DBusData):
         return self.mount_points.get("/")
 
 
-class RequiredMountPointData(DBusData):
-    """Constrains (filesystem and device types allowed) for mount points required
-       for the installed system
-    """
+class MountPointConstraintsData(DBusData):
+    """Constrains (filesystem and device types allowed) for mount points"""
 
     def __init__(self):
         self._mount_point = ""

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -26,7 +26,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError
 from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
-    DeviceFormatData, OSData, RequiredMountPointData
+    DeviceFormatData, OSData, MountPointConstraintsData
 from pyanaconda.modules.storage.devicetree.utils import get_required_device_size, \
     get_supported_filesystems
 from pyanaconda.modules.storage.platform import platform
@@ -474,9 +474,9 @@ class DeviceTreeViewer(ABC):
         """Get the mount point data.
 
         :param spec: an instance of PartSpec
-        :return: an instance of RequiredMountPointData
+        :return: an instance of MountPointConstraintsData
         """
-        data = RequiredMountPointData()
+        data = MountPointConstraintsData()
         data.mount_point = spec.mountpoint or ""
         data.required_filesystem_type = spec.fstype or ""
         data.encryption_allowed = spec.encrypted
@@ -487,16 +487,33 @@ class DeviceTreeViewer(ABC):
     def get_required_mount_points(self):
         """Get list of required mount points for the current platform
 
-        This includes mount points required to boot (e.g. /boot and /boot/efi)
+        This includes mount points required to boot (e.g. /boot/efi)
         and the / partition which is always considered to be required.
 
-        :return: a list of mount points
+        FIXME in general /boot is not required, just recommended. Depending on
+        the filesystem on the root partition it may be required (ie crypted
+        root).
+
+        :return: a list of mount points with its constraints
         """
         root_partition = PartSpec(mountpoint="/", lv=True, thin=True, encrypted=True)
-        # FIXME in general /boot is not required, just recommended. Depending
-        # on the filesystem on the root partition it may be required (ie
-        # crypted root).
         ret = list(map(self._get_platform_mount_point_data,
                        [p for p in platform.partitions if p.mountpoint and p.mountpoint != "/boot"]
                        + [root_partition]))
+        return ret
+
+    def get_recommended_mount_points(self):
+        """Get list of recommended mount points for the current platform
+
+        Currently it contains only /boot partition if it is default the for
+        platform.
+
+        :return: a list of mount points with its constraints
+        """
+        # FIXME in general /boot is not required, just recommended. Depending
+        # on the filesystem on the root partition it may be required (ie
+        # crypted root).
+        recommended = ["/boot"]
+        ret = list(map(self._get_platform_mount_point_data,
+                       [p for p in platform.partitions if p.mountpoint in recommended]))
         return ret

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -493,6 +493,10 @@ class DeviceTreeViewer(ABC):
         :return: a list of mount points
         """
         root_partition = PartSpec(mountpoint="/", lv=True, thin=True, encrypted=True)
+        # FIXME in general /boot is not required, just recommended. Depending
+        # on the filesystem on the root partition it may be required (ie
+        # crypted root).
         ret = list(map(self._get_platform_mount_point_data,
-                       [p for p in platform.partitions if p.mountpoint] + [root_partition]))
+                       [p for p in platform.partitions if p.mountpoint and p.mountpoint != "/boot"]
+                       + [root_partition]))
         return ret

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -22,7 +22,7 @@ from pyanaconda.modules.common.base.base_template import InterfaceTemplate
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_VIEWER
 from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
-    DeviceFormatData, OSData, RequiredMountPointData
+    DeviceFormatData, OSData, MountPointConstraintsData
 
 __all__ = ["DeviceTreeViewerInterface"]
 
@@ -196,10 +196,25 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
     def GetRequiredMountPoints(self) -> List[Structure]:
         """Get list of required mount points for the current platform
 
-        This includes mount points required to boot (e.g. /boot and /boot/efi)
+        This includes mount points required to boot (e.g. /boot/efi)
         and the / partition which is always considered to be required.
 
-        :return: a list of mount points
+        FIXME in general /boot is not required, just recommended. Depending on
+        the filesystem on the root partition it may be required (ie crypted
+        root).
+
+        :return: a list of mount points with its constraints
         """
-        return RequiredMountPointData.to_structure_list(
+        return MountPointConstraintsData.to_structure_list(
             self.implementation.get_required_mount_points())
+
+    def GetRecommendedMountPoints(self) -> List[Structure]:
+        """Get list of recommended mount points for the current platform
+
+        Currently it contains only /boot partition if it is default the for
+        platform.
+
+        :return: a list of mount points with its constraints
+        """
+        return MountPointConstraintsData.to_structure_list(
+            self.implementation.get_recommended_mount_points())

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -193,6 +193,20 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         """
         return OSData.to_structure_list(self.implementation.get_existing_systems())
 
+    # FIXME: remove the replaced API
+    def GetMountPointConstraints(self) -> List[Structure]:
+        """Get list of constraints on mountpoints for the current platform
+
+        Also provides hints if the partition is required or recommended.
+
+        This includes mount points required to boot (e.g. /boot/efi, /boot)
+        and the / partition which is always considered to be required.
+
+        :return: a list of mount points with its constraints
+        """
+        return MountPointConstraintsData.to_structure_list(
+            self.implementation.get_mount_point_constraints())
+
     def GetRequiredMountPoints(self) -> List[Structure]:
         """Get list of required mount points for the current platform
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -36,7 +36,7 @@ from blivet.size import Size
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.core.kernel import KernelArguments
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError, MountFilesystemError
-from pyanaconda.modules.common.structures.storage import DeviceFormatData, RequiredMountPointData
+from pyanaconda.modules.common.structures.storage import DeviceFormatData, MountPointConstraintsData
 from pyanaconda.modules.storage.devicetree import DeviceTreeModule, create_storage, utils
 from pyanaconda.modules.storage.devicetree.devicetree_interface import DeviceTreeInterface
 from pyanaconda.modules.storage.devicetree.populate import FindDevicesTask
@@ -855,7 +855,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         assert isinstance(result, list)
         assert len(result) != 0
 
-        result = RequiredMountPointData.from_structure_list(self.interface.GetRequiredMountPoints())
+        result = MountPointConstraintsData.from_structure_list(self.interface.GetRequiredMountPoints())
         for mp in result:
             assert mp.mount_point is not None
             assert mp.required_filesystem_type is not None
@@ -868,6 +868,19 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         assert root.mount_point == "/"
         assert root.required_filesystem_type == ""
 
+    def test_get_recommended_mount_points(self):
+        """Test GetRecommendedMountPoints."""
+        result = self.interface.GetRecommendedMountPoints()
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+        result = MountPointConstraintsData.from_structure_list(self.interface.GetRecommendedMountPoints())
+        boot = result[0]
+        assert boot is not None
+        assert boot.encryption_allowed is False
+        assert boot.logical_volume_allowed is False
+        assert boot.mount_point == "/boot"
+        assert boot.required_filesystem_type == ""
 
 class DeviceTreeTasksTestCase(unittest.TestCase):
     """Test the storage tasks."""


### PR DESCRIPTION
Related to the webui PR: TODO

In the PR I was first adding `GetRecommendedMountPoints` to the existing `GetRequiredMountPoints` but in the end would like to use the newly added `GetMountPointConstraints` that would replace both of them (after merging the webui part which is replacing the API calls).

TODO:
- [ ] update tests