### PR TITLE
Remove libgnomekbd

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -57,7 +57,6 @@ BuildRequires: gobject-introspection-devel
 %if %{with glade}
 BuildRequires: glade-devel
 %endif
-BuildRequires: libgnomekbd-devel
 BuildRequires: libxklavier-devel >= %{libxklavierver}
 BuildRequires: make
 BuildRequires: pango-devel
@@ -273,9 +272,9 @@ Requires: anaconda-core = %{version}-%{release}
 Requires: anaconda-widgets = %{version}-%{release}
 Requires: python3-meh-gui >= %{mehver}
 Requires: adwaita-icon-theme
+Requires: tecla
 Requires: tigervnc-server-minimal
 Requires: libxklavier >= %{libxklavierver}
-Requires: libgnomekbd
 Requires: nm-connection-editor
 %ifnarch s390 s390x
 Requires: NetworkManager-wifi

--- a/docs/release-notes/remove-libgnomekbd.rst
+++ b/docs/release-notes/remove-libgnomekbd.rst
@@ -1,0 +1,11 @@
+:Type: GUI
+:Summary: Remove libgnomekbd
+
+:Description:
+    libgnomekbd is a C library used by Anaconda to display the keyboard
+    preview widget. It is stuck in GTK 3 and X11 (libxklavier).
+    
+    Replace it with Tecla.
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/5417

--- a/pyanaconda/ui/gui/xkl_wrapper.py
+++ b/pyanaconda/ui/gui/xkl_wrapper.py
@@ -115,7 +115,6 @@ class XklWrapper(object):
                     # really wrong
                     raise XklWrapperError("Failed to initialize layouts")
 
-        #needed also for Gkbd.KeyboardDrawingDialog
         self.configreg = Xkl.ConfigRegistry.get_instance(self._engine)
         self.configreg.load(False)
 


### PR DESCRIPTION
libgnomekbd is a C library used by Anaconda to display the keyboard preview widget. It is stuck in GTK 3 and X11 (libxklavier).

Replace it with Tecla.