### PR TITLE
RHEL-9 Block `makebumpver` with any bad commit

### DIFF
--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -324,7 +324,12 @@ class MakeBumpVer:
                 continue
 
             if self.rhel:
-                bad, bugs = self._check_rhel_issues(commit, summary, body, author)
+                bad_commit, bugs = self._check_rhel_issues(commit, summary, body, author)
+
+                # If one of the commits were bad mark whole set as bad
+                if bad_commit:
+                    bad = True
+
                 rpm_log.append(("%s (%s)" % (summary.strip(), author), list(bugs)))
             else:
                 rpm_log.append(("%s (%s)" % (summary.strip(), author), None))


### PR DESCRIPTION
Current implementation was wrong. It was resolving the whole transaction based on the last commit.

The `bad` variable is set for each commit check, so the result of the whole check is set by the last commit.

Backport of https://github.com/rhinstaller/anaconda/pull/5378