### PR TITLE
Add support for bootupd to RHEL 9

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -436,7 +436,7 @@ class ConfigureBootloader(Task):
                 "backend",
                 "install",
                 "--auto",
-                "--with-static-configs",
+                "--write-uuid",
                 "--device",
                 dev_data.path,
                 "/",

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -24,10 +24,12 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.glib import format_size_full, create_new_context, Variant, GError
 from pyanaconda.core.i18n import _
 from pyanaconda.core.util import execWithRedirect, mkdirChain, set_system_root
+from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE, BOOTLOADER
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.structures.storage import DeviceData
+from pyanaconda.modules.payloads.payload.rpm_ostree.util import have_bootupd
 
 import gi
 gi.require_version("OSTree", "1.0")
@@ -417,8 +419,34 @@ class ConfigureBootloader(Task):
         return "Configure OSTree bootloader"
 
     def run(self):
-        self._move_grub_config()
+        if have_bootupd(self._sysroot):
+            self._install_bootupd()
+        else:
+            self._move_grub_config()
         self._set_kargs()
+
+    def _install_bootupd(self):
+        bootloader = STORAGE.get_proxy(BOOTLOADER)
+        device_tree = STORAGE.get_proxy(DEVICE_TREE)
+        dev_data = DeviceData.from_structure(device_tree.GetDeviceData(bootloader.Drive))
+
+        rc = execWithRedirect(
+            "bootupctl",
+            [
+                "backend",
+                "install",
+                "--auto",
+                "--with-static-configs",
+                "--device",
+                dev_data.path,
+                "/",
+            ],
+            root=self._sysroot
+        )
+
+        if rc:
+            raise BootloaderInstallationError(
+                "failed to write boot loader configuration")
 
     def _move_grub_config(self):
         """If using GRUB2, move its config file, also with a compatibility symlink."""

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -456,6 +456,8 @@ class ConfigureBootloader(Task):
         if root_data.type == "btrfs subvolume":
             set_kargs_args.append("rootflags=subvol=" + root_name)
 
+        set_kargs_args.append("rw")
+
         safe_exec_with_redirect("ostree", set_kargs_args, root=self._sysroot)
 
 
@@ -515,7 +517,18 @@ class DeployOSTreeTask(Task):
                  self._data.remote + ':' + ref]
             )
 
-        log.info("ostree deploy complete")
+        log.info("ostree config set sysroot.readonly true")
+
+        safe_exec_with_redirect(
+            "ostree",
+            ["config",
+             "--repo=" + self._sysroot + "/ostree/repo",
+             "set",
+             "sysroot.readonly",
+             "true"]
+        )
+
+        log.info("ostree admin deploy complete")
         self.report_progress(_("Deployment complete: {}").format(ref))
 
 

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/util.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/util.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+
+import os.path
+from pyanaconda.core.util import join_paths
+
+__all__ = ["have_bootupd"]
+
+
+def have_bootupd(sysroot):
+    """Is bootupd/bootupctl present in sysroot?"""
+    return os.path.exists(join_paths(sysroot, "/usr/bin/bootupctl"))

--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -723,21 +723,13 @@ class BootLoader(object):
     def timeout(self, seconds):
         self._timeout = seconds
 
-    def prepare(self, storage):
-        """Prepare the bootloader for the installation.
-
-        FIXME: Move this function into a task.
-        """
+    def prepare(self):
+        """Prepare the bootloader for the installation."""
         bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
         self._update_flags(bootloader_proxy)
         self._apply_password(bootloader_proxy)
         self._apply_timeout(bootloader_proxy)
         self._apply_zipl_secure_boot(bootloader_proxy)
-        self._set_extra_boot_args(bootloader_proxy)
-        self._set_storage_boot_args(storage)
-        self._preserve_some_boot_args()
-        self._set_graphical_boot_args()
-        self._set_security_boot_args()
 
     def _update_flags(self, bootloader_proxy):
         """Update flags."""
@@ -775,8 +767,20 @@ class BootLoader(object):
         log.debug("Applying ZIPL Secure Boot: %s", secure_boot)
         self.secure = secure_boot
 
