### PR TITLE
Enable users to start koji build by Packit

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -34,8 +34,6 @@ actions:
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 
 jobs:
-
-
   - job: propose_downstream
     trigger: release
     dist_git_branches: main
@@ -65,4 +63,13 @@ jobs:
     trigger: commit
     dist_git_branches:
       - fedora-rawhide
-
+    allowed_committers:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+    allowed_pr_authors:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -27,9 +27,7 @@ actions:
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 
 jobs:
-
 {% if distro_release == "rawhide" %}
-
   - job: propose_downstream
     trigger: release
     dist_git_branches: main
@@ -54,14 +52,7 @@ jobs:
     owner: "@rhinstaller"
     project: Anaconda
     preserve_project: True
-
-  - job: koji_build
-    trigger: commit
-    dist_git_branches:
-      - fedora-rawhide
-
 {% elif distro_name == "fedora" %}
-
   - job: propose_downstream
     trigger: release
     dist_git_branches: f{$ distro_release $}
@@ -84,9 +75,23 @@ jobs:
       # This repository contains fixup of Rawhide broken environment.
       # Mainly useful when there is a package which is not yet in Rawhide but build is available.
       - "https://fedorapeople.org/groups/anaconda/repos/anaconda_fixup_repo/"
+{% endif %}
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
+{% if distro_release == "rawhide" %}
+      - fedora-rawhide
+{% elif distro_name == "fedora" %}
       - fedora-{$ distro_release $}
 {% endif %}
+    allowed_committers:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+    allowed_pr_authors:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny


### PR DESCRIPTION
Without this list only Packit created dist-git MR will trigger the Koji build. With this change all the users listed here will have automatic builds after merging their dist-git MR and they can also use `/packit koji-build` on any PR / opened issue.