### PR TITLE
Remove the timezone map from the Time & Date spoke

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,7 +35,6 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libarchivever 3.0.4
 %define libblockdevver 2.1
 %define libreportanacondaver 2.0.21-1
-%define libtimezonemapver 0.4.1-2
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
@@ -70,7 +69,6 @@ BuildRequires: libarchive-devel >= %{libarchivever}
 %ifarch s390 s390x
 BuildRequires: s390utils-devel
 %endif
-BuildRequires: libtimezonemap-devel >= %{libtimezonemapver}
 
 # Tools used by the widgets resource bundle generation
 BuildRequires: gdk-pixbuf2-devel
@@ -278,7 +276,6 @@ Requires: adwaita-icon-theme
 Requires: tigervnc-server-minimal
 Requires: libxklavier >= %{libxklavierver}
 Requires: libgnomekbd
-Requires: libtimezonemap >= %{libtimezonemapver}
 Requires: nm-connection-editor
 %ifnarch s390 s390x
 Requires: NetworkManager-wifi

--- a/docs/release-notes/redesign_gui_time_date_spoke.rst
+++ b/docs/release-notes/redesign_gui_time_date_spoke.rst
@@ -1,0 +1,11 @@
+:Type: GUI
+:Summary: Redesign the Time & Date spoke in GUI
+
+:Description:
+    The timezone map was removed from the Time & Date spoke in the GKT-based user interface
+    and the spoke was redesigned to accommodate the changes. The installer no longer depends
+    on the the ``libtimezonemap`` package.
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/issues/5404
+    - https://github.com/rhinstaller/anaconda/discussions/5355

--- a/pyanaconda/timezone.py
+++ b/pyanaconda/timezone.py
@@ -117,20 +117,38 @@ def get_all_regions_and_timezones():
     Get a dictionary mapping the regions to the list of their timezones.
 
     :rtype: dict