-    def _set_extra_boot_args(self, bootloader_proxy):
+    def collect_arguments(self, storage):
+        """Collect kernel arguments for the installation.
+
+        FIXME: Move this code out of this class.
+        """
+        self._set_extra_boot_args()
+        self._set_storage_boot_args(storage)
+        self._preserve_some_boot_args()
+        self._set_graphical_boot_args()
+        self._set_security_boot_args()
+
+    def _set_extra_boot_args(self):
         """Set the extra boot args."""
+        bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
         self.boot_args.update(bootloader_proxy.ExtraArguments)
 
     def _set_storage_boot_args(self, storage):

--- a/pyanaconda/modules/storage/bootloader/bootloader.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader.py
@@ -38,7 +38,7 @@ from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.storage.bootloader.bootloader_interface import BootloaderInterface
 from pyanaconda.modules.storage.bootloader.installation import ConfigureBootloaderTask, \
     InstallBootloaderTask, FixZIPLBootloaderTask, FixBTRFSBootloaderTask, RecreateInitrdsTask, \
-    CreateRescueImagesTask, CreateBLSEntriesTask
+    CreateRescueImagesTask, CreateBLSEntriesTask, CollectKernelArgumentsTask
 from pyanaconda.modules.storage.constants import BootloaderMode, ZIPLSecureBoot
 
 log = get_module_logger(__name__)
@@ -479,6 +479,10 @@ class BootloaderModule(KickstartBaseModule):
                 payload_type=payload_type,
                 kernel_versions=kernel_versions,
                 sysroot=conf.target.system_root
+            ),
+            CollectKernelArgumentsTask(
+                storage=self.storage,
+                mode=self.bootloader_mode
             ),
             InstallBootloaderTask(
                 storage=self.storage,

--- a/pyanaconda/modules/storage/bootloader/bootloader.py
+++ b/pyanaconda/modules/storage/bootloader/bootloader.py
@@ -486,7 +486,9 @@ class BootloaderModule(KickstartBaseModule):
             ),
             InstallBootloaderTask(
                 storage=self.storage,
-                mode=self.bootloader_mode
+                mode=self.bootloader_mode,
+                payload_type=payload_type,
+                sysroot=conf.target.system_root
             ),
             CreateBLSEntriesTask(
                 storage=self.storage,

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -20,6 +20,7 @@
 from blivet import arch
 from blivet.devices import BTRFSDevice
 from pyanaconda.core.constants import PAYLOAD_TYPE_RPM_OSTREE, PAYLOAD_LIVE_TYPES
+from pyanaconda.modules.payloads.payload.rpm_ostree.util import have_bootupd
 from pyanaconda.modules.storage.bootloader import BootLoaderError
 
 from pyanaconda.core.util import execInSysroot
@@ -152,11 +153,13 @@ class CollectKernelArgumentsTask(Task):
 class InstallBootloaderTask(Task):
     """Installation task for the bootloader."""
 
-    def __init__(self, storage, mode):
+    def __init__(self, storage, mode, payload_type, sysroot):
         """Create a new task."""
         super().__init__()
         self._storage = storage
         self._mode = mode
+        self._payload_type = payload_type
+        self._sysroot = sysroot
 
     @property
     def name(self):
@@ -183,6 +186,10 @@ class InstallBootloaderTask(Task):
 
         if self._mode == BootloaderMode.SKIPPED:
             log.debug("The bootloader installation is skipped.")
+            return
+
+        if self._payload_type == PAYLOAD_TYPE_RPM_OSTREE and have_bootupd(self._sysroot):
+            log.debug("Will not install regular bootloader for ostree with bootupd")
             return
 
         log.debug("Installing the boot loader.")
@@ -302,7 +309,9 @@ class FixBTRFSBootloaderTask(Task):
 
         InstallBootloaderTask(
             self._storage,
-            self._mode
+            self._mode,
+            self._payload_type,
+            self._sysroot
         ).run()
 
 

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -142,14 +142,15 @@ class InstallBootloaderTask(Task):
             return
 
         try:
+            self._collect_kernel_arguments()
             self._install_boot_loader()
         except BootLoaderError as e:
             log.exception("Bootloader installation has failed: %s", e)
             raise BootloaderInstallationError(str(e)) from None
 
-    def _install_boot_loader(self):
-        """Do the final write of the bootloader."""
-        log.debug("Installing the boot loader.")
+    def _collect_kernel_arguments(self):
+        """Collect kernel arguments."""
+        log.debug("Collecting the kernel arguments.")
 
         stage1_device = self._bootloader.stage1_device
         log.info("boot loader stage1 target device is %s", stage1_device.name)
@@ -157,10 +158,13 @@ class InstallBootloaderTask(Task):
         stage2_device = self._bootloader.stage2_device
         log.info("boot loader stage2 target device is %s", stage2_device.name)
 
-        # Prepare the bootloader for the installation.
-        self._bootloader.prepare(self._storage)
+        self._bootloader.collect_arguments(self._storage)
 
-        # Install the bootloader.
+    def _install_boot_loader(self):
+        """Do the final write of the bootloader."""
+        log.debug("Installing the boot loader.")
+
+        self._bootloader.prepare()
         self._bootloader.write()
 
 

--- a/pyanaconda/modules/storage/bootloader/installation.py
+++ b/pyanaconda/modules/storage/bootloader/installation.py
@@ -37,7 +37,7 @@ log = get_module_logger(__name__)
 
 __all__ = ["ConfigureBootloaderTask", "InstallBootloaderTask", "FixBTRFSBootloaderTask",
            "FixZIPLBootloaderTask", "RecreateInitrdsTask", "CreateRescueImagesTask",
-           "CreateBLSEntriesTask"]
+           "CreateBLSEntriesTask", "CollectKernelArgumentsTask"]
 
 
 class CreateRescueImagesTask(Task):
