### PR TITLE
RHEL-9: infra: bumpver: Fix wrong locale comming from JIRA

### DIFF
--- a/.structure-config
+++ b/.structure-config
@@ -10,4 +10,7 @@ dockerfile/
 docs/requirements.txt
 scripts/testing/
 scripts/githooks/
+scripts/makebumpver
+scripts/rhel_version.py
+scripts/rhel_version.py.j2
 )

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -261,28 +261,9 @@ class MakeBumpVer:
         return new
 
     def _is_RHEL(self):
-        proc = run_program(['git', 'branch'])
-        lines = [x for x in proc[0].strip('\n').split('\n') if x.startswith('*')]
+        if rhel_version:
+            return True
 
-        if lines == [] or len(lines) > 1:
-            return False
-
-        fields = lines[0].split(' ')
-
-        if len(fields) == 2:
-            self.git_branch = fields[1]
-        else:
-            return False
-
-        if self.git_branch.startswith('rhel'):
-            branch_pattern = r"^rhel(\d+)-(.*)"
-            m = re.match(branch_pattern, self.git_branch)
-            if m:
-                return m.group(1)
-            rhel_branch_pattern = r"^rhel-(\d+)(.*)"
-            m = re.match(rhel_branch_pattern, self.git_branch)
-            if m:
-                return m.group(1)
         return False
 
     def _get_commit_detail(self, commit, field):

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -121,10 +121,14 @@ class JIRAValidator:
     def validate_RHEL_issue_status(self, bug):
         issue = self._query_RHEL_issue(bug)
 
-        valid_statuses = ("Planning", "In Progress")
-        status = issue.fields.status.name
-        if status not in valid_statuses:
-            return False, f"incorrect status '{status}'! Valid values: {valid_statuses}"
+        # translation from status id to name because JIRA is using locale set in the JIRA account
+        # that can't be changed from REST API
+        valid_status_map = {13521: "Planning",
+                            10018: "In Progress"}
+
+        status = issue.fields.status
+        if int(status.id) not in valid_status_map:
+            return False, f"incorrect status! Valid values: {', '.join(valid_status_map.values())}"
 
         return True, ""
 

--- a/scripts/rhel_version.py
+++ b/scripts/rhel_version.py
@@ -26,3 +26,4 @@
 
 
 rhel_version = "rhel-9"
+

--- a/scripts/rhel_version.py.j2
+++ b/scripts/rhel_version.py.j2
@@ -17,5 +17,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+{% if distro_name == "rhel" %}
 
 rhel_version = "rhel-{$ distro_release $}"
+
+{% else %}
+
+rhel_version = ""
+
+{% endif %}


### PR DESCRIPTION
JIRA account is the one what define responses locale. Unfortunately this can't be changed from REST API. At the end it means that we need to use ID of the statuses instead of their name.