### PR TITLE
rpm-ostree: Setup readonly sysroot for ostree & rw karg

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -456,6 +456,8 @@ class ConfigureBootloader(Task):
         if root_data.type == "btrfs subvolume":
             set_kargs_args.append("rootflags=subvol=" + root_name)
 
+        set_kargs_args.append("rw")
+
         safe_exec_with_redirect("ostree", set_kargs_args, root=self._sysroot)
 
 
@@ -515,7 +517,18 @@ class DeployOSTreeTask(Task):
                  self._data.remote + ':' + ref]
             )
 
-        log.info("ostree deploy complete")
+        log.info("ostree config set sysroot.readonly true")
+
+        safe_exec_with_redirect(
+            "ostree",
+            ["config",
+             "--repo=" + self._sysroot + "/ostree/repo",
+             "set",
+             "sysroot.readonly",
+             "true"]
+        )
+
+        log.info("ostree admin deploy complete")
         self.report_progress(_("Deployment complete: {}").format(ref))
 
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -625,7 +625,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             exec_mock.assert_called_once_with(
                 "ostree",
                 ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC",
-                 "rootflags=subvol=device-name"],
+                 "rootflags=subvol=device-name", "rw"],
                 root=sysroot
             )
 
@@ -661,7 +661,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             )
             exec_mock.assert_called_once_with(
                 "ostree",
-                ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC"],
+                ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
                 root=sysroot
             )
 


### PR DESCRIPTION
- Enable read only sysroot in the ostree repo config.
- Add `rw` to the kernel arguments to keep statefull parts of the system (/var & /etc) writable.
- Update units tests to account for the new rw karg

(cherry-picked from a commit 0e00c90882)

Related: RHEL-2250