@@ -105,6 +105,50 @@ class ConfigureBootloaderTask(Task):
         )
 
 
+class CollectKernelArgumentsTask(Task):
+    """Installation task for collecting the kernel arguments."""
+
+    def __init__(self, storage, mode):
+        """Create a new task."""
+        super().__init__()
+        self._storage = storage
+        self._mode = mode
+
+    @property
+    def name(self):
+        """Name of the task."""
+        return "Collect kernel arguments"
+
+    @property
+    def _bootloader(self):
+        """Representation of the bootloader."""
+        return self._storage.bootloader
+
+    def run(self):
+        """Run the task."""
+        if conf.target.is_directory:
+            log.debug("The bootloader installation is disabled for dir installations.")
+            return
+
+        if self._mode == BootloaderMode.DISABLED:
+            log.debug("The bootloader installation is disabled.")
+            return
+
+        if self._mode == BootloaderMode.SKIPPED:
+            log.debug("The bootloader installation is skipped.")
+            return
+
+        log.debug("Collecting the kernel arguments.")
+
+        stage1_device = self._bootloader.stage1_device
+        log.info("boot loader stage1 target device is %s", stage1_device.name)
+
+        stage2_device = self._bootloader.stage2_device
+        log.info("boot loader stage2 target device is %s", stage2_device.name)
+
+        self._bootloader.collect_arguments(self._storage)
+
+
 class InstallBootloaderTask(Task):
     """Installation task for the bootloader."""
 
@@ -141,31 +185,14 @@ class InstallBootloaderTask(Task):
             log.debug("The bootloader installation is skipped.")
             return
 
+        log.debug("Installing the boot loader.")
+
         try:
-            self._collect_kernel_arguments()
-            self._install_boot_loader()
+            self._bootloader.prepare()
+            self._bootloader.write()
         except BootLoaderError as e:
             log.exception("Bootloader installation has failed: %s", e)
             raise BootloaderInstallationError(str(e)) from None
-
-    def _collect_kernel_arguments(self):
-        """Collect kernel arguments."""
-        log.debug("Collecting the kernel arguments.")
-
-        stage1_device = self._bootloader.stage1_device
-        log.info("boot loader stage1 target device is %s", stage1_device.name)
-
-        stage2_device = self._bootloader.stage2_device
-        log.info("boot loader stage2 target device is %s", stage2_device.name)
-
-        self._bootloader.collect_arguments(self._storage)
-
-    def _install_boot_loader(self):
-        """Do the final write of the bootloader."""
-        log.debug("Installing the boot loader.")
-
-        self._bootloader.prepare()
-        self._bootloader.write()
 
 
 class CreateBLSEntriesTask(Task):

