### PR TITLE
Try what happens if we drop the tiger-vnc dependency

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -274,8 +274,9 @@ Summary: Graphical user interface for the Anaconda installer
 Requires: anaconda-core = %{version}-%{release}
 Requires: anaconda-widgets = %{version}-%{release}
 Requires: python3-meh-gui >= %{mehver}
+# FIXME: we should not have to manually drag in drivers like this :P
+Requires: mesa-dri-drivers
 Requires: adwaita-icon-theme
-Requires: tigervnc-server-minimal
 Requires: libxklavier >= %{libxklavierver}
 Requires: libgnomekbd
 Requires: libtimezonemap >= %{libtimezonemapver}

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex; \
 COPY ["lorax-build", "/"]
 COPY ["lorax-build-webui", "/"]
 COPY ["adjust-templates-for-webui.patch", "/"]
+COPY ["drop-tiger-vnc-from-templates.patch", "/"]
 
 RUN mkdir /lorax /anaconda-rpms /images
 

--- a/dockerfile/anaconda-iso-creator/drop-tiger-vnc-from-templates.patch
+++ b/dockerfile/anaconda-iso-creator/drop-tiger-vnc-from-templates.patch
@@ -1,0 +1,38 @@
+From 9212dc01de34f49e2fb2dc63068c48560927ad34 Mon Sep 17 00:00:00 2001
+From: Martin Kolman <mkolman@redhat.com>
+Date: Wed, 17 Jan 2024 18:09:53 +0100
+Subject: [PATCH] Drop tiger-vnc from templates
+
+---
+ share/templates.d/99-generic/runtime-cleanup.tmpl | 1 -
+ share/templates.d/99-generic/runtime-install.tmpl | 2 --
+ 2 files changed, 3 deletions(-)
+
+diff --git a/share/templates.d/99-generic/runtime-cleanup.tmpl b/share/templates.d/99-generic/runtime-cleanup.tmpl
+index aad31f77..bc0b11b5 100644
+--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
++++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
+@@ -56,7 +56,6 @@ removepkg libasyncns
+ removepkg lvm2-libs
+ removepkg mobile-broadband-provider-info
+ removepkg rmt rpcbind squashfs-tools
+-removepkg tigervnc-license xml-common
+ removepkg mkfontscale fonttosfnt
+ removepkg xorg-x11-server-common
+ # do not remove this, required for ppc64le and s390x !!!
+diff --git a/share/templates.d/99-generic/runtime-install.tmpl b/share/templates.d/99-generic/runtime-install.tmpl
+index d6029830..4df2fb99 100644
+--- a/share/templates.d/99-generic/runtime-install.tmpl
++++ b/share/templates.d/99-generic/runtime-install.tmpl
+@@ -131,8 +131,6 @@ installpkg selinux-policy-targeted audit
+ 
+ ## network tools/servers
+ installpkg ethtool openssh-server nfs-utils openssh-clients
+-installpkg tigervnc-server-minimal
+-installpkg tigervnc-server-module
+ installpkg net-tools
+ installpkg bridge-utils
+ installpkg nmap-ncat
+-- 
+2.43.0
+

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -36,12 +36,16 @@ mkdir -p $REPO_DIR
 cp -a $INPUT_RPMS/* $REPO_DIR || echo "RPM files can't be copied!"  # We could just do the build with official repositories only
 createrepo_c $REPO_DIR
 
+cp -r /usr/share/lorax/templates.d/ /lorax/
+patch -p2 -i /drop-tiger-vnc-from-templates.patch
+
 # build boot.iso with our rpms
 . /etc/os-release
 # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
 # The --volid argument can cause different network interface naming: https://github.com/rhinstaller/kickstart-tests/issues/448
 lorax -p Fedora -v "$VERSION_ID" -r "$VERSION_ID" \
       --volid Fedora-S-dvd-x86_64-rawh \
+      --sharedir ./templates.d/99-generic/ \
       -s http://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/ \
       -s file://$REPO_DIR/ \
       "$@" \


### PR DESCRIPTION
### Drop the tiger-vnc dependency

Drop the Tiger VNC package from Anaconda spec file.

This by itself is actually not sufficient as for some
reason Tiger VNC packages are also part of the Lorax templates (!).

So to fully remove Tiger VNC, it is also necessary to remove it
from the Lorax templates.

Lastly, it looks like Tiger VNC is actually the only thing pulling
in the mesa-dri-drivers (!!) packake, without which gnome-kiosk will
crash at startup (!!!). So also add mesa-dri-drivers as a depndency of
the Anaconda GUI package.