### PR TITLE
Fix network spokes connectivity check

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1540,7 +1540,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         # TODO: check also if source requires updates when implemented
         # If we can't configure network, don't require it
         return (not conf.system.can_configure_network
-                or self._network_module.GetActivatedInterfaces())
+                or self._network_module.Connected)
 
     @property
     def mandatory(self):
@@ -1691,7 +1691,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
     @property
     def completed(self):
         return (not conf.system.can_configure_network
-                or self._network_module.GetActivatedInterfaces()
+                or self._network_module.Connected
                 or not (self.payload.source_type != conf.payload.default_source
                         and self.payload.needs_network))
 

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -255,7 +255,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         """ Check whether this spoke is complete or not."""
         # If we can't configure network, don't require it
         return (not conf.system.can_configure_network
-                or self._network_module.GetActivatedInterfaces())
+                or self._network_module.Connected)
 
     @property
     def mandatory(self):


### PR DESCRIPTION
Since NetworkManager 1.41.6 or RHEL 9.2, NM manages lo, so GetActivatedInterfaces() returns at least ['lo']. Use 'Connected' as that's we really want to know anyway.

This was only tested by patching an Alma 9.3 ISO