--- a/pyanaconda/modules/storage/bootloader/utils.py
+++ b/pyanaconda/modules/storage/bootloader/utils.py
@@ -208,9 +208,8 @@ def install_boot_loader(storage):
     stage2_device = storage.bootloader.stage2_device
     log.info("boot loader stage2 target device is %s", stage2_device.name)
 
-    # Set up the arguments.
-    # FIXME: do this from elsewhere?
-    storage.bootloader.set_boot_args(storage)
+    # Prepare the bootloader for the installation.
+    storage.bootloader.prepare(storage)
 
     # Install the bootloader.
     storage.bootloader.write()

--- a/pyanaconda/modules/storage/bootloader/utils.py
+++ b/pyanaconda/modules/storage/bootloader/utils.py
@@ -27,8 +27,7 @@ from pyanaconda.product import productName
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ["configure_boot_loader", "install_boot_loader", "recreate_initrds",
-           "create_rescue_images"]
+__all__ = ["configure_boot_loader", "recreate_initrds", "create_rescue_images"]
 
 
 def create_rescue_images(sysroot, kernel_versions):
@@ -192,27 +191,6 @@ def _write_sysconfig_kernel(sysroot, storage):
     f.write("# DEFAULTKERNEL specifies the default kernel package type\n")
     f.write("DEFAULTKERNEL=%s\n" % kernel)
     f.close()
-
-
-def install_boot_loader(storage):
-    """Do the final write of the boot loader.
-
-    :param storage: an instance of the storage
-    :raise: BootLoaderError if the installation fails
-    """
-    log.debug("Installing the boot loader.")
-
-    stage1_device = storage.bootloader.stage1_device
-    log.info("boot loader stage1 target device is %s", stage1_device.name)
-
-    stage2_device = storage.bootloader.stage2_device
-    log.info("boot loader stage2 target device is %s", stage2_device.name)
-
-    # Prepare the bootloader for the installation.
-    storage.bootloader.prepare(storage)
-
-    # Install the bootloader.
-    storage.bootloader.write()
 
 
 def create_bls_entries(sysroot, storage, kernel_versions):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -694,7 +694,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             exec_mock.assert_has_calls([
                 call(
                     "bootupctl",
-                    ["backend", "install", "--auto", "--with-static-configs", "--device",
+                    ["backend", "install", "--auto", "--write-uuid", "--device",
                      "/dev/btldr-drv", "/"],
                     root=sysroot
                 ),

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -625,7 +625,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             exec_mock.assert_called_once_with(
                 "ostree",
                 ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC",
-                 "rootflags=subvol=device-name"],
+                 "rootflags=subvol=device-name", "rw"],
                 root=sysroot
             )
 
@@ -661,7 +661,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             )
             exec_mock.assert_called_once_with(
                 "ostree",
-                ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC"],
+                ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
                 root=sysroot
             )
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -32,7 +32,6 @@ from pyanaconda.modules.payloads.payload.rpm_ostree.installation import \
     ChangeOSTreeRemoteTask, ConfigureBootloader, DeployOSTreeTask, PullRemoteAndDeleteTask, \
     SetSystemRootTask
 
