### PR TITLE
Include partitions without mountpoints in GetMountPointConstraints

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -501,7 +501,7 @@ class DeviceTreeViewer(ABC):
 
         # Platform partitions are required except for /boot partiotion which is recommended
         for p in platform.partitions:
-            if p.mountpoint:
+            if p:
                 constraint = self._get_mount_point_constraints_data(p)
                 if p.mountpoint == "/boot":
                     constraint.recommended = True

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -836,7 +836,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
         """Test GetMountPointConstraints."""
         result = self.interface.GetMountPointConstraints()
         assert isinstance(result, list)
-        assert len(result) == 2
+        assert len(result) == 3
 
         result = MountPointConstraintsData.from_structure_list(
             self.interface.GetMountPointConstraints()


### PR DESCRIPTION
Requires update in WebUI: https://github.com/rhinstaller/anaconda-webui/pull/140/commits/00b8f69ae482f3f5932f7a2243132961547c8e93