### PR TITLE
Do not use blivet COPR for container builds

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -42,8 +42,6 @@ RUN set -ex; \
     fi; \
     BRANCH=${BRANCH#fedora-}; \
     dnf copr enable -y ${copr_repo} fedora-${BRANCH}-x86_64; \
-    dnf copr enable -y @storage/blivet-daily fedora-${BRANCH}-x86_64; \
-    dnf copr enable -y @storage/udisks-daily fedora-${BRANCH}-x86_64; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
   fi; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -45,8 +45,6 @@ RUN set -ex; \
     fi; \
     BRANCH=${BRANCH#fedora-}; \
     dnf copr enable -y ${copr_repo} fedora-${BRANCH}-x86_64; \
-    dnf copr enable -y @storage/blivet-daily fedora-${BRANCH}-x86_64; \
-    dnf copr enable -y @storage/udisks-daily fedora-${BRANCH}-x86_64; \
   else \
     dnf copr enable -y ${copr_repo} fedora-eln-x86_64; \
   fi; \


### PR DESCRIPTION
Blivet project is building COPR daily builds always from `master` branch. However, Fedora-39 Anaconda is not compatible with `master` blivet because of removal of NVDIMM support.

This will fix container builds for Fedora-39.