-
 def _make_config_data():
     """Create OSTree configuration data for testing
 
@@ -664,6 +663,47 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                 ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
                 root=sysroot
             )
+
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.have_bootupd")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
+    def test_bootupd_run(self, devdata_mock, storage_mock, symlink_mock, rename_mock, exec_mock,
+                         have_bootupd_mock):
+        """Test OSTree bootloader config task, bootupd"""
+        exec_mock.return_value = 0
+        have_bootupd_mock.return_value = True
+
+        proxy_mock = storage_mock.get_proxy()
+        proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
+        proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
+        proxy_mock.GetRootDevice.return_value = "device-name"
+        proxy_mock.Drive = "btldr-drv"
+        devdata_mock.from_structure.return_value.type = "something-non-btrfs-subvolume-ish"
+        devdata_mock.from_structure.return_value.path = "/dev/btldr-drv"
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            task = ConfigureBootloader(sysroot, is_dirinstall=False)
+            task.run()
+
+            rename_mock.assert_not_called()
+            symlink_mock.assert_not_called()
+            assert exec_mock.call_count == 2
+            exec_mock.assert_has_calls([
+                call(
+                    "bootupctl",
+                    ["backend", "install", "--auto", "--with-static-configs", "--device",
+                     "/dev/btldr-drv", "/"],
+                    root=sysroot
+                ),
+                call(
+                    "ostree",
+                    ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
+                    root=sysroot
+                )
+            ])
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_util.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_util.py
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import tempfile
+import unittest
+
+from pyanaconda.core.util import join_paths, touch, mkdirChain as make_directories
+from pyanaconda.modules.payloads.payload.rpm_ostree.util import have_bootupd
+
+
+class RPMOSTreeUtilTestCase(unittest.TestCase):
+    """Test the RPM OSTree utils."""
+
+    def test_have_bootupd(self):
+        """Test bootupd detection."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            assert have_bootupd(sysroot) is False
+
+            make_directories(join_paths(sysroot, "/usr/bin"))
+            touch(join_paths(sysroot, "/usr/bin/bootupctl"))
+            assert have_bootupd(sysroot) is True

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -387,7 +387,7 @@ class BootloaderTasksTestCase(unittest.TestCase):
         bootloader.write.assert_not_called()
 
         InstallBootloaderTask(storage, BootloaderMode.ENABLED).run()
-        bootloader.set_boot_args.assert_called_once()
+        bootloader.prepare.assert_called_once()
         bootloader.write.assert_called_once()
 
     @patch('pyanaconda.modules.storage.bootloader.utils.execWithRedirect')

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -51,7 +51,7 @@ from pyanaconda.modules.storage.bootloader import BootloaderModule
 from pyanaconda.modules.storage.bootloader.bootloader_interface import BootloaderInterface
 from pyanaconda.modules.storage.bootloader.installation import ConfigureBootloaderTask, \
     InstallBootloaderTask, FixZIPLBootloaderTask, FixBTRFSBootloaderTask, RecreateInitrdsTask, \
-    CreateRescueImagesTask, CreateBLSEntriesTask
+    CreateRescueImagesTask, CreateBLSEntriesTask, CollectKernelArgumentsTask
 
 
 class BootloaderInterfaceTestCase(unittest.TestCase):
@@ -201,6 +201,7 @@ class BootloaderInterfaceTestCase(unittest.TestCase):
         task_classes = [
             CreateRescueImagesTask,
             ConfigureBootloaderTask,
+            CollectKernelArgumentsTask,
             InstallBootloaderTask,
             CreateBLSEntriesTask
         ]
@@ -374,6 +375,20 @@ class BootloaderTasksTestCase(unittest.TestCase):
         assert image.version == version
         assert image.label == "anaconda"
         assert image.device == storage.root_device