-
     """
-
     result = OrderedDict()
 
     for tz in sorted(all_timezones()):
-        parts = tz.split("/", 1)
+        region, city = parse_timezone(tz)
 
-        if len(parts) > 1:
-            if parts[0] not in result:
-                result[parts[0]] = set()
-            result[parts[0]].add(parts[1])
+        if region and city:
+            result.setdefault(region, set())
+            result[region].add(city)
 
     return result
+
+
+def parse_timezone(timezone):
+    """Parse the specified timezone.
+
+    Return empty strings if the timezone cannot be parsed.
+
+    :return: a region and a city
+    :rtype: a tuple of strings
+    """
+    try:
+        region, city = timezone.split("/", 1)
+
+        if region and city:
+            return region, city
+
+    except ValueError:
+        pass
+
+    log.debug("Invalid timezone: %s", timezone)
+    return "", ""
 
 
 def is_valid_timezone(timezone):

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.glade
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
@@ -12,17 +12,17 @@
     </columns>
   </object>
   <object class="GtkTreeModelFilter" id="citiesFilter">
-    <property name="child_model">cities</property>
+    <property name="child-model">cities</property>
   </object>
   <object class="GtkEntryCompletion" id="cityCompletion">
     <property name="model">citiesFilter</property>
-    <property name="inline_completion">True</property>
+    <property name="inline-completion">True</property>
     <signal name="match-selected" handler="on_completion_match_selected" object="cityCombobox" swapped="no"/>
   </object>
   <object class="GtkImage" id="configImage">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">system-run-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">system-run-symbolic</property>
   </object>
   <object class="GtkListStore" id="days">
     <columns>
@@ -33,22 +33,22 @@
     </columns>
   </object>
   <object class="GtkTreeModelFilter" id="daysFilter">
-    <property name="child_model">days</property>
+    <property name="child-model">days</property>
   </object>
   <object class="GtkImage" id="downImage">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">go-down-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">go-down-symbolic</property>
   </object>
   <object class="GtkImage" id="downImage1">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">go-down-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">go-down-symbolic</property>
   </object>
   <object class="GtkImage" id="downImage2">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">go-down-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">go-down-symbolic</property>
   </object>
   <object class="GtkListStore" id="months">
     <columns>
@@ -68,39 +68,40 @@
   </object>
   <object class="GtkEntryCompletion" id="regionCompletion">
     <property name="model">regions</property>
-    <property name="inline_completion">True</property>
+    <property name="inline-completion">True</property>
     <signal name="match-selected" handler="on_completion_match_selected" object="regionCombobox" swapped="no"/>
   </object>
   <object class="GtkImage" id="upImage">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">go-up-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">go-up-symbolic</property>
   </object>
   <object class="GtkImage" id="upImage1">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">go-up-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">go-up-symbolic</property>
   </object>
   <object class="GtkImage" id="upImage2">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">go-up-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">go-up-symbolic</property>
   </object>
   <object class="AnacondaSpokeWindow" id="datetimeWindow">
-    <property name="can_focus">False</property>
-    <property name="window_name" translatable="yes">TIME &amp; DATE</property>
+    <property name="can-focus">False</property>
+    <property name="window-name" translatable="yes">TIME &amp; DATE</property>
     <signal name="button-clicked" handler="on_back_clicked" swapped="no"/>
     <child internal-child="main_box">
       <object class="GtkBox" id="AnacondaSpokeWindow-main_box1">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <child internal-child="nav_box">
           <object class="GtkEventBox" id="AnacondaSpokeWindow-nav_box1">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child internal-child="nav_area">
+              <!-- n-columns=3 n-rows=3 -->
               <object class="GtkGrid" id="AnacondaSpokeWindow-nav_area1">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
               </object>
             </child>
           </object>
@@ -112,35 +113,35 @@
         </child>
         <child internal-child="alignment">
           <object class="GtkAlignment" id="AnacondaSpokeWindow-alignment1">
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="yalign">0</property>
             <child internal-child="action_area">
               <object class="GtkBox" id="AnacondaSpokeWindow-action_area1">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkBox" id="box1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">vertical</property>
                     <child>
                       <object class="GtkAlignment" id="headerAlignment">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="xalign">1</property>
                         <property name="xscale">0.949999988079071</property>
                         <child>
                           <object class="GtkBox" id="headerBox">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkLabel" id="regionLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes" context="GUI|Date and Time">_Region:</property>
-                                <property name="use_underline">True</property>
-                                <property name="mnemonic_widget">regionCombobox</property>
+                                <property name="use-underline">True</property>
+                                <property name="mnemonic-widget">regionCombobox</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -152,16 +153,16 @@
                             <child>
                               <object class="GtkComboBox" id="regionCombobox">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="model">regions</property>
-                                <property name="has_entry">True</property>
-                                <property name="entry_text_column">1</property>
+                                <property name="has-entry">True</property>
+                                <property name="entry-text-column">1</property>
                                 <signal name="changed" handler="on_region_changed" object="regionsEntry" swapped="no"/>
                                 <child internal-child="entry">
                                   <object class="GtkEntry" id="regionsEntry">
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_KEY_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
-                                    <property name="width_chars">20</property>
+                                    <property name="width-chars">20</property>
                                     <property name="completion">regionCompletion</property>
                                     <signal name="activate" handler="on_city_region_text_entry_activated" swapped="no"/>
                                     <signal name="focus-out-event" handler="on_entry_left" swapped="no"/>
@@ -184,11 +185,11 @@
                             <child>
                               <object class="GtkLabel" id="cityLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_start">6</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-start">6</property>
                                 <property name="label" translatable="yes" context="GUI|Date and Time">_City:</property>
-                                <property name="use_underline">True</property>
-                                <property name="mnemonic_widget">cityCombobox</property>
+                                <property name="use-underline">True</property>
+                                <property name="mnemonic-widget">cityCombobox</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -200,16 +201,16 @@
                             <child>
                               <object class="GtkComboBox" id="cityCombobox">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="model">citiesFilter</property>
-                                <property name="has_entry">True</property>
-                                <property name="entry_text_column">1</property>
+                                <property name="has-entry">True</property>
+                                <property name="entry-text-column">1</property>
                                 <signal name="changed" handler="on_city_changed" object="citiesEntry" swapped="no"/>
                                 <child internal-child="entry">
                                   <object class="GtkEntry" id="citiesEntry">
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_KEY_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
-                                    <property name="width_chars">20</property>
+                                    <property name="width-chars">20</property>
                                     <property name="completion">cityCompletion</property>
                                     <signal name="activate" handler="on_city_region_text_entry_activated" swapped="no"/>
                                     <signal name="focus-out-event" handler="on_entry_left" swapped="no"/>
@@ -231,22 +232,22 @@
                             <child>
                               <object class="GtkAlignment" id="alignment4">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="xalign">1</property>
                                 <property name="xscale">0.20000000298023224</property>
-                                <property name="right_padding">24</property>
+                                <property name="right-padding">24</property>
                                 <child>
                                   <object class="GtkBox" id="box6">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">end</property>
                                     <child>
                                       <object class="GtkLabel" id="networkTimeLabel">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="label" translatable="yes" context="GUI|Date and Time">_Network Time</property>
-                                        <property name="use_underline">True</property>
-                                        <property name="mnemonic_widget">networkTimeSwitch</property>
+                                        <property name="use-underline">True</property>
+                                        <property name="mnemonic-widget">networkTimeSwitch</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -258,9 +259,9 @@
                                     <child>
                                       <object class="GtkSwitch" id="networkTimeSwitch">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="valign">center</property>
-                                        <property name="margin_end">6</property>
+                                        <property name="margin-end">6</property>
                                         <signal name="notify::active" handler="on_ntp_switched" swapped="no"/>
                                         <child internal-child="accessible">
                                           <object class="AtkObject" id="networkTimeSwitch-atkobject">
@@ -278,8 +279,8 @@
                                     <child>
                                       <object class="GtkButton" id="ntpConfigButton">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">True</property>
                                         <property name="image">configImage</property>
                                         <signal name="clicked" handler="on_ntp_config_clicked" swapped="no"/>
                                         <child internal-child="accessible">
@@ -316,22 +317,23 @@
                     <child>
                       <object class="GtkAlignment" id="footerAlignment">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="xalign">1</property>
-                        <property name="left_padding">24</property>
+                        <property name="left-padding">24</property>
                         <child>
                           <object class="GtkBox" id="footerBox">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_bottom">6</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-bottom">6</property>
                             <child>
+                              <!-- n-columns=5 n-rows=3 -->
                               <object class="GtkGrid" id="grid2">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <child>
                                   <object class="GtkLabel" id="hoursLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label">00</property>
                                     <attributes>
                                       <attribute name="scale" value="2"/>
@@ -343,28 +345,28 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">1</property>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="colonLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes" context="GUI|Date and Time" comments="TRANSLATORS: This is the separator between hours and minutes, like in HH:MM">:</property>
                                     <attributes>
                                       <attribute name="scale" value="2"/>
                                     </attributes>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="top_attach">1</property>
+                                    <property name="left-attach">1</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="minutesLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label">00</property>
                                     <attributes>
                                       <attribute name="scale" value="2"/>
@@ -376,15 +378,15 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="top_attach">1</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="hoursUpButton">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
                                     <property name="image">upImage</property>
                                     <signal name="clicked" handler="on_up_hours_clicked" swapped="no"/>
                                     <child internal-child="accessible">
@@ -394,15 +396,15 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">0</property>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="hoursDownButton">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
                                     <property name="image">downImage</property>
                                     <signal name="clicked" handler="on_down_hours_clicked" swapped="no"/>
                                     <child internal-child="accessible">
@@ -412,15 +414,15 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">0</property>
-                                    <property name="top_attach">2</property>
+                                    <property name="left-attach">0</property>
+                                    <property name="top-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="minutesUpButton">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
                                     <property name="image">upImage2</property>
                                     <signal name="clicked" handler="on_up_minutes_clicked" swapped="no"/>
                                     <child internal-child="accessible">
@@ -430,15 +432,15 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="top_attach">0</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">0</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="minutesDownButton">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
                                     <property name="image">downImage2</property>
                                     <signal name="clicked" handler="on_down_minutes_clicked" swapped="no"/>
                                     <child internal-child="accessible">
@@ -448,41 +450,41 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="top_attach">2</property>
+                                    <property name="left-attach">2</property>
+                                    <property name="top-attach">2</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkLabel" id="spaceLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label"> </property>
                                     <attributes>
                                       <attribute name="scale" value="2"/>
                                     </attributes>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">3</property>
-                                    <property name="top_attach">1</property>
+                                    <property name="left-attach">3</property>
+                                    <property name="top-attach">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkRevealer" id="amPmRevealer">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="transition_type">crossfade</property>
-                                    <property name="reveal_child">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="transition-type">crossfade</property>
+                                    <property name="reveal-child">True</property>
                                     <child>
                                       <object class="GtkBox" id="amPmBox">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="valign">center</property>
                                         <property name="orientation">vertical</property>
                                         <child>
                                           <object class="GtkButton" id="amPmUpButton">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
                                             <property name="image">upImage1</property>
                                             <signal name="clicked" handler="on_updown_ampm_clicked" swapped="no"/>
                                             <child internal-child="accessible">
@@ -500,9 +502,9 @@
                                         <child>
                                           <object class="GtkLabel" id="amPmLabel">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="margin_top">4</property>
-                                            <property name="margin_bottom">5</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="margin-top">4</property>
+                                            <property name="margin-bottom">5</property>
                                             <property name="label" translatable="yes">PM</property>
                                             <attributes>
                                               <attribute name="scale" value="1.5"/>
@@ -517,8 +519,8 @@
                                         <child>
                                           <object class="GtkButton" id="amPmDownButton">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
                                             <property name="image">downImage1</property>
                                             <signal name="clicked" handler="on_updown_ampm_clicked" swapped="no"/>
                                             <child internal-child="accessible">
@@ -537,8 +539,8 @@
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">4</property>
-                                    <property name="top_attach">0</property>
+                                    <property name="left-attach">4</property>
+                                    <property name="top-attach">0</property>
                                     <property name="height">3</property>
                                   </packing>
                                 </child>
@@ -564,24 +566,24 @@
                             <child>
                               <object class="GtkAlignment" id="alignment2">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="yalign">1</property>
                                 <property name="yscale">0.5</property>
                                 <child>
                                   <object class="GtkBox" id="box4">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkRadioButton" id="timeFormatRB">
                                         <property name="label" translatable="yes" context="GUI|Date and Time">24-_hour</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
                                         <property name="xalign">0</property>
                                         <property name="active">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <signal name="toggled" handler="on_timeformat_changed" swapped="no"/>
                                       </object>
                                       <packing>
@@ -594,11 +596,11 @@
                                       <object class="GtkRadioButton" id="timeFormatRB2">
                                         <property name="label" translatable="yes" context="GUI|Date and Time">_AM/PM</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="use_underline">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
+                                        <property name="use-underline">True</property>
                                         <property name="xalign">0</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <property name="group">timeFormatRB</property>
                                       </object>
                                       <packing>
@@ -620,15 +622,15 @@
                             <child>
                               <object class="GtkAlignment" id="alignment5">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="xalign">1</property>
                                 <property name="xscale">0.30000001192092896</property>
                                 <property name="yscale">0.20000000298023224</property>
-                                <property name="right_padding">24</property>
+                                <property name="right-padding">24</property>
                                 <child>
                                   <object class="GtkBox" id="dateBox">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="spacing">3</property>
                                     <child>

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.glade
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.glade
@@ -3,7 +3,6 @@
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <requires lib="AnacondaWidgets" version="1.0"/>
-  <requires lib="TimezoneMap" version="0.4"/>
   <object class="GtkListStore" id="cities">
     <columns>
       <!-- column-name name -->
@@ -312,19 +311,6 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="CcTimezoneMap" id="tzmap">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <signal name="location-changed" handler="on_location_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="padding">6</property>
-                        <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
@@ -674,6 +660,7 @@
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
+                        <property name="pack-type">end</property>
                         <property name="position">2</property>
                       </packing>
                     </child>

--- a/pyanaconda/ui/gui/spokes/datetime_spoke.glade
+++ b/pyanaconda/ui/gui/spokes/datetime_spoke.glade
@@ -124,189 +124,26 @@
                   <object class="GtkBox" id="box1">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">start</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <property name="margin-top">12</property>
+                    <property name="margin-bottom">12</property>
+                    <property name="vexpand">True</property>
                     <property name="orientation">vertical</property>
+                    <property name="baseline-position">top</property>
                     <child>
-                      <object class="GtkAlignment" id="headerAlignment">
+                      <object class="GtkLabel" id="timezoneLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="xalign">1</property>
-                        <property name="xscale">0.949999988079071</property>
-                        <child>
-                          <object class="GtkBox" id="headerBox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <child>
-                              <object class="GtkLabel" id="regionLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes" context="GUI|Date and Time">_Region:</property>
-                                <property name="use-underline">True</property>
-                                <property name="mnemonic-widget">regionCombobox</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">3</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBox" id="regionCombobox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="model">regions</property>
-                                <property name="has-entry">True</property>
-                                <property name="entry-text-column">1</property>
-                                <signal name="changed" handler="on_region_changed" object="regionsEntry" swapped="no"/>
-                                <child internal-child="entry">
-                                  <object class="GtkEntry" id="regionsEntry">
-                                    <property name="can-focus">True</property>
-                                    <property name="events">GDK_KEY_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
-                                    <property name="width-chars">20</property>
-                                    <property name="completion">regionCompletion</property>
-                                    <signal name="activate" handler="on_city_region_text_entry_activated" swapped="no"/>
-                                    <signal name="focus-out-event" handler="on_entry_left" swapped="no"/>
-                                    <signal name="key-release-event" handler="on_city_region_key_released" swapped="no"/>
-                                    <child internal-child="accessible">
-                                      <object class="AtkObject" id="regionsEntry-atkobject">
-                                        <property name="AtkObject::accessible-name" translatable="yes">Region</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">2</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="cityLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-start">6</property>
-                                <property name="label" translatable="yes" context="GUI|Date and Time">_City:</property>
-                                <property name="use-underline">True</property>
-                                <property name="mnemonic-widget">cityCombobox</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkComboBox" id="cityCombobox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="model">citiesFilter</property>
-                                <property name="has-entry">True</property>
-                                <property name="entry-text-column">1</property>
-                                <signal name="changed" handler="on_city_changed" object="citiesEntry" swapped="no"/>
-                                <child internal-child="entry">
-                                  <object class="GtkEntry" id="citiesEntry">
-                                    <property name="can-focus">True</property>
-                                    <property name="events">GDK_KEY_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
-                                    <property name="width-chars">20</property>
-                                    <property name="completion">cityCompletion</property>
-                                    <signal name="activate" handler="on_city_region_text_entry_activated" swapped="no"/>
-                                    <signal name="focus-out-event" handler="on_entry_left" swapped="no"/>
-                                    <signal name="key-release-event" handler="on_city_region_key_released" swapped="no"/>
-                                    <child internal-child="accessible">
-                                      <object class="AtkObject" id="citiesEntry-atkobject">
-                                        <property name="AtkObject::accessible-name" translatable="yes">City</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkAlignment" id="alignment4">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="xalign">1</property>
-                                <property name="xscale">0.20000000298023224</property>
-                                <property name="right-padding">24</property>
-                                <child>
-                                  <object class="GtkBox" id="box6">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">end</property>
-                                    <child>
-                                      <object class="GtkLabel" id="networkTimeLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="label" translatable="yes" context="GUI|Date and Time">_Network Time</property>
-                                        <property name="use-underline">True</property>
-                                        <property name="mnemonic-widget">networkTimeSwitch</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">3</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSwitch" id="networkTimeSwitch">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="valign">center</property>
-                                        <property name="margin-end">6</property>
-                                        <signal name="notify::active" handler="on_ntp_switched" swapped="no"/>
-                                        <child internal-child="accessible">
-                                          <object class="AtkObject" id="networkTimeSwitch-atkobject">
-                                            <property name="AtkObject::accessible-name" translatable="yes">Use Network Time</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">1</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkButton" id="ntpConfigButton">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                        <property name="image">configImage</property>
-                                        <signal name="clicked" handler="on_ntp_config_clicked" swapped="no"/>
-                                        <child internal-child="accessible">
-                                          <object class="AtkObject" id="ntpConfigButton-atkobject">
-                                            <property name="AtkObject::accessible-name" translatable="yes">Configure NTP</property>
-                                          </object>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">1</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">4</property>
-                              </packing>
-                            </child>
-                          </object>
-                        </child>
+                        <property name="halign">start</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="label" translatable="yes">Time zone</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -315,276 +152,386 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkAlignment" id="footerAlignment">
+                      <object class="GtkBox" id="timezoneBox">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="xalign">1</property>
-                        <property name="left-padding">24</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-bottom">30</property>
+                        <property name="spacing">5</property>
                         <child>
-                          <object class="GtkBox" id="footerBox">
+                          <object class="GtkLabel" id="regionLabel">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="margin-bottom">6</property>
+                            <property name="label" translatable="yes" context="GUI|Date and Time">_Region:</property>
+                            <property name="use-underline">True</property>
+                            <property name="mnemonic-widget">regionCombobox</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="regionCombobox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="model">regions</property>
+                            <property name="has-entry">True</property>
+                            <property name="entry-text-column">1</property>
+                            <signal name="changed" handler="on_region_changed" object="regionsEntry" swapped="no"/>
+                            <child internal-child="entry">
+                              <object class="GtkEntry" id="regionsEntry">
+                                <property name="can-focus">True</property>
+                                <property name="events">GDK_KEY_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
+                                <property name="width-chars">20</property>
+                                <property name="completion">regionCompletion</property>
+                                <signal name="activate" handler="on_city_region_text_entry_activated" swapped="no"/>
+                                <signal name="focus-out-event" handler="on_entry_left" swapped="no"/>
+                                <signal name="key-release-event" handler="on_city_region_key_released" swapped="no"/>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="regionsEntry-atkobject">
+                                    <property name="AtkObject::accessible-name" translatable="yes">Region</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="cityLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">6</property>
+                            <property name="margin-start">6</property>
+                            <property name="label" translatable="yes" context="GUI|Date and Time">_City:</property>
+                            <property name="use-underline">True</property>
+                            <property name="mnemonic-widget">cityCombobox</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="cityCombobox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="model">citiesFilter</property>
+                            <property name="has-entry">True</property>
+                            <property name="entry-text-column">1</property>
+                            <signal name="changed" handler="on_city_changed" object="citiesEntry" swapped="no"/>
+                            <child internal-child="entry">
+                              <object class="GtkEntry" id="citiesEntry">
+                                <property name="can-focus">True</property>
+                                <property name="events">GDK_KEY_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
+                                <property name="width-chars">20</property>
+                                <property name="completion">cityCompletion</property>
+                                <signal name="activate" handler="on_city_region_text_entry_activated" swapped="no"/>
+                                <signal name="focus-out-event" handler="on_entry_left" swapped="no"/>
+                                <signal name="key-release-event" handler="on_city_region_key_released" swapped="no"/>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="citiesEntry-atkobject">
+                                    <property name="AtkObject::accessible-name" translatable="yes">City</property>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="ntpRadioButton">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="on_ntp_button_toggled" swapped="no"/>
+                        <child>
+                          <object class="GtkAccelLabel" id="ntpLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes" context="GUI|Date and Time">_Automatic date &amp; time</property>
+                            <property name="use-underline">True</property>
+                            <property name="accel-widget">ntpRadioButton</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="ntpDescriptionLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin-start">28</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="label" translatable="yes">This feature requires connecting to an NTP (Network Time Protocol) server.</property>
+                        <property name="wrap">True</property>
+                        <property name="max-width-chars">60</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="ntpConfigButton">
+                        <property name="label" translatable="yes" context="GUI|Date and Time">Configure _NTP ...</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="halign">start</property>
+                        <property name="margin-start">28</property>
+                        <property name="margin-bottom">24</property>
+                        <property name="image">configImage</property>
+                        <property name="use-underline">True</property>
+                        <property name="always-show-image">True</property>
+                        <signal name="clicked" handler="on_ntp_config_clicked" swapped="no"/>
+                        <child internal-child="accessible">
+                          <object class="AtkObject" id="ntpConfigButton-atkobject">
+                            <property name="AtkObject::accessible-name" translatable="yes">Configure NTP</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="padding">1</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkRadioButton" id="manualRadioButton">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-bottom">12</property>
+                        <property name="draw-indicator">True</property>
+                        <property name="group">ntpRadioButton</property>
+                        <child>
+                          <object class="GtkAccelLabel" id="manualLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes" context="GUI|Date and Time">_Manual date &amp; time</property>
+                            <property name="use-underline">True</property>
+                            <property name="accel-widget">manualRadioButton</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <!-- n-columns=3 n-rows=2 -->
+                      <object class="GtkGrid" id="manualGrid">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">28</property>
+                        <property name="margin-bottom">24</property>
+                        <property name="row-spacing">6</property>
+                        <property name="column-spacing">6</property>
+                        <child>
+                          <!-- n-columns=5 n-rows=3 -->
+                          <object class="GtkGrid" id="timeBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
                             <child>
-                              <!-- n-columns=5 n-rows=3 -->
-                              <object class="GtkGrid" id="grid2">
+                              <object class="GtkLabel" id="hoursLabel">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <child>
-                                  <object class="GtkLabel" id="hoursLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label">00</property>
-                                    <attributes>
-                                      <attribute name="scale" value="2"/>
-                                    </attributes>
-                                    <child internal-child="accessible">
-                                      <object class="AtkObject" id="hoursLabel-atkobject">
-                                        <property name="AtkObject::accessible-name" translatable="yes">Hours</property>
-                                      </object>
-                                    </child>
+                                <property name="label">00</property>
+                                <attributes>
+                                  <attribute name="scale" value="2"/>
+                                </attributes>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="hoursLabel-atkobject">
+                                    <property name="AtkObject::accessible-name" translatable="yes">Hours</property>
                                   </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="colonLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label" translatable="yes" context="GUI|Date and Time" comments="TRANSLATORS: This is the separator between hours and minutes, like in HH:MM">:</property>
-                                    <attributes>
-                                      <attribute name="scale" value="2"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">1</property>
-                                    <property name="top-attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="minutesLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label">00</property>
-                                    <attributes>
-                                      <attribute name="scale" value="2"/>
-                                    </attributes>
-                                    <child internal-child="accessible">
-                                      <object class="AtkObject" id="minutesLabel-atkobject">
-                                        <property name="AtkObject::accessible-name" translatable="yes">Minutes</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">2</property>
-                                    <property name="top-attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="hoursUpButton">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="image">upImage</property>
-                                    <signal name="clicked" handler="on_up_hours_clicked" swapped="no"/>
-                                    <child internal-child="accessible">
-                                      <object class="AtkObject" id="hoursUpButton-atkobject">
-                                        <property name="AtkObject::accessible-name" translatable="yes">Hour Up</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="hoursDownButton">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="image">downImage</property>
-                                    <signal name="clicked" handler="on_down_hours_clicked" swapped="no"/>
-                                    <child internal-child="accessible">
-                                      <object class="AtkObject" id="hoursDownButton-atkobject">
-                                        <property name="AtkObject::accessible-name" translatable="yes">Hour Down</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">0</property>
-                                    <property name="top-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="minutesUpButton">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="image">upImage2</property>
-                                    <signal name="clicked" handler="on_up_minutes_clicked" swapped="no"/>
-                                    <child internal-child="accessible">
-                                      <object class="AtkObject" id="minutesUpButton-atkobject">
-                                        <property name="AtkObject::accessible-name" translatable="yes">Minutes Up</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">2</property>
-                                    <property name="top-attach">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="minutesDownButton">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="image">downImage2</property>
-                                    <signal name="clicked" handler="on_down_minutes_clicked" swapped="no"/>
-                                    <child internal-child="accessible">
-                                      <object class="AtkObject" id="minutesDownButton-atkobject">
-                                        <property name="AtkObject::accessible-name" translatable="yes">Minutes Down</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">2</property>
-                                    <property name="top-attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="spaceLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="label"> </property>
-                                    <attributes>
-                                      <attribute name="scale" value="2"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">3</property>
-                                    <property name="top-attach">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRevealer" id="amPmRevealer">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="transition-type">crossfade</property>
-                                    <property name="reveal-child">True</property>
-                                    <child>
-                                      <object class="GtkBox" id="amPmBox">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="valign">center</property>
-                                        <property name="orientation">vertical</property>
-                                        <child>
-                                          <object class="GtkButton" id="amPmUpButton">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">True</property>
-                                            <property name="image">upImage1</property>
-                                            <signal name="clicked" handler="on_updown_ampm_clicked" swapped="no"/>
-                                            <child internal-child="accessible">
-                                              <object class="AtkObject" id="amPmUpButton-atkobject">
-                                                <property name="AtkObject::accessible-name" translatable="yes">AM/PM Up</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="amPmLabel">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-top">4</property>
-                                            <property name="margin-bottom">5</property>
-                                            <property name="label" translatable="yes">PM</property>
-                                            <attributes>
-                                              <attribute name="scale" value="1.5"/>
-                                            </attributes>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="amPmDownButton">
-                                            <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="receives-default">True</property>
-                                            <property name="image">downImage1</property>
-                                            <signal name="clicked" handler="on_updown_ampm_clicked" swapped="no"/>
-                                            <child internal-child="accessible">
-                                              <object class="AtkObject" id="amPmDownButton-atkobject">
-                                                <property name="AtkObject::accessible-name" translatable="yes">AM/PM Down</property>
-                                              </object>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">2</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left-attach">4</property>
-                                    <property name="top-attach">0</property>
-                                    <property name="height">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <placeholder/>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">1</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkAlignment" id="alignment2">
+                              <object class="GtkLabel" id="colonLabel">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="yalign">1</property>
-                                <property name="yscale">0.5</property>
+                                <property name="label" translatable="yes" context="GUI|Date and Time" comments="TRANSLATORS: This is the separator between hours and minutes, like in HH:MM">:</property>
+                                <attributes>
+                                  <attribute name="scale" value="2"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="minutesLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label">00</property>
+                                <attributes>
+                                  <attribute name="scale" value="2"/>
+                                </attributes>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="minutesLabel-atkobject">
+                                    <property name="AtkObject::accessible-name" translatable="yes">Minutes</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="hoursUpButton">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="image">upImage</property>
+                                <signal name="clicked" handler="on_up_hours_clicked" swapped="no"/>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="hoursUpButton-atkobject">
+                                    <property name="AtkObject::accessible-name" translatable="yes">Hour Up</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="hoursDownButton">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="image">downImage</property>
+                                <signal name="clicked" handler="on_down_hours_clicked" swapped="no"/>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="hoursDownButton-atkobject">
+                                    <property name="AtkObject::accessible-name" translatable="yes">Hour Down</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="minutesUpButton">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="image">upImage2</property>
+                                <signal name="clicked" handler="on_up_minutes_clicked" swapped="no"/>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="minutesUpButton-atkobject">
+                                    <property name="AtkObject::accessible-name" translatable="yes">Minutes Up</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="minutesDownButton">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="image">downImage2</property>
+                                <signal name="clicked" handler="on_down_minutes_clicked" swapped="no"/>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="minutesDownButton-atkobject">
+                                    <property name="AtkObject::accessible-name" translatable="yes">Minutes Down</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="spaceLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label"> </property>
+                                <attributes>
+                                  <attribute name="scale" value="2"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkRevealer" id="amPmRevealer">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="transition-type">crossfade</property>
+                                <property name="reveal-child">True</property>
                                 <child>
-                                  <object class="GtkBox" id="box4">
+                                  <object class="GtkBox" id="amPmBox">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
+                                    <property name="valign">center</property>
                                     <property name="orientation">vertical</property>
                                     <child>
-                                      <object class="GtkRadioButton" id="timeFormatRB">
-                                        <property name="label" translatable="yes" context="GUI|Date and Time">24-_hour</property>
+                                      <object class="GtkButton" id="amPmUpButton">
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <property name="xalign">0</property>
-                                        <property name="active">True</property>
-                                        <property name="draw-indicator">True</property>
-                                        <signal name="toggled" handler="on_timeformat_changed" swapped="no"/>
+                                        <property name="receives-default">True</property>
+                                        <property name="image">upImage1</property>
+                                        <signal name="clicked" handler="on_updown_ampm_clicked" swapped="no"/>
+                                        <child internal-child="accessible">
+                                          <object class="AtkObject" id="amPmUpButton-atkobject">
+                                            <property name="AtkObject::accessible-name" translatable="yes">AM/PM Up</property>
+                                          </object>
+                                        </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -593,15 +540,15 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkRadioButton" id="timeFormatRB2">
-                                        <property name="label" translatable="yes" context="GUI|Date and Time">_AM/PM</property>
+                                      <object class="GtkLabel" id="amPmLabel">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">False</property>
-                                        <property name="use-underline">True</property>
-                                        <property name="xalign">0</property>
-                                        <property name="draw-indicator">True</property>
-                                        <property name="group">timeFormatRB</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="margin-top">4</property>
+                                        <property name="margin-bottom">5</property>
+                                        <property name="label" translatable="yes">PM</property>
+                                        <attributes>
+                                          <attribute name="scale" value="1.5"/>
+                                        </attributes>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -609,66 +556,169 @@
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkButton" id="amPmDownButton">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">True</property>
+                                        <property name="image">downImage1</property>
+                                        <signal name="clicked" handler="on_updown_ampm_clicked" swapped="no"/>
+                                        <child internal-child="accessible">
+                                          <object class="AtkObject" id="amPmDownButton-atkobject">
+                                            <property name="AtkObject::accessible-name" translatable="yes">AM/PM Down</property>
+                                          </object>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">8</property>
-                                <property name="position">1</property>
+                                <property name="left-attach">4</property>
+                                <property name="top-attach">0</property>
+                                <property name="height">3</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkAlignment" id="alignment5">
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkAlignment" id="timeFormatAlignment">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="yalign">1</property>
+                            <property name="yscale">0.5</property>
+                            <child>
+                              <object class="GtkBox" id="timeFormatBox">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
-                                <property name="xalign">1</property>
-                                <property name="xscale">0.30000001192092896</property>
-                                <property name="yscale">0.20000000298023224</property>
-                                <property name="right-padding">24</property>
+                                <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkBox" id="dateBox">
+                                  <object class="GtkRadioButton" id="timeFormatRB">
+                                    <property name="label" translatable="yes" context="GUI|Date and Time">24-_hour</property>
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">end</property>
-                                    <property name="spacing">3</property>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <placeholder/>
-                                    </child>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="xalign">0</property>
+                                    <property name="active">True</property>
+                                    <property name="draw-indicator">True</property>
+                                    <signal name="toggled" handler="on_timeformat_changed" swapped="no"/>
                                   </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
                                 </child>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child internal-child="accessible">
-                              <object class="AtkObject" id="footerBox-atkobject">
-                                <property name="AtkObject::accessible-name" translatable="yes">Set Date &amp; Time</property>
+                                <child>
+                                  <object class="GtkRadioButton" id="timeFormatRB2">
+                                    <property name="label" translatable="yes" context="GUI|Date and Time">_AM/PM</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="use-underline">True</property>
+                                    <property name="xalign">0</property>
+                                    <property name="draw-indicator">True</property>
+                                    <property name="group">timeFormatRB</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                             </child>
                           </object>
+                          <packing>
+                            <property name="left-attach">2</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="dateBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="valign">start</property>
+                            <property name="margin-end">28</property>
+                            <property name="spacing">0</property>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="dateLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Date</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="timeLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="label" translatable="yes">Time</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="pack-type">end</property>
-                        <property name="position">2</property>
+                        <property name="position">6</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
+                    <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
                   </packing>

--- a/pyanaconda/ui/gui/spokes/lib/ntp_dialog.glade
+++ b/pyanaconda/ui/gui/spokes/lib/ntp_dialog.glade
@@ -2,7 +2,6 @@
 <!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <requires lib="TimezoneMap" version="0.4"/>
   <object class="GtkListStore" id="serversStore">
     <columns>
       <!-- column-name hostname -->

--- a/tests/unit_tests/pyanaconda_tests/test_simple_import.py
+++ b/tests/unit_tests/pyanaconda_tests/test_simple_import.py
@@ -17,13 +17,11 @@
 #
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
-import sys
 import pyanaconda
 import unittest
 
 from importlib import import_module
 from pkgutil import walk_packages
-from unittest.mock import Mock
 
 
 class SimpleImportTestCase(unittest.TestCase):
@@ -31,13 +29,6 @@ class SimpleImportTestCase(unittest.TestCase):
 
     Import all pyanaconda modules.
     """
