### PR TITLE
Make boot not required

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -450,10 +450,8 @@ class OSData(DBusData):
         return self.mount_points.get("/")
 
 
-class RequiredMountPointData(DBusData):
-    """Constrains (filesystem and device types allowed) for mount points required
-       for the installed system
-    """
+class MountPointConstraintsData(DBusData):
+    """Constrains (filesystem and device types allowed) for mount points"""
 
     def __init__(self):
         self._mount_point = ""

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -458,6 +458,8 @@ class MountPointConstraintsData(DBusData):
         self._required_filesystem_type = ""
         self._encryption_allowed = False
         self._logical_volume_allowed = False
+        self._required = False
+        self._recommended = False
 
     @property
     def mount_point(self) -> Str:
@@ -506,3 +508,27 @@ class MountPointConstraintsData(DBusData):
     @logical_volume_allowed.setter
     def logical_volume_allowed(self, logical_volume_allowed: Bool):
         self._logical_volume_allowed = logical_volume_allowed
+
+    @property
+    def required(self) -> Bool:
+        """Whether this mount point is required
+
+        :return: bool
+        """
+        return self._required
+
+    @required.setter
+    def required(self, required: Bool):
+        self._required = required
+
+    @property
+    def recommended(self) -> Bool:
+        """Whether this mount point is recommended
+
+        :return: bool
+        """
+        return self._recommended
+
+    @recommended.setter
+    def recommended(self, recommended: Bool):
+        self._recommended = recommended

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -541,19 +541,3 @@ class DeviceTreeViewer(ABC):
                        [p for p in platform.partitions if p.mountpoint and p.mountpoint != "/boot"]
                        + [root_partition]))
         return ret
-
-    def get_recommended_mount_points(self):
-        """Get list of recommended mount points for the current platform
-
-        Currently it contains only /boot partition if it is default the for
-        platform.
-
-        :return: a list of mount points with its constraints
-        """
-        # FIXME in general /boot is not required, just recommended. Depending
-        # on the filesystem on the root partition it may be required (ie
-        # crypted root).
-        recommended = ["/boot"]
-        ret = list(map(self._get_platform_mount_point_data,
-                       [p for p in platform.partitions if p.mountpoint in recommended]))
-        return ret

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -485,6 +485,10 @@ class DeviceTreeViewer(ABC):
         :return: a list of mount points
         """
         root_partition = PartSpec(mountpoint="/", lv=True, thin=True, encrypted=True)
+        # FIXME in general /boot is not required, just recommended. Depending
+        # on the filesystem on the root partition it may be required (ie
+        # crypted root).
         ret = list(map(self._get_platform_mount_point_data,
-                       [p for p in platform.partitions if p.mountpoint] + [root_partition]))
+                       [p for p in platform.partitions if p.mountpoint and p.mountpoint != "/boot"]
+                       + [root_partition]))
         return ret

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -462,6 +462,54 @@ class DeviceTreeViewer(ABC):
         }
         return data
 
+    def _get_mount_point_constraints_data(self, spec):
+        """Get the mount point data.
+
+        :param spec: an instance of PartSpec
+        :return: an instance of MountPointConstraintsData
+        """
+        data = MountPointConstraintsData()
+        data.mount_point = spec.mountpoint or ""
+        data.required_filesystem_type = spec.fstype or ""
+        data.encryption_allowed = spec.encrypted
+        data.logical_volume_allowed = spec.lv
+
+        return data
+
+    def get_mount_point_constraints(self):
+        """Get list of constraints on mountpoints for the current platform
+
+        Also provides hints if the partition is required or recommended.
+
+        This includes mount points required to boot (e.g. /boot/efi, /boot)
+        and the / partition which is always considered to be required.
+
+        FIXME /boot can be required in some cases, depending on the filesystem
+        on the root partition (ie crypted root).
+
+        :return: a list of mount points with its constraints
+        """
+
+        constraints = []
+
+        # Root partition is required
+        root_partition = PartSpec(mountpoint="/", lv=True, thin=True, encrypted=True)
+        root_constraint = self._get_mount_point_constraints_data(root_partition)
+        root_constraint.required = True
+        constraints.append(root_constraint)
+
+        # Platform partitions are required except for /boot partiotion which is recommended
+        for p in platform.partitions:
+            if p.mountpoint:
+                constraint = self._get_mount_point_constraints_data(p)
+                if p.mountpoint == "/boot":
+                    constraint.recommended = True
+                else:
+                    constraint.required = True
+                constraints.append(constraint)
+
+        return constraints
+
     def _get_platform_mount_point_data(self, spec):
         """Get the mount point data.
 

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -22,7 +22,7 @@ from pyanaconda.modules.common.base.base_template import InterfaceTemplate
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_VIEWER
 from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
-    DeviceFormatData, OSData, RequiredMountPointData
+    DeviceFormatData, OSData, MountPointConstraintsData
 
 __all__ = ["DeviceTreeViewerInterface"]
 
@@ -196,10 +196,25 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
     def GetRequiredMountPoints(self) -> List[Structure]:
         """Get list of required mount points for the current platform
 
-        This includes mount points required to boot (e.g. /boot and /boot/efi)
+        This includes mount points required to boot (e.g. /boot/efi)
         and the / partition which is always considered to be required.
 
-        :return: a list of mount points
+        FIXME in general /boot is not required, just recommended. Depending on
+        the filesystem on the root partition it may be required (ie crypted
+        root).
+
+        :return: a list of mount points with its constraints
         """
