### PR TITLE
infra: packit: get version from specfile

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -49,7 +49,6 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-rawhide
-      - fedora-eln
 
   - job: copr_build
     trigger: commit

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -43,7 +43,6 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-rawhide
-      - fedora-eln
 
   - job: copr_build
     trigger: commit


### PR DESCRIPTION
https://copr.fedorainfracloud.org/coprs/packit/rhinstaller-anaconda-5380/builds/

