### PR TITLE
Set GTK 4 decoration layout

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -435,6 +435,7 @@ rm -rf \
 %endif
 %{_datadir}/anaconda/window-manager
 %{_datadir}/anaconda/anaconda-gtk.css
+%{_datadir}/anaconda/gtk-4.0/settings.ini
 
 %files tui
 %{python3_sitearch}/pyanaconda/rescue.py

--- a/configure.ac
+++ b/configure.ac
@@ -111,6 +111,7 @@ AC_CONFIG_FILES([Makefile
                  data/liveinst/gnome/Makefile
                  data/systemd/Makefile
                  data/dbus/Makefile
+                 data/gtk-4.0/Makefile
                  data/window-manager/Makefile
                  data/window-manager/config/Makefile
                  po/Makefile

--- a/data/gtk-4.0/Makefile.am
+++ b/data/gtk-4.0/Makefile.am
@@ -1,4 +1,4 @@
-# data/Makefile.am for anaconda
+# data/gtk-4.0/Makefile.am for anaconda
 #
 # Copyright (C) 2009  Red Hat, Inc.
 #
@@ -15,18 +15,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = command-stubs gtk-4.0 liveinst systemd pixmaps window-manager dbus conf.d profile.d
-
 CLEANFILES = *~
 
-dist_pkgdata_DATA          = interactive-defaults.ks \
-			     tmux.conf \
-			     anaconda-gtk.css
-
-helpdir               = $(datadir)/$(PACKAGE_NAME)
-dist_help_DATA        = anaconda_options.txt
-
-configdir           = $(sysconfdir)/$(PACKAGE_NAME)
-dist_config_DATA    = anaconda.conf
+gtk4dir           = $(datadir)/$(PACKAGE_NAME)/gtk-4.0
+dist_gtk4_DATA    = settings.ini
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/data/gtk-4.0/settings.ini
+++ b/data/gtk-4.0/settings.ini
@@ -1,0 +1,2 @@
+[Settings]
+gtk-decoration-layout=:close

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -193,6 +193,11 @@ def do_startup_x11_actions():
     else:
         xdg_data_dirs = datadir + '/window-manager:/usr/share'
 
+    xdg_config_dirs = datadir
+    if 'XDG_CONFIG_DIRS' in os.environ:
+        xdg_config_dirs = datadir + ':' + os.environ['XDG_CONFIG_DIRS']
+    os.environ['XDG_CONFIG_DIRS'] = xdg_config_dirs
+
     def x11_preexec():
         # to set GUI subprocess SIGINT handler
         signal.signal(signal.SIGINT, signal.SIG_IGN)


### PR DESCRIPTION
The current attempt to show only the close button in the external application windows (see org.gnome.desktop.wm.preferences.gschema.override, button-layout property) is not working.

Instead, add a configuration file for GTK 4.

------------------------------------------

After spending quite a lot of time trying to make `.gschema.override` files work I gave up and decided to follow this approach.

I'm not sure if including this configuration file is acceptable or not.

Note that I had to set the environment variable `XDG_CONFIG_DIRS` (`os.environ['XDG_CONFIG_DIRS'] = xdg_config_dirs`) instead of settings it in `util.startProgram(env_add=...)`. Otherwise, child processes, like Teclas, won't use the right paths.

I wonder if `XDG_CONFIG_DIRS` should be set in `augmentEnv()` instead. Waiting for feedback:
```python
def augmentEnv():
    env = os.environ.copy()

    # Set XDG_CONFIG_DIRS so GTK 4 preferences are used
    datadir = os.environ.get('ANACONDA_DATADIR', '/usr/share/anaconda')
    xdg_config_dirs = datadir
    if 'XDG_CONFIG_DIRS' in os.environ:
        xdg_config_dirs = datadir + ':' + os.environ['XDG_CONFIG_DIRS']
    env.update({"XDG_CONFIG_DIRS": xdg_config_dirs})

    # FIXME: Remove the support for the ANA_INSTALL_PATH variable.
    env.update({"ANA_INSTALL_PATH": conf.target.system_root})
    env.update(_child_env)
    return env
```

As a side note, I also tried to follow the same approach with `XDG_DATA_DIRS`, but it didn't fix the issues.