### PR TITLE
liveinst: bubble more user env variables through anaconda to the webui

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -22,13 +22,18 @@
 # unprivileged, restart running as root.
 if [ "$(id -u)" -ne 0 ]; then
     xhost +si:localuser:root
-    unset XAUTHORITY
     pkexec "$0" "$@"
 fi
 
-# pkexec clears DBUS_SESSION_BUS_ADDRESS from environment
-if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
-    export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${PKEXEC_UID}/bus
+
+# pkexec clears the environment, so get it back
+if [ -n "${PKEXEC_UID}" ]; then
+    INSTALLER_USER=$(id -n -u "${PKEXEC_UID}")
+    readarray -t user_environment < <(pkexec --user "${INSTALLER_USER}" env XDG_RUNTIME_DIR="/run/user/${PKEXEC_UID}" systemctl --user show-environment)
+
+    for variable in "${user_environment[@]}"; do
+        export "$variable"
+    done
 fi
 
 # Allow running another command in the place of anaconda, but in this same


### PR DESCRIPTION
In particular, we need XDG_CURRENT_DESKTOP, but this commit brings it all through, so firefox runs in an environment as close to getting run directly by the live user as possible.