-
-    def setUp(self):
-        # Mock the TimezoneMap hack.
-        sys.modules["gi.repository.TimezoneMap"] = Mock()
-
-    def tearDown(self):
-        sys.modules.pop("gi.repository.TimezoneMap")
 
     def _check_package(self, package, expected_imports, skipped_imports):
         """Check if all submodules of the package can be imported."""

--- a/tests/unit_tests/pyanaconda_tests/ui/test_simple_ui.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_simple_ui.py
@@ -19,7 +19,6 @@
 #
 import os
 import re
-import sys
 import unittest
 
 from unittest.mock import Mock, patch, create_autospec
@@ -44,12 +43,6 @@ class SimpleUITestCase(unittest.TestCase):
         self.data = Mock()
         self.storage = Mock()
         self.payload = Mock()
-
-        # Mock the TimezoneMap hack.
-        sys.modules["gi.repository.TimezoneMap"] = Mock()
-
-    def tearDown(self):
-        sys.modules.pop("gi.repository.TimezoneMap")
 
     @property
     def paths(self):


### PR DESCRIPTION
The timezone map was removed from the Time & Date spoke in the GKT-based user interface
and the spoke was redesigned to accommodate the changes. The installer no longer depends
on the the `libtimezonemap` package.

**TODO:**
- [x] Build and test a boot.iso.
- [x] Run kickstart tests for `time`.
- [x] Test the live media.

See: https://github.com/rhinstaller/anaconda/discussions/5355