### PR TITLE
Propagate a lazy proxy of the storage model

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1492,3 +1492,40 @@ def restorecon(paths, root, skip_nonexistent=False):
         return False
     else:
         return True
+
+
+class LazyObject(object):
+    """The lazy object."""
+
+    def __init__(self, getter):
+        """Create a proxy of an object.
+
+        The object might not exist until we call the given
+        function. The function is called only when we try
+        to access the attributes of the object.
+
+        The returned object is not cached in this class.
+        We call the function every time.
+
+        :param getter: a function that returns the object
+        """
+        self._getter = getter
+
+    @property
+    def _object(self):
+        return self._getter()
+
+    def __eq__(self, other):
+        return self._object == other
+
+    def __hash__(self):
+        return self._object.__hash__()
+
+    def __getattr__(self, name):
+        return getattr(self._object, name)
+
+    def __setattr__(self, name, value):
+        if name in ("_getter", ):
+            return super().__setattr__(name, value)
+
+        return setattr(self._object, name, value)

--- a/tests/nosetests/pyanaconda_tests/module_part_interactive_test.py
+++ b/tests/nosetests/pyanaconda_tests/module_part_interactive_test.py
@@ -72,6 +72,24 @@ class InteractivePartitioningInterfaceTestCase(unittest.TestCase):
         self.assertEqual(self.interface.PartitioningMethod, PARTITIONING_METHOD_INTERACTIVE)
 
     @patch_dbus_publish_object
+    def lazy_storage_test(self, publisher):
+        """Make sure that the storage playground is created lazily."""
+        self.module.on_storage_changed(create_storage())
+
+        device_tree_module = self.module.get_device_tree()
+        self.assertIsNone(self.module._storage_playground)
+
+        device_tree_module.get_disks()
+        self.assertIsNotNone(self.module._storage_playground)
+
+        self.module.on_partitioning_reset()
+        self.module.on_storage_changed(create_storage())
+        self.assertIsNone(self.module._storage_playground)
+
+        device_tree_module.get_actions()
+        self.assertIsNotNone(self.module._storage_playground)
+
+    @patch_dbus_publish_object
     def get_device_tree_test(self, publisher):
         """Test GetDeviceTree."""
         DeviceTreeContainer._counter = 0


### PR DESCRIPTION
The storage model for the partitioning modules should be always created lazily. When we reset the partitioning, the new model shouldn't be created until we try to work with it. Then we create a new copy of the storage model, hide disks that are not selected and possibly initialize empty disks.

There is a problem with modules that need to be able to work with the same copy of the storage model as the partitioning modules. At this moment, it is only the device tree module. The suggested solution is to propagate a lazy proxy of the storage model. It will not trigger the creation of the copy until we try to access the attributes of the storage model.

Basically, the device tree module always gets the storage model on demand from the storage property of the partitioning module.

(cherry picked from commit 39d3a894411e3069cdb14354509153028a48e6c5)

Related: rhbz#1868577
Resolves: RHEL-16276