+
+    def test_collect_kernel_arguments(self):
+        """Test the collection of the kernel arguments for the installation."""
+        bootloader = Mock()
+        storage = Mock(bootloader=bootloader)
+
+        CollectKernelArgumentsTask(storage, BootloaderMode.DISABLED).run()
+        bootloader.collect_arguments.assert_not_called()
+
+        CollectKernelArgumentsTask(storage, BootloaderMode.SKIPPED).run()
+        bootloader.collect_arguments.assert_not_called()
+
+        CollectKernelArgumentsTask(storage, BootloaderMode.ENABLED).run()
+        bootloader.collect_arguments.assert_called_once_with(storage)
 
     def test_install(self):
         """Test the installation task for the boot loader."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_bootloader.py
@@ -33,6 +33,7 @@ from pyanaconda.modules.storage.devicetree import create_storage
 from tests.unit_tests.pyanaconda_tests import patch_dbus_publish_object, check_dbus_property, \
     reset_boot_loader_factory, check_task_creation_list, check_task_creation
 
+from pyanaconda.core.util import mkdirChain as make_directories, touch
 from pyanaconda.modules.storage import platform
 from pyanaconda.modules.storage.bootloader import BootLoaderFactory
 from pyanaconda.modules.storage.bootloader.base import BootLoader
@@ -45,7 +46,7 @@ from pyanaconda.modules.storage.constants import BootloaderMode
 
 from pyanaconda.modules.storage.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.core.constants import BOOTLOADER_SKIPPED, BOOTLOADER_LOCATION_PARTITION, \
-    PAYLOAD_TYPE_RPM_OSTREE, PAYLOAD_TYPE_LIVE_IMAGE
+    PAYLOAD_TYPE_RPM_OSTREE, PAYLOAD_TYPE_LIVE_IMAGE, PAYLOAD_TYPE_DNF
 from pyanaconda.modules.common.constants.objects import BOOTLOADER
 from pyanaconda.modules.storage.bootloader import BootloaderModule
 from pyanaconda.modules.storage.bootloader.bootloader_interface import BootloaderInterface
@@ -395,15 +396,55 @@ class BootloaderTasksTestCase(unittest.TestCase):
         bootloader = Mock()
         storage = Mock(bootloader=bootloader)
 
-        InstallBootloaderTask(storage, BootloaderMode.DISABLED).run()
-        bootloader.write.assert_not_called()
+        with tempfile.TemporaryDirectory() as sysroot:
+            InstallBootloaderTask(
+                storage,
+                BootloaderMode.DISABLED,
+                PAYLOAD_TYPE_DNF,
+                sysroot
+            ).run()
+            bootloader.write.assert_not_called()
 
-        InstallBootloaderTask(storage, BootloaderMode.SKIPPED).run()
-        bootloader.write.assert_not_called()
+            InstallBootloaderTask(
+                storage,
+                BootloaderMode.SKIPPED,
+                PAYLOAD_TYPE_DNF,
+                sysroot
+            ).run()
+            bootloader.write.assert_not_called()
 
-        InstallBootloaderTask(storage, BootloaderMode.ENABLED).run()
-        bootloader.prepare.assert_called_once()
-        bootloader.write.assert_called_once()
+            InstallBootloaderTask(
+                storage,
+                BootloaderMode.ENABLED,
+                PAYLOAD_TYPE_DNF,
+                sysroot
+            ).run()
+            bootloader.prepare.assert_called_once()
+            bootloader.write.assert_called_once()
+
+            bootloader.prepare.reset_mock()
+            bootloader.write.reset_mock()
+            InstallBootloaderTask(
+                storage,
+                BootloaderMode.ENABLED,
+                PAYLOAD_TYPE_RPM_OSTREE,
+                sysroot
+            ).run()
+            bootloader.prepare.assert_called_once()
+            bootloader.write.assert_called_once()
+
+            bootloader.prepare.reset_mock()
+            bootloader.write.reset_mock()
+            make_directories(sysroot + "/usr/bin")
+            touch(sysroot + "/usr/bin/bootupctl")
+            InstallBootloaderTask(
+                storage,
+                BootloaderMode.ENABLED,
+                PAYLOAD_TYPE_RPM_OSTREE,
+                sysroot
+            ).run()
+            bootloader.prepare.assert_not_called()
+            bootloader.write.assert_not_called()
 
     @patch('pyanaconda.modules.storage.bootloader.utils.execWithRedirect')
     def test_create_bls_entries(self, exec_mock):
@@ -664,7 +705,9 @@ class BootloaderTasksTestCase(unittest.TestCase):
         )
         install.assert_called_once_with(
             storage,
-            BootloaderMode.ENABLED
+            BootloaderMode.ENABLED,
+            PAYLOAD_TYPE_LIVE_IMAGE,
+            sysroot
         )
 
     @patch('pyanaconda.modules.storage.bootloader.installation.conf')


### PR DESCRIPTION
Port the support for bootupd from https://github.com/rhinstaller/anaconda/pull/5350, https://github.com/rhinstaller/anaconda/pull/5342 and https://github.com/rhinstaller/anaconda/pull/5363.

Resolves: RHEL-17205

**Depends on:** https://github.com/rhinstaller/anaconda/pull/5427
