### PR TITLE
Make boot not required 2

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -450,16 +450,16 @@ class OSData(DBusData):
         return self.mount_points.get("/")
 
 
-class RequiredMountPointData(DBusData):
-    """Constrains (filesystem and device types allowed) for mount points required
-       for the installed system
-    """
+class MountPointConstraintsData(DBusData):
+    """Constrains (filesystem and device types allowed) for mount points"""
 
     def __init__(self):
         self._mount_point = ""
         self._required_filesystem_type = ""
         self._encryption_allowed = False
         self._logical_volume_allowed = False
+        self._required = False
+        self._recommended = False
 
     @property
     def mount_point(self) -> Str:
@@ -508,3 +508,27 @@ class RequiredMountPointData(DBusData):
     @logical_volume_allowed.setter
     def logical_volume_allowed(self, logical_volume_allowed: Bool):
         self._logical_volume_allowed = logical_volume_allowed
+
+    @property
+    def required(self) -> Bool:
+        """Whether this mount point is required
+
+        :return: bool
+        """
+        return self._required
+
+    @required.setter
+    def required(self, required: Bool):
+        self._required = required
+
+    @property
+    def recommended(self) -> Bool:
+        """Whether this mount point is recommended
+
+        :return: bool
+        """
+        return self._recommended
+
+    @recommended.setter
+    def recommended(self, recommended: Bool):
+        self._recommended = recommended

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -484,6 +484,9 @@ class DeviceTreeViewer(ABC):
         This includes mount points required to boot (e.g. /boot/efi, /boot)
         and the / partition which is always considered to be required.
 
+        /boot is not required in general but can be required in some cases,
+        depending on the filesystem on the root partition (ie crypted root).
+
         :return: a list of mount points with its constraints
         """
 
@@ -499,7 +502,10 @@ class DeviceTreeViewer(ABC):
         for p in platform.partitions:
             if p.mountpoint:
                 constraint = self._get_mount_point_constraints_data(p)
-                constraint.required = True
+                if p.mountpoint == "/boot":
+                    constraint.recommended = True
+                else:
+                    constraint.required = True
                 constraints.append(constraint)
 
         return constraints

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -22,7 +22,7 @@ from pyanaconda.modules.common.base.base_template import InterfaceTemplate
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.constants.interfaces import DEVICE_TREE_VIEWER
 from pyanaconda.modules.common.structures.storage import DeviceData, DeviceActionData, \
-    DeviceFormatData, OSData, RequiredMountPointData
+    DeviceFormatData, OSData, MountPointConstraintsData
 
 __all__ = ["DeviceTreeViewerInterface"]
 
@@ -193,13 +193,27 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         """
         return OSData.to_structure_list(self.implementation.get_existing_systems())
 
+    # FIXME: remove the replaced API
+    def GetMountPointConstraints(self) -> List[Structure]:
+        """Get list of constraints on mountpoints for the current platform
+
+        Also provides hints if the partition is required or recommended.
+
+        This includes mount points required to boot (e.g. /boot/efi, /boot)
+        and the / partition which is always considered to be required.
+
+        :return: a list of mount points with its constraints
+        """
+        return MountPointConstraintsData.to_structure_list(
+            self.implementation.get_mount_point_constraints())
+
     def GetRequiredMountPoints(self) -> List[Structure]:
         """Get list of required mount points for the current platform
 
         This includes mount points required to boot (e.g. /boot and /boot/efi)
         and the / partition which is always considered to be required.
 
-        :return: a list of mount points
+        :return: a list of mount points with its constraints
         """
-        return RequiredMountPointData.to_structure_list(
+        return MountPointConstraintsData.to_structure_list(
             self.implementation.get_required_mount_points())

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -36,7 +36,8 @@ from blivet.size import Size
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.core.kernel import KernelArguments
 from pyanaconda.modules.common.errors.storage import UnknownDeviceError, MountFilesystemError
-from pyanaconda.modules.common.structures.storage import DeviceFormatData, RequiredMountPointData
+from pyanaconda.modules.common.structures.storage import DeviceFormatData, \
+    MountPointConstraintsData
 from pyanaconda.modules.storage.devicetree import DeviceTreeModule, create_storage, utils
 from pyanaconda.modules.storage.devicetree.devicetree_interface import DeviceTreeInterface
 from pyanaconda.modules.storage.devicetree.populate import FindDevicesTask
@@ -829,13 +830,38 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         self.interface.SetDeviceMountOptions("dev1", "")
         assert dev1.format.options == "defaults"
 
+    def test_get_mount_point_constraints(self):
+        """Test GetMountPointConstraints."""
+        result = self.interface.GetMountPointConstraints()
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+        result = MountPointConstraintsData.from_structure_list(
+            self.interface.GetMountPointConstraints()
+        )
+        for mp in result:
+            assert mp.mount_point is not None
+            assert mp.required_filesystem_type is not None
+
+        # we are always adding / so it's a good candidate for testing
+        root = next(r for r in result if r.mount_point == "/")
+        assert root is not None
+        assert root.encryption_allowed is True
+        assert root.logical_volume_allowed is True
+        assert root.mount_point == "/"
+        assert root.required_filesystem_type == ""
+        assert root.required is True
+        assert root.recommended is False
+
     def test_get_required_mount_points(self):
         """Test GetRequiredMountPoints."""
         result = self.interface.GetRequiredMountPoints()
         assert isinstance(result, list)
         assert len(result) != 0
 
-        result = RequiredMountPointData.from_structure_list(self.interface.GetRequiredMountPoints())
+        result = MountPointConstraintsData.from_structure_list(
+            self.interface.GetRequiredMountPoints()
+        )
         for mp in result:
             assert mp.mount_point is not None
             assert mp.required_filesystem_type is not None


### PR DESCRIPTION
This is a take on https://github.com/rhinstaller/anaconda/pull/5372 keeping compatibility with current webui. The code is the same as in the PR, just the old API is not changed (/boot is still required in the old API)
The tests should now pass.