-        return RequiredMountPointData.to_structure_list(
+        return MountPointConstraintsData.to_structure_list(
             self.implementation.get_required_mount_points())
+
+    def GetRecommendedMountPoints(self) -> List[Structure]:
+        """Get list of recommended mount points for the current platform
+
+        Currently it contains only /boot partition if it is default the for
+        platform.
+
+        :return: a list of mount points with its constraints
+        """
+        return MountPointConstraintsData.to_structure_list(
+            self.implementation.get_recommended_mount_points())

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -221,14 +221,3 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         """
         return MountPointConstraintsData.to_structure_list(
             self.implementation.get_required_mount_points())
-
-    def GetRecommendedMountPoints(self) -> List[Structure]:
-        """Get list of recommended mount points for the current platform
-
-        Currently it contains only /boot partition if it is default the for
-        platform.
-
-        :return: a list of mount points with its constraints
-        """
-        return MountPointConstraintsData.to_structure_list(
-            self.implementation.get_recommended_mount_points())

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -193,6 +193,20 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         """
         return OSData.to_structure_list(self.implementation.get_existing_systems())
 
+    # FIXME: remove the replaced API
+    def GetMountPointConstraints(self) -> List[Structure]:
+        """Get list of constraints on mountpoints for the current platform
+
+        Also provides hints if the partition is required or recommended.
+
+        This includes mount points required to boot (e.g. /boot/efi, /boot)
+        and the / partition which is always considered to be required.
+
+        :return: a list of mount points with its constraints
+        """
+        return MountPointConstraintsData.to_structure_list(
+            self.implementation.get_mount_point_constraints())
+
     def GetRequiredMountPoints(self) -> List[Structure]:
         """Get list of required mount points for the current platform
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -36,7 +36,8 @@ from blivet.size import Size
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.core.kernel import KernelArguments
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError, MountFilesystemError
-from pyanaconda.modules.common.structures.storage import DeviceFormatData, RequiredMountPointData
+from pyanaconda.modules.common.structures.storage import DeviceFormatData, \
+    MountPointConstraintsData
 from pyanaconda.modules.storage.devicetree import DeviceTreeModule, create_storage, utils
 from pyanaconda.modules.storage.devicetree.devicetree_interface import DeviceTreeInterface
 from pyanaconda.modules.storage.devicetree.populate import FindDevicesTask
@@ -835,7 +836,9 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         assert isinstance(result, list)
         assert len(result) != 0
 
-        result = RequiredMountPointData.from_structure_list(self.interface.GetRequiredMountPoints())
+        result = MountPointConstraintsData.from_structure_list(
+            self.interface.GetRequiredMountPoints()
+        )
         for mp in result:
             assert mp.mount_point is not None
             assert mp.required_filesystem_type is not None
@@ -848,6 +851,19 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         assert root.mount_point == "/"
         assert root.required_filesystem_type == ""
 
+    def test_get_recommended_mount_points(self):
+        """Test GetRecommendedMountPoints."""
+        result = self.interface.GetRecommendedMountPoints()
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+        result = MountPointConstraintsData.from_structure_list(self.interface.GetRecommendedMountPoints())
+        boot = result[0]
+        assert boot is not None
+        assert boot.encryption_allowed is False
+        assert boot.logical_volume_allowed is False
+        assert boot.mount_point == "/boot"
+        assert boot.required_filesystem_type == ""
 
 class DeviceTreeTasksTestCase(unittest.TestCase):
     """Test the storage tasks."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -830,6 +830,29 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         self.interface.SetDeviceMountOptions("dev1", "")
         assert dev1.format.options == "defaults"
 
+    def test_get_mount_point_constraints(self):
+        """Test GetMountPointConstraints."""
+        result = self.interface.GetMountPointConstraints()
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+        result = MountPointConstraintsData.from_structure_list(
+            self.interface.GetMountPointConstraints()
+        )
+        for mp in result:
+            assert mp.mount_point is not None
+            assert mp.required_filesystem_type is not None
+
+        # we are always adding / so it's a good candidate for testing
+        root = next(r for r in result if r.mount_point == "/")
+        assert root is not None
+        assert root.encryption_allowed is True
+        assert root.logical_volume_allowed is True
+        assert root.mount_point == "/"
+        assert root.required_filesystem_type == ""
+        assert root.required is True
+        assert root.recommended is False
+
     def test_get_required_mount_points(self):
         """Test GetRequiredMountPoints."""
         result = self.interface.GetRequiredMountPoints()

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -874,20 +874,6 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         assert root.mount_point == "/"
         assert root.required_filesystem_type == ""
 
-    def test_get_recommended_mount_points(self):
-        """Test GetRecommendedMountPoints."""
-        result = self.interface.GetRecommendedMountPoints()
-        assert isinstance(result, list)
-        assert len(result) == 1
-
-        result = MountPointConstraintsData.from_structure_list(self.interface.GetRecommendedMountPoints())
-        boot = result[0]
-        assert boot is not None
-        assert boot.encryption_allowed is False
-        assert boot.logical_volume_allowed is False
-        assert boot.mount_point == "/boot"
-        assert boot.required_filesystem_type == ""
-
 class DeviceTreeTasksTestCase(unittest.TestCase):
     """Test the storage tasks."""
 


### PR DESCRIPTION
Related to the webui PR: https://github.com/rhinstaller/anaconda-webui/pull/95

In the PR I was first adding `GetRecommendedMountPoints` to the existing `GetRequiredMountPoints` but in the end I am instesd adding more generic `GetMountPointConstraints` that would replace both of them (after merging the webui part which is replacing the API calls).