### PR TITLE
Use blivet's "device ID" as a unique device identifier

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -66,9 +66,9 @@ def exitHandler(rebootData):
     device_tree = STORAGE.get_proxy(DEVICE_TREE)  # pylint: disable=possibly-used-before-assignment
     optical_media = []
 
-    for device_name in device_tree.FindOpticalMedia():
+    for device_id in device_tree.FindOpticalMedia():
         device_data = DeviceData.from_structure(
-            device_tree.GetDeviceData(device_name)
+            device_tree.GetDeviceData(device_id)
         )
         optical_media.append(device_data.path)
 

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -26,6 +26,7 @@ class DeviceData(DBusData):
     """Device data."""
 
     def __init__(self):
+        self._device_id = ""
         self._type = ""
         self._name = ""
         self._path = ""
@@ -62,6 +63,18 @@ class DeviceData(DBusData):
     @name.setter
     def name(self, name: Str):
         self._name = name
+
+    @property
+    def device_id(self) -> Str:
+        """A ID of the device
+
+        :return: a device ID
+        """
+        return self._device_id
+
+    @device_id.setter
+    def device_id(self, device_id: Str):
+        self._device_id = device_id
 
     @property
     def path(self) -> Str:
@@ -121,19 +134,19 @@ class DeviceData(DBusData):
     def parents(self) -> List[Str]:
         """Parents of the device.
 
-        :return: a list of device names
+        :return: a list of device IDs
         """
         return self._parents
 
     @parents.setter
-    def parents(self, names):
-        self._parents = names
+    def parents(self, ids):
+        self._parents = ids
 
     @property
     def children(self) -> List[Str]:
         """Children of the device.
 
-        :return: a list of device names
+        :return: a list of device IDs
         """
         return self._children
 
@@ -313,6 +326,7 @@ class DeviceActionData(DBusData):
         self._object_description = ""
 
         self._device_name = ""
+        self._device_id = ""
         self._device_description = ""
 
         self._attrs = {}
@@ -383,6 +397,18 @@ class DeviceActionData(DBusData):
     @device_name.setter
     def device_name(self, name: Str):
         self._device_name = name
+
+    @property
+    def device_id(self) -> Str:
+        """A ID of the device.
+
+        :return: a device ID
+        """
+        return self._device_id
+
+    @device_id.setter
+    def device_id(self, device_id: Str):
+        self._device_id = device_id
 
     @property
     def device_description(self) -> Str:

--- a/pyanaconda/modules/payloads/payload/live_image/installation_progress.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation_progress.py
@@ -109,8 +109,8 @@ class InstallationProgress(Cancellable):
         result = []
         counted_btrfs_volumes = []
 
-        for path, device in mount_points.items():
-            dev_data = DeviceData.from_structure(device_tree.GetDeviceData(device))
+        for path, device_id in mount_points.items():
+            dev_data = DeviceData.from_structure(device_tree.GetDeviceData(device_id))
 
             if not dev_data.type == "btrfs subvolume":
                 # not btrfs subvolume, so just take it as is
@@ -118,7 +118,7 @@ class InstallationProgress(Cancellable):
             else:
                 # For BTRFS, add only one mount-pointed subvolume per volume.
                 # That's because statvfs reports free/used as aggregate across the whole volume.
-                ancestors = device_tree.GetAncestors([device])
+                ancestors = device_tree.GetAncestors([device_id])
                 for ancestor in ancestors:
                     anc_data = DeviceData.from_structure(device_tree.GetDeviceData(ancestor))
                     if anc_data.type == "btrfs volume" and ancestor not in counted_btrfs_volumes:

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -564,17 +564,17 @@ class ConfigureBootloader(Task):
         bootloader = STORAGE.get_proxy(BOOTLOADER)
         device_tree = STORAGE.get_proxy(DEVICE_TREE)
 
-        root_name = device_tree.GetRootDevice()
+        root_id = device_tree.GetRootDevice()
         root_data = DeviceData.from_structure(
-            device_tree.GetDeviceData(root_name)
+            device_tree.GetDeviceData(root_id)
         )
 
         set_kargs_args = ["admin", "instutil", "set-kargs"]
         set_kargs_args.extend(bootloader.GetArguments())
-        set_kargs_args.append("root=" + device_tree.GetFstabSpec(root_name))
+        set_kargs_args.append("root=" + device_tree.GetFstabSpec(root_id))
 
         if root_data.type == "btrfs subvolume":
-            set_kargs_args.append("rootflags=subvol=" + root_name)
+            set_kargs_args.append("rootflags=subvol=" + root_data.name)
 
         set_kargs_args.append("rw")
 

--- a/pyanaconda/modules/payloads/source/cdrom/cdrom.py
+++ b/pyanaconda/modules/payloads/source/cdrom/cdrom.py
@@ -41,8 +41,8 @@ class CdromSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
 
     def __init__(self):
         super().__init__()
-        self._device_name = ""
-        self.device_name_changed = Signal()
+        self._device_id = ""
+        self.device_id_changed = Signal()
 
     def __repr__(self):
         return "Source(type='CDROM')"
@@ -79,13 +79,13 @@ class CdromSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
         return 0
 
     @property
-    def device_name(self):
-        """Get device name of the cdrom found.
+    def device_id(self):
+        """Get device ID of the cdrom found.
 
-        :return: name of the cdrom device
+        :return: device ID of the cdrom device
         :rtype: str
         """
-        return self._device_name
+        return self._device_id
 
     def get_state(self):
         """Get state of this source."""
@@ -126,6 +126,6 @@ class CdromSourceModule(PayloadSourceBase, MountingSourceMixin, RPMSourceMixin):
         data.cdrom.seen = True
 
     def _handle_setup_task_result(self, task):
-        self._device_name = task.get_result()
-        self.device_name_changed.emit()
+        self._device_id = task.get_result()
+        self.device_id_changed.emit()
         self.module_properties_changed.emit()

--- a/pyanaconda/modules/payloads/source/cdrom/cdrom_interface.py
+++ b/pyanaconda/modules/payloads/source/cdrom/cdrom_interface.py
@@ -34,9 +34,9 @@ class CdromSourceInterface(PayloadSourceBaseInterface):
 
     def connect_signals(self):
         super().connect_signals()
-        self.watch_property("DeviceName", self.implementation.device_name_changed)
+        self.watch_property("DeviceID", self.implementation.device_id_changed)
 
     @property
-    def DeviceName(self) -> Str:
-        """Get device name of the cdrom found."""
-        return self.implementation.device_name
+    def DeviceID(self) -> Str:
+        """Get device ID of the cdrom found."""
+        return self.implementation.device_id

--- a/pyanaconda/modules/payloads/source/cdrom/initialization.py
+++ b/pyanaconda/modules/payloads/source/cdrom/initialization.py
@@ -46,32 +46,33 @@ class SetUpCdromSourceTask(SetUpMountTask):
         device_tree = STORAGE.get_proxy(DEVICE_TREE)
 
         device_candidates = self._get_device_candidate_list(device_tree)
-        device_name = self._choose_installation_device(device_tree, device_candidates)
+        device_id = self._choose_installation_device(device_tree, device_candidates)
 
-        if not device_name:
+        if not device_id:
             raise SourceSetupError("Found no CD-ROM")
 
-        return device_name
+        return device_id
 
     def _get_device_candidate_list(self, device_tree):
         return device_tree.FindOpticalMedia()
 
     def _choose_installation_device(self, device_tree, devices_candidates):
-        device_name = ""
+        device_id = ""
 
-        for dev_name in devices_candidates:
+        for dev_id in devices_candidates:
             try:
-                device_data = DeviceData.from_structure(device_tree.GetDeviceData(dev_name))
+                device_data = DeviceData.from_structure(device_tree.GetDeviceData(dev_id))
                 mount(device_data.path, self._target_mount, "iso9660", "ro")
             except OSError as e:
-                log.debug("Failed to mount %s: %s", dev_name, str(e))
+                log.debug("Failed to mount %s: %s", device_data.path, str(e))
                 continue
 
             if is_valid_install_disk(self._target_mount):
-                device_name = dev_name
-                log.info("using CD-ROM device %s mounted at %s", dev_name, self._target_mount)
+                device_id = dev_id
+                log.info("using CD-ROM device %s mounted at %s",
+                         device_data.name, self._target_mount)
                 break
             else:
                 unmount(self._target_mount)
 
-        return device_name
+        return device_id

--- a/pyanaconda/modules/payloads/source/live_os/initialization.py
+++ b/pyanaconda/modules/payloads/source/live_os/initialization.py
@@ -132,14 +132,14 @@ class SetUpLiveOSSourceTask(SetUpMountTask):
         device_tree = STORAGE.get_proxy(DEVICE_TREE)
 
         # Get the device name.
-        device_name = device_tree.ResolveDevice(self._image_path)
+        device_id = device_tree.ResolveDevice(self._image_path)
 
-        if not device_name:
+        if not device_id:
             raise SourceSetupError("Failed to resolve the Live OS image.")
 
         # Get the device path.
         device_data = DeviceData.from_structure(
-            device_tree.GetDeviceData(device_name)
+            device_tree.GetDeviceData(device_id)
         )
         device_path = device_data.path
 

--- a/pyanaconda/modules/storage/dasd/dasd.py
+++ b/pyanaconda/modules/storage/dasd/dasd.py
@@ -47,27 +47,27 @@ class DASDModule(StorageSubscriberModule):
         """Is this module supported?"""
         return arch.is_s390()
 
-    def _get_device(self, name):
-        """Find a device by its name.
+    def _get_device(self, device_id):
+        """Find a device by its ID.
 
-        :param name: a name of the device
+        :param device_id: ID of the device
         :return: an instance of the Blivet's device
         :raise: UnknownDeviceError if no device is found
         """
-        device = self.storage.devicetree.get_device_by_name(name, hidden=True)
+        device = self.storage.devicetree.get_device_by_device_id(device_id, hidden=True)
 
         if not device:
-            raise UnknownDeviceError(name)
+            raise UnknownDeviceError(device_id)
 
         return device
 
-    def _get_devices(self, names):
-        """Find devices by their names.
+    def _get_devices(self, device_ids):
+        """Find devices by their IDs.
 
-        :param names: names of the devices
+        :param device_ids: IDs of the devices
         :return: a list of instances of the Blivet's device
         """
-        return list(map(self._get_device, names))
+        return list(map(self._get_device, device_ids))
 
     def on_format_unrecognized_enabled_changed(self, value):
         """Update the flag for formatting unformatted DASDs."""
@@ -85,20 +85,20 @@ class DASDModule(StorageSubscriberModule):
         """
         return DASDDiscoverTask(device_number)
 
-    def find_formattable(self, disk_names):
+    def find_formattable(self, disk_ids):
         """Find DASDs for formatting.
 
-        :param disk_names: a list of disk names to search
+        :param disk_ids: a list of disk IDs to search
         :return: a list of DASDs for formatting
         """
         task = FindFormattableDASDTask(
-            self._get_devices(disk_names),
+            self._get_devices(disk_ids),
             self._can_format_unformatted,
             self._can_format_ldl
         )
 
         found_disks = task.run()
-        return [d.name for d in found_disks]
+        return [d.device_id for d in found_disks]
 
     def format_with_task(self, dasds):
         """Format specified DASD disks.

--- a/pyanaconda/modules/storage/dasd/dasd_interface.py
+++ b/pyanaconda/modules/storage/dasd/dasd_interface.py
@@ -43,13 +43,13 @@ class DASDInterface(KickstartModuleInterfaceTemplate):
             self.implementation.discover_with_task(device_number)
         )
 
-    def FindFormattable(self, disk_names: List[Str]) -> List[Str]:
+    def FindFormattable(self, disk_ids: List[Str]) -> List[Str]:
         """Find DASDs for formatting.
 
-        :param disk_names: a list of disk names to search
+        :param disk_ids: a list of disk IDs to search
         :return: a list of DASDs for formatting
         """
-        return self.implementation.find_formattable(disk_names)
+        return self.implementation.find_formattable(disk_ids)
 
     def FormatWithTask(self, dasds: List[Str]) -> ObjPath:
         """Format DASDs.

--- a/pyanaconda/modules/storage/devicetree/fsset.py
+++ b/pyanaconda/modules/storage/devicetree/fsset.py
@@ -73,6 +73,7 @@ def get_containing_device(path, devicetree):
         # have I told you lately that I love you, device-mapper?
         device_name = blockdev.dm.name_from_node(device_name)
 
+    # XXX we get device name from sysfs so usage of get_device_by_name here is correct
     return devicetree.get_device_by_name(device_name)
 
 

--- a/pyanaconda/modules/storage/devicetree/handler_interface.py
+++ b/pyanaconda/modules/storage/devicetree/handler_interface.py
@@ -30,33 +30,33 @@ __all__ = ["DeviceTreeHandlerInterface"]
 class DeviceTreeHandlerInterface(InterfaceTemplate):
     """DBus interface for the device tree handler."""
 
-    def MountDevice(self, device_name: Str, mount_point: Str, options: Str):
+    def MountDevice(self, device_id: Str, mount_point: Str, options: Str):
         """Mount a filesystem on the device.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :param mount_point: a path to the mount point
         :param options: a string with mount options or an empty string to use defaults
         :raise: MountFilesystemError if mount fails
         """
-        self.implementation.mount_device(device_name, mount_point, options)
+        self.implementation.mount_device(device_id, mount_point, options)
 
-    def UnmountDevice(self, device_name: Str, mount_point: Str):
+    def UnmountDevice(self, device_id: Str, mount_point: Str):
         """Unmount a filesystem on the device.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :param mount_point: a path to the mount point
         :raise: MountFilesystemError if unmount fails
         """
-        self.implementation.unmount_device(device_name, mount_point)
+        self.implementation.unmount_device(device_id, mount_point)
 
-    def UnlockDevice(self, device_name: Str, passphrase: Str) -> Bool:
+    def UnlockDevice(self, device_id: Str, passphrase: Str) -> Bool:
         """Unlock a device.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :param passphrase: a passphrase
         :return: True if success, otherwise False
         """
-        return self.implementation.unlock_device(device_name, passphrase)
+        return self.implementation.unlock_device(device_id, passphrase)
 
     def FindUnconfiguredLUKS(self) -> List[Str]:
         """Find all unconfigured LUKS devices.
@@ -64,37 +64,37 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
         Returns a list of devices that require to set up
         a passphrase to complete their configuration.
 
-        :return: a list of device names
+        :return: a list of device IDs
         """
         return self.implementation.find_unconfigured_luks()
 
-    def SetDevicePassphrase(self, device_name: Str, passphrase: Str):
+    def SetDevicePassphrase(self, device_id: Str, passphrase: Str):
         """Set a passphrase of the unconfigured LUKS device.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :param passphrase: a passphrase
         """
-        self.implementation.set_device_passphrase(device_name, passphrase)
+        self.implementation.set_device_passphrase(device_id, passphrase)
 
-    def GetDeviceMountOptions(self, device_name: Str) -> Str:
+    def GetDeviceMountOptions(self, device_id: Str) -> Str:
         """Get mount options of the specified device.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :return: a string with options
         """
-        return self.implementation.get_device_mount_options(device_name)
+        return self.implementation.get_device_mount_options(device_id)
 
-    def SetDeviceMountOptions(self, device_name: Str, mount_options: Str):
+    def SetDeviceMountOptions(self, device_id: Str, mount_options: Str):
         """Set mount options of the specified device.
 
         Specifies a free form string of options to be used when
         mounting the filesystem. This string will be copied into
         the /etc/fstab file of the installed system.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :param mount_options: a string with options
         """
-        self.implementation.set_device_mount_options(device_name, mount_options)
+        self.implementation.set_device_mount_options(device_id, mount_options)
 
     def FindDevicesWithTask(self) -> ObjPath:
         """Find new devices.
@@ -110,14 +110,14 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
     def FindOpticalMedia(self) -> List[Str]:
         """Find all devices with mountable optical media.
 
-        :return: a list of device names
+        :return: a list of device IDs
         """
         return self.implementation.find_optical_media()
 
     def FindMountablePartitions(self) -> List[Str]:
         """Find all mountable partitions.
 
-        :return: a list of device names
+        :return: a list of device IDs
         """
         return self.implementation.find_mountable_partitions()
 
@@ -132,13 +132,13 @@ class DeviceTreeHandlerInterface(InterfaceTemplate):
             self.implementation.find_existing_systems_with_task()
         )
 
-    def MountExistingSystemWithTask(self, device_name: Str, read_only: Bool) -> ObjPath:
+    def MountExistingSystemWithTask(self, device_id: Str, read_only: Bool) -> ObjPath:
         """Mount existing GNU/Linux installation.
 
-        :param device_name: a name of the root device
+        :param device_id: device ID of the root device
         :param read_only: mount the system in read-only mode
         :return: a path to the task
         """
         return TaskContainer.to_object_path(
-            self.implementation.mount_existing_system_with_task(device_name, read_only)
+            self.implementation.mount_existing_system_with_task(device_id, read_only)
         )

--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -418,15 +418,15 @@ class InstallerStorage(Blivet):
         # Remove duplicate names from the list.
         return sorted(set(disks), key=lambda d: d.name)
 
-    def select_disks(self, selected_names):
+    def select_disks(self, selected_ids):
         """Select disks that should be used for the installation.
 
         Hide usable disks that are not selected.
 
-        :param selected_names: a list of disk names
+        :param selected_names: a list of disk device IDs
         """
         for disk in self.usable_disks:
-            if disk.name not in selected_names:
+            if disk.device_id not in selected_ids:
                 if disk in self.devices:
                     self.devicetree.hide(disk)
             else:

--- a/pyanaconda/modules/storage/devicetree/viewer_interface.py
+++ b/pyanaconda/modules/storage/devicetree/viewer_interface.py
@@ -41,7 +41,7 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
     def GetDevices(self) -> List[Str]:
         """Get all devices in the device tree.
 
-        :return: a list of device names
+        :return: a list of device IDs
         """
         return self.implementation.get_devices()
 
@@ -50,37 +50,37 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
 
         Ignored disks are excluded, as are disks with no media present.
 
-        :return: a list of device names
+        :return: a list of device IDs
         """
         return self.implementation.get_disks()
 
     def GetMountPoints(self) -> Dict[Str, Str]:
         """Get all mount points in the device tree.
 
-        :return: a dictionary of mount points and device names
+        :return: a dictionary of mount points and device IDs
         """
         return self.implementation.get_mount_points()
 
-    def GetDeviceData(self, name: Str) -> Structure:
+    def GetDeviceData(self, device_id: Str) -> Structure:
         """Get the device data.
 
-        :param name: a device name
+        :param device_id: device ID
         :return: a structure with device data
         :raise: UnknownDeviceError if the device is not found
         """
-        return DeviceData.to_structure(self.implementation.get_device_data(name))
+        return DeviceData.to_structure(self.implementation.get_device_data(device_id))
 
-    def GetFormatData(self, name: Str) -> Structure:
+    def GetFormatData(self, device_id: Str) -> Structure:
         """Get the device format data.
 
         Return data about a format of the specified device.
 
         For example: sda1
 
-        :param name: a name of the device
+        :param device_id: ID of the device
         :return: a structure with format data
         """
-        return DeviceFormatData.to_structure(self.implementation.get_format_data(name))
+        return DeviceFormatData.to_structure(self.implementation.get_format_data(device_id))
 
     def GetFormatTypeData(self, name: Str) -> Structure:
         """Get the format type data.
@@ -111,20 +111,20 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         If no device is found, return an empty string.
 
         :param dev_spec: a string describing a block device
-        :return: a device name or an empty string
+        :return: a device ID or an empty string
         """
         return self.implementation.resolve_device(dev_spec)
 
-    def GetAncestors(self, device_names: List[Str]) -> List[Str]:
+    def GetAncestors(self, device_ids: List[Str]) -> List[Str]:
         """Collect ancestors of the specified devices.
 
         Ancestors of a device don't include the device itself.
-        The list is sorted by names of the devices.
+        The list is sorted by IDs of the devices.
 
-        :param device_names: a list of device names
-        :return: a list of device names
+        :param device_ids: a list of device names
+        :return: a list of device IDs
         """
-        return self.implementation.get_ancestors(device_names)
+        return self.implementation.get_ancestors(device_ids)
 
     def GetSupportedFileSystems(self) -> List[Str]:
         """Get the supported types of filesystems.
@@ -149,42 +149,42 @@ class DeviceTreeViewerInterface(InterfaceTemplate):
         """
         return self.implementation.get_file_system_free_space(mount_points)
 
-    def GetDiskFreeSpace(self, disk_names: List[Str]) -> UInt64:
+    def GetDiskFreeSpace(self, disk_ids: List[Str]) -> UInt64:
         """Get total free space on the given disks.
 
         Calculates free space available for use.
 
-        :param disk_names: a list of disk names
+        :param disk_ids: a list of disk IDs
         :return: a total size in bytes
         """
-        return self.implementation.get_disk_free_space(disk_names)
+        return self.implementation.get_disk_free_space(disk_ids)
 
-    def GetDiskReclaimableSpace(self, disk_names: List[Str]) -> UInt64:
+    def GetDiskReclaimableSpace(self, disk_ids: List[Str]) -> UInt64:
         """Get total reclaimable space on the given disks.
 
         Calculates free space unavailable but reclaimable
         from existing partitions.
 
-        :param disk_names: a list of disk names
+        :param disk_ids: a list of disk IDs
         :return: a total size in bytes
         """
-        return self.implementation.get_disk_reclaimable_space(disk_names)
+        return self.implementation.get_disk_reclaimable_space(disk_ids)
 
-    def GetDiskTotalSpace(self, disk_names: List[Str]) -> UInt64:
+    def GetDiskTotalSpace(self, disk_ids: List[Str]) -> UInt64:
         """Get total space on the given disks.
 
-        :param disk_names: a list of disk names
+        :param disk_ids: a list of disk IDs
         :return: a total size in bytes
         """
-        return self.implementation.get_disk_total_space(disk_names)
+        return self.implementation.get_disk_total_space(disk_ids)
 
-    def GetFstabSpec(self, name: Str) -> Str:
+    def GetFstabSpec(self, device_id: Str) -> Str:
         """Get the device specifier for use in /etc/fstab.
 
-        :param name: a name of the device
+        :param device_id: ID of the device
         :return: a device specifier for /etc/fstab
         """
-        return self.implementation.get_fstab_spec(name)
+        return self.implementation.get_fstab_spec(device_id)
 
     def GetExistingSystems(self) -> List[Structure]:
         """Get existing GNU/Linux installations.

--- a/pyanaconda/modules/storage/disk_selection/selection.py
+++ b/pyanaconda/modules/storage/disk_selection/selection.py
@@ -76,7 +76,7 @@ class DiskSelectionModule(StorageSubscriberModule):
         Specifies those disks that anaconda can use for
         partitioning, formatting, and clearing.
 
-        :param drives: a list of drives names
+        :param drives: a list of drives IDs
         """
         self._selected_disks = drives
         self.selected_disks_changed.emit(list(drives))
@@ -85,7 +85,7 @@ class DiskSelectionModule(StorageSubscriberModule):
     def validate_selected_disks(self, drives):
         """Validate the list of selected disks.
 
-        :param drives: a list of drives names
+        :param drives: a list of drives IDs
         :return: a validation report
         """
         report = ValidationReport()
@@ -106,7 +106,7 @@ class DiskSelectionModule(StorageSubscriberModule):
 
         It can be set from the kickstart with 'ignoredisk --onlyuse'.
 
-        :param drives: a list of drives names
+        :param drives: a list of drives IDs
         """
         self._exclusive_disks = drives
         self.exclusive_disks_changed.emit()
@@ -123,7 +123,7 @@ class DiskSelectionModule(StorageSubscriberModule):
         Specifies those disks that anaconda should not touch
         when it does partitioning, formatting, and clearing.
 
-        :param drives: a list of drive names
+        :param drives: a list of drive IDs
         """
         self._ignored_disks = drives
         self.ignored_disks_changed.emit()
@@ -139,7 +139,7 @@ class DiskSelectionModule(StorageSubscriberModule):
 
         Specifies those disks that anaconda should protect.
 
-        :param devices: a list of device names
+        :param devices: a list of device IDs
         """
         self._protected_devices = devices
         self.protected_devices_changed.emit(list(devices))
@@ -162,6 +162,6 @@ class DiskSelectionModule(StorageSubscriberModule):
     def get_usable_disks(self):
         """Get a list of disks that can be used for the installation.
 
-        :return: a list of disk names
+        :return: a list of disk IDs
         """
-        return [disk.name for disk in self.storage.usable_disks]
+        return [disk.device_id for disk in self.storage.usable_disks]

--- a/pyanaconda/modules/storage/disk_selection/selection_interface.py
+++ b/pyanaconda/modules/storage/disk_selection/selection_interface.py
@@ -51,14 +51,14 @@ class DiskSelectionInterface(KickstartModuleInterfaceTemplate):
         Specifies those disks that anaconda can use for
         partitioning, formatting, and clearing.
 
-        :param drives: a list of drives names
+        :param drives: a list of drives IDs
         """
         self.implementation.set_selected_disks(drives)
 
     def ValidateSelectedDisks(self, drives: List[Str]) -> Structure:
         """Validate the list of selected disks.
 
-        :param drives: a list of drives names
+        :param drives: a list of drives IDs
         :return: a validation report
         """
         return ValidationReport.to_structure(
@@ -81,7 +81,7 @@ class DiskSelectionInterface(KickstartModuleInterfaceTemplate):
 
         It can be set from the kickstart with 'ignoredisk --onlyuse'.
 
-        :param drives: a list of drives names
+        :param drives: a list of drives IDs
         """
         self.implementation.set_exclusive_disks(drives)
 
@@ -98,7 +98,7 @@ class DiskSelectionInterface(KickstartModuleInterfaceTemplate):
         Specifies those disks that anaconda should not touch
         when it does partitioning, formatting, and clearing.
 
-        :param drives: a list of drive names
+        :param drives: a list of drive IDs
         """
         self.implementation.set_ignored_disks(drives)
 
@@ -114,7 +114,7 @@ class DiskSelectionInterface(KickstartModuleInterfaceTemplate):
 
         Specifies those disks that anaconda should protect.
 
-        :param devices: a list of device names
+        :param devices: a list of device IDs
         """
         self.implementation.set_protected_devices(devices)
 
@@ -135,6 +135,6 @@ class DiskSelectionInterface(KickstartModuleInterfaceTemplate):
     def GetUsableDisks(self) -> List[Str]:
         """Get a list of disks that can be used for the installation.
 
-        :return: a list of disk names
+        :return: a list of disk IDs
         """
         return self.implementation.get_usable_disks()

--- a/pyanaconda/modules/storage/disk_selection/utils.py
+++ b/pyanaconda/modules/storage/disk_selection/utils.py
@@ -29,15 +29,15 @@ def check_disk_selection(storage, selected_disks):
     """
     errors = []
 
-    for name in selected_disks:
-        selected = storage.devicetree.get_device_by_name(name, hidden=True)
+    for disk_id in selected_disks:
+        selected = storage.devicetree.get_device_by_device_id(disk_id, hidden=True)
 
         if not selected:
-            errors.append(_("The selected disk {} is not recognized.").format(name))
+            errors.append(_("The selected disk {} is not recognized.").format(disk_id))
             continue
 
-        related = sorted(storage.devicetree.get_related_disks(selected), key=lambda d: d.name)
-        missing = [r.name for r in related if r.name not in selected_disks]
+        related = sorted(storage.devicetree.get_related_disks(selected), key=lambda d: d.device_id)
+        missing = [r for r in related if r.device_id not in selected_disks]
 
         if not missing:
             continue
@@ -53,7 +53,7 @@ def check_disk_selection(storage, selected_disks):
             "these disks as a set.",
             len(missing)) % {
             "selected": selected.name,
-            "unselected": ", ".join(missing)
+            "unselected": ", ".join([m.name for m in missing])
         })
 
     return errors

--- a/pyanaconda/modules/storage/partitioning/automatic/resizable_interface.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/resizable_interface.py
@@ -29,52 +29,52 @@ __all__ = ["ResizableDeviceTreeInterface"]
 class ResizableDeviceTreeInterface(DeviceTreeInterface):
     """DBus interface for the resizable device tree."""
 
-    def IsDevicePartitioned(self, device_name: Str) -> Bool:
+    def IsDevicePartitioned(self, device_id: Str) -> Bool:
         """Is the specified device partitioned?
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         :return: True or False
         """
-        return self.implementation.is_device_partitioned(device_name)
+        return self.implementation.is_device_partitioned(device_id)
 
-    def IsDeviceShrinkable(self, device_name: Str) -> Bool:
+    def IsDeviceShrinkable(self, device_id: Str) -> Bool:
         """Is the specified device shrinkable?
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         :return: True or False
         """
-        return self.implementation.is_device_shrinkable(device_name)
+        return self.implementation.is_device_shrinkable(device_id)
 
-    def GetDevicePartitions(self, device_name: Str) -> List[Str]:
+    def GetDevicePartitions(self, device_id: Str) -> List[Str]:
         """Get partitions of the specified device.
 
-        :param device_name: a name of the device
-        :return: a list of device names
+        :param device_id: device ID of the device
+        :return: a list of device IDs
         """
-        return self.implementation.get_device_partitions(device_name)
+        return self.implementation.get_device_partitions(device_id)
 
-    def GetDeviceSizeLimits(self, device_name: Str) -> Tuple[UInt64, UInt64]:
+    def GetDeviceSizeLimits(self, device_id: Str) -> Tuple[UInt64, UInt64]:
         """Get size limits of the given device.
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         :return: a tuple of min and max sizes in bytes
         """
-        return self.implementation.get_device_size_limits(device_name)
+        return self.implementation.get_device_size_limits(device_id)
 
-    def ShrinkDevice(self, device_name: Str, size: UInt64):
+    def ShrinkDevice(self, device_id: Str, size: UInt64):
         """Shrink the size of the device.
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         :param size: a new size in bytes
         """
-        self.implementation.shrink_device(device_name, size)
+        self.implementation.shrink_device(device_id, size)
 
-    def RemoveDevice(self, device_name: Str):
+    def RemoveDevice(self, device_id: Str):
         """Remove a device after removing its dependent devices.
 
         If the device is protected, do nothing. If the device has
         protected children, just remove the unprotected ones.
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         """
-        self.implementation.remove_device(device_name)
+        self.implementation.remove_device(device_id)

--- a/pyanaconda/modules/storage/partitioning/automatic/resizable_module.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/resizable_module.py
@@ -38,13 +38,13 @@ class ResizableDeviceTreeModule(DeviceTreeModule):
         """Return a DBus representation."""
         return ResizableDeviceTreeInterface(self)
 
-    def is_device_partitioned(self, device_name):
+    def is_device_partitioned(self, device_id):
         """Is the specified device partitioned?
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         :return: True or False
         """
-        device = self._get_device(device_name)
+        device = self._get_device(device_id)
         return self._is_device_partitioned(device)
 
     @staticmethod
@@ -52,28 +52,28 @@ class ResizableDeviceTreeModule(DeviceTreeModule):
         """Is the specified device partitioned?"""
         return device.is_disk and device.partitioned and device.format.supported
 
-    def is_device_shrinkable(self, device_name):
+    def is_device_shrinkable(self, device_id):
         """Is the specified device shrinkable?
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         :return: True or False
         """
-        device = self._get_device(device_name)
+        device = self._get_device(device_id)
         return device.resizable and device.min_size < device.size
 
-    def get_device_partitions(self, device_name):
+    def get_device_partitions(self, device_id):
         """Get partitions of the specified device.
 
-        :param device_name: a name of the device
-        :return: a list of device names
+        :param device_id: device ID of the device
+        :return: a list of device IDs
         """
-        device = self._get_device(device_name)
+        device = self._get_device(device_id)
 
         if not self._is_device_partitioned(device):
             return []
 
         return [
-            d.name for d in device.children
+            d.device_id for d in device.children
             if not (
                 isinstance(d, PartitionDevice)
                 and d.is_extended
@@ -81,32 +81,32 @@ class ResizableDeviceTreeModule(DeviceTreeModule):
             )
         ]
 
-    def get_device_size_limits(self, device_name):
+    def get_device_size_limits(self, device_id):
         """Get size limits of the given device.
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         :return: a tuple of min and max sizes in bytes
         """
-        device = self._get_device(device_name)
+        device = self._get_device(device_id)
         return device.min_size.get_bytes(), device.max_size.get_bytes()
 
-    def shrink_device(self, device_name, size):
+    def shrink_device(self, device_id, size):
         """Shrink the size of the device.
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         :param size: a new size in bytes
         """
         size = Size(size)
-        device = self._get_device(device_name)
+        device = self._get_device(device_id)
         shrink_device(self.storage, device, size)
 
-    def remove_device(self, device_name):
+    def remove_device(self, device_id):
         """Remove a device after removing its dependent devices.
 
         If the device is protected, do nothing. If the device has
         protected children, just remove the unprotected ones.
 
-        :param device_name: a name of the device
+        :param device_id: device ID of the device
         """
-        device = self._get_device(device_name)
+        device = self._get_device(device_id)
         remove_device(self.storage, device)

--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_interface.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_interface.py
@@ -35,40 +35,40 @@ __all__ = ["DeviceTreeSchedulerInterface"]
 class DeviceTreeSchedulerInterface(DeviceTreeInterface):
     """DBus interface for the device tree scheduler."""
 
-    def IsDevice(self, device_name: Str) -> Bool:
+    def IsDevice(self, device_id: Str) -> Bool:
         """Is the specified device in the device tree?
 
         It can recognize also hidden and incomplete devices.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :return: True or False
         """
-        return self.implementation.is_device(device_name)
+        return self.implementation.is_device(device_id)
 
-    def IsDeviceLocked(self, device_name: Str) -> Bool:
+    def IsDeviceLocked(self, device_id: Str) -> Bool:
         """Is the specified device locked?
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :return: True or False
         """
-        return self.implementation.is_device_locked(device_name)
+        return self.implementation.is_device_locked(device_id)
 
-    def IsDeviceEditable(self, device_name: Str) -> Bool:
+    def IsDeviceEditable(self, device_id: Str) -> Bool:
         """Is the specified device editable?
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :return: True or False
         """
-        return self.implementation.is_device_editable(device_name)
+        return self.implementation.is_device_editable(device_id)
 
-    def CheckCompleteness(self, device_name: Str) -> Structure:
+    def CheckCompleteness(self, device_id: Str) -> Structure:
         """Check that the specified device is complete.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :return: a validation report
         """
         return ValidationReport.to_structure(
-            self.implementation.check_completeness(device_name)
+            self.implementation.check_completeness(device_id)
         )
 
     def GetDefaultFileSystem(self) -> Str:
@@ -88,7 +88,7 @@ class DeviceTreeSchedulerInterface(DeviceTreeInterface):
     def GetContainerFreeSpace(self, container_name: Str) -> UInt64:
         """Get total free space in the specified container.
 
-        :param container_name: a name of the container
+        :param container_name: device ID of the container
         :return: a size in bytes
         """
         return self.implementation.get_container_free_space(container_name)
@@ -126,17 +126,17 @@ class DeviceTreeSchedulerInterface(DeviceTreeInterface):
         """
         return self.implementation.generate_container_name()
 
-    def GenerateDeviceFactoryRequest(self, device_name: Str) -> Structure:
+    def GenerateDeviceFactoryRequest(self, device_id: Str) -> Structure:
         """Generate a device factory request for the given device.
 
         The request will reflect the current state of the device.
         It can be modified and used to change the device.
 
-        :param device_name: a device name
+        :param device_id: a device ID
         :return: a device factory request
         """
         return DeviceFactoryRequest.to_structure(
-            self.implementation.generate_device_factory_request(device_name)
+            self.implementation.generate_device_factory_request(device_id)
         )
 
     def GenerateDeviceFactoryPermissions(self, request: Structure) -> Structure:
@@ -214,21 +214,21 @@ class DeviceTreeSchedulerInterface(DeviceTreeInterface):
             self.implementation.collect_supported_systems()
         )
 
-    def GetDeviceTypesForDevice(self, device_name: Str) -> List[Int]:
+    def GetDeviceTypesForDevice(self, device_id: Str) -> List[Int]:
         """Collect supported device types for the given device.
 
-        :param device_name: a device name
+        :param device_id: a device ID
         :return: a list of device types
         """
-        return self.implementation.get_device_types_for_device(device_name)
+        return self.implementation.get_device_types_for_device(device_id)
 
-    def GetFileSystemsForDevice(self, device_name: Str) -> List[Str]:
+    def GetFileSystemsForDevice(self, device_id: Str) -> List[Str]:
         """Get supported file system types for the given device.
 
-        :param device_name: a device name
+        :param device_id: a device ID
         :return: a list of file system names
         """
-        return self.implementation.get_file_systems_for_device(device_name)
+        return self.implementation.get_file_systems_for_device(device_id)
 
     def GetSupportedRaidLevels(self, device_type: Int) -> List[Str]:
         """Get RAID levels for the specified device type.
@@ -303,23 +303,23 @@ class DeviceTreeSchedulerInterface(DeviceTreeInterface):
             DeviceFactoryRequest.from_structure(original_request)
         )
 
-    def ResetDevice(self, device_name: Str):
+    def ResetDevice(self, device_id: Str):
         """Reset the specified device in the storage model.
 
         FIXME: Merge with DestroyDevice.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :raise: StorageConfigurationError in case of failure
         """
-        self.implementation.reset_device(device_name)
+        self.implementation.reset_device(device_id)
 
-    def DestroyDevice(self, device_name: Str):
+    def DestroyDevice(self, device_id: Str):
         """Destroy the specified device in the storage model.
 
-        :param device_name: a name of the device
+        :param device_id: ID of the device
         :raise: StorageConfigurationError in case of failure
         """
-        self.implementation.destroy_device(device_name)
+        self.implementation.destroy_device(device_id)
 
     def SchedulePartitionsWithTask(self, request: Structure) -> ObjPath:
         """Schedule the partitioning actions.

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -774,8 +774,8 @@ def get_device_factory_arguments(storage, request: DeviceFactoryRequest, subset=
     """
     args = {
         "device_type": request.device_type,
-        "device": storage.devicetree.get_device_by_name(request.device_spec),
-        "disks": [storage.devicetree.get_device_by_name(d) for d in request.disks],
+        "device": storage.devicetree.get_device_by_device_id(request.device_spec),
+        "disks": [storage.devicetree.get_device_by_device_id(d) for d in request.disks],
         "mountpoint": request.mount_point or None,
         "fstype": request.format_type or None,
         "label": request.label or None,
@@ -815,7 +815,7 @@ def generate_device_factory_request(storage, device) -> DeviceFactoryRequest:
 
     # Generate the device data.
     request = DeviceFactoryRequest()
-    request.device_spec = device.name
+    request.device_spec = device.device_id
     request.device_name = getattr(device.raw_device, "lvname", device.raw_device.name)
     request.device_size = device.size.get_bytes()
     request.device_type = device_type
@@ -832,7 +832,7 @@ def generate_device_factory_request(storage, device) -> DeviceFactoryRequest:
     else:
         disks = device.disks
 
-    request.disks = [d.name for d in disks]
+    request.disks = [d.device_id for d in disks]
 
     if request.device_type not in CONTAINER_DEVICE_TYPES:
         return request
@@ -857,7 +857,7 @@ def set_container_data(request: DeviceFactoryRequest, container):
     :param request: a device factory request
     :param container: a container
     """
-    request.container_spec = container.name
+    request.container_spec = container.device_id
     request.container_name = container.name
     request.container_encrypted = container.encrypted
     request.container_raid_level = get_container_raid_level_name(container)
@@ -881,7 +881,7 @@ def generate_container_data(storage, request: DeviceFactoryRequest):
         return
 
     # Find a container of the requested type.
-    device = storage.devicetree.resolve_device(request.device_spec)
+    device = storage.devicetree.get_device_by_device_id(request.device_spec)
     container = get_container(storage, request.device_type, device.raw_device)
 
     if container:
@@ -917,7 +917,7 @@ def update_container_data(storage, request: DeviceFactoryRequest, container_name
         set_container_data(request, container)
 
         # Use the container's disks.
-        request.disks = [d.name for d in container.disks]
+        request.disks = [d.device_id for d in container.disks]
     else:
         # Set the request from the new container.
         request.container_name = container_name
@@ -934,8 +934,8 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
     :return: device factory permissions
     """
     permissions = DeviceFactoryPermissions()
-    device = storage.devicetree.resolve_device(request.device_spec)
-    container = storage.devicetree.resolve_device(request.container_name)
+    device = storage.devicetree.get_device_by_device_id(request.device_spec)
+    container = storage.devicetree.get_device_by_device_id(request.container_spec)
     fmt = get_format(request.format_type)
 
     if not device:

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -368,7 +368,7 @@ def validate_device_factory_request(storage, request: DeviceFactoryRequest):
     :param request: a device factory request to validate
     :return: an error message
     """
-    device = storage.devicetree.resolve_device(request.device_spec)
+    device = storage.devicetree.get_device_by_device_id(request.device_spec)
     device_type = request.device_type
     reformat = request.reformat
     fs_type = request.format_type

--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -57,7 +57,10 @@ class ManualPartitioningModule(PartitioningModule):
         for mount_data in data.mount.mount_points:
             request = MountPointRequest()
             request.mount_point = mount_data.mount_point
-            request.device_spec = mount_data.device
+
+            device = self.storage.devicetree.resolve_device(mount_data.device)
+            request.device_spec = device.device_id
+
             request.reformat = mount_data.reformat
             request.format_type = mount_data.format
             request.format_options = mount_data.mkfs_opts
@@ -73,8 +76,11 @@ class ManualPartitioningModule(PartitioningModule):
         for request in self.requests:
             mount_data = data.MountData()
             mount_data.mount_point = request.mount_point
-            mount_data.device = request.device_spec
+
+            device = self.storage.devicetree.get_device_by_device_id(request.device_spec)
+            mount_data.device = device.path
             mount_data.reformat = request.reformat
+
             mount_data.format = request.format_type
             mount_data.mkfs_opts = request.format_options
             mount_data.mount_opts = request.mount_options
@@ -157,7 +163,7 @@ class ManualPartitioningModule(PartitioningModule):
         :return: an instance of MountPointRequest or None
         """
         for request in requests:
-            if device is self.storage.devicetree.resolve_device(request.device_spec):
+            if device is self.storage.devicetree.get_device_by_device_id(request.device_spec):
                 return request
 
         return None
@@ -169,7 +175,7 @@ class ManualPartitioningModule(PartitioningModule):
         :return: an instance of MountPointRequest
         """
         request = MountPointRequest()
-        request.device_spec = device.name
+        request.device_spec = device.device_id
         request.format_type = device.format.type or ""
         request.reformat = False
 

--- a/pyanaconda/payload/utils.py
+++ b/pyanaconda/payload/utils.py
@@ -26,40 +26,40 @@ from pyanaconda.modules.common.structures.storage import DeviceData
 log = get_module_logger(__name__)
 
 
-def get_device_path(device_name):
+def get_device_path(device_id):
     """Return a device path.
 
-    :param device_name: a device name
+    :param device_id: device ID
     :return: a device path
     """
-    if device_name is None:
+    if device_id is None:
         return None
 
     device_tree = STORAGE.get_proxy(DEVICE_TREE)
-    device_data = DeviceData.from_structure(device_tree.GetDeviceData(device_name))
+    device_data = DeviceData.from_structure(device_tree.GetDeviceData(device_id))
     return device_data.path
 
 
-def mount_device(device_name, mount_point):
+def mount_device(device_id, mount_point):
     """Mount a filesystem on the device.
 
-    :param device_name: a device name
+    :param device_id: device ID
     :param str mount_point: a path to the mount point
     """
     device_tree = STORAGE.get_proxy(DEVICE_TREE)
-    device_tree.MountDevice(device_name, mount_point, "ro")
+    device_tree.MountDevice(device_id, mount_point, "ro")
 
 
-def unmount_device(device_name, mount_point):
+def unmount_device(device_id, mount_point):
     """Unmount a filesystem on the device.
 
     FIXME: Always specify the mount point.
 
-    :param device_name: a device name
+    :param device_id: device ID
     :param str mount_point: a path to the mount point or None
     """
     if not mount_point:
-        device_path = get_device_path(device_name)
+        device_path = get_device_path(device_id)
         mount_paths = get_mount_paths(device_path)
 
         if not mount_paths:
@@ -68,7 +68,7 @@ def unmount_device(device_name, mount_point):
         mount_point = mount_paths[-1]
 
     device_tree = STORAGE.get_proxy(DEVICE_TREE)
-    device_tree.UnmountDevice(device_name, mount_point)
+    device_tree.UnmountDevice(device_id, mount_point)
 
 
 def get_mount_paths(device_path):

--- a/pyanaconda/ui/gui/spokes/advanced_storage.glade
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.glade
@@ -13,6 +13,8 @@
       <column type="gboolean"/>
       <!-- column-name diskName -->
       <column type="gchararray"/>
+      <!-- column-name diskDeviceId -->
+      <column type="gchararray"/>
       <!-- column-name diskType -->
       <column type="gchararray"/>
       <!-- column-name diskModel -->
@@ -54,6 +56,35 @@
       <!-- column-name diskNamespaceId -->
       <column type="gchararray"/>
     </columns>
+    <data>
+      <row>
+        <col id="0">False</col>
+        <col id="1">False</col>
+        <col id="2">False</col>
+        <col id="3"/>
+        <col id="4"/>
+        <col id="5"/>
+        <col id="6"/>
+        <col id="7"/>
+        <col id="8"/>
+        <col id="9"/>
+        <col id="10"/>
+        <col id="11"/>
+        <col id="12"/>
+        <col id="13"/>
+        <col id="14"/>
+        <col id="15"/>
+        <col id="16"/>
+        <col id="17"/>
+        <col id="18"/>
+        <col id="19"/>
+        <col id="20"/>
+        <col id="21"/>
+        <col id="22"/>
+        <col id="23"/>
+        <col id="24"/>
+      </row>
+    </data>
   </object>
   <object class="GtkTreeModelFilter" id="multipathModel">
     <property name="child-model">diskStore</property>
@@ -93,6 +124,12 @@
                 <property name="margin-start">18</property>
                 <property name="margin-end">18</property>
                 <property name="margin-top">6</property>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
               </object>
             </child>
           </object>

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -56,7 +56,7 @@ PAGE_Z = 4
 
 DiskStoreRow = namedtuple("DiskStoreRow", [
     "visible", "selected", "mutable",
-    "name", "type", "model", "capacity",
+    "name", "device_id", "type", "model", "capacity",
     "vendor", "interconnect", "serial",
     "wwid", "paths", "port", "target",
     "lun", "ccw", "wwpn", "namespace", "mode",
@@ -87,6 +87,7 @@ def create_row(device_data, selected, mutable):
         selected=selected,
         mutable=mutable and not device.protected,
         name=device.name,
+        device_id=device.device_id,
         type=device.type,
         model=attrs.get("model", ""),
         capacity=str(Size(device.size)),
@@ -603,8 +604,8 @@ class FilterSpoke(NormalSpoke):
         self._store.clear()
 
         disks_data = DeviceData.from_structure_list([
-            self._device_tree.GetDeviceData(device_name)
-            for device_name in self._disks
+            self._device_tree.GetDeviceData(device_id)
+            for device_id in self._disks
         ])
 
         for page in self._pages.values():
@@ -693,10 +694,10 @@ class FilterSpoke(NormalSpoke):
         itr = filter_model.convert_iter_to_child_iter(model_itr)
         self._store[itr][1] = not self._store[itr][1]
 
-        if self._store[itr][1] and self._store[itr][3] not in self._selected_disks:
-            self._selected_disks.append(self._store[itr][3])
-        elif not self._store[itr][1] and self._store[itr][3] in self._selected_disks:
-            self._selected_disks.remove(self._store[itr][3])
+        if self._store[itr][1] and self._store[itr][4] not in self._selected_disks:
+            self._selected_disks.append(self._store[itr][4])
+        elif not self._store[itr][1] and self._store[itr][4] in self._selected_disks:
+            self._selected_disks.remove(self._store[itr][4])
 
         self._update_summary()
 

--- a/pyanaconda/ui/gui/spokes/lib/cart.py
+++ b/pyanaconda/ui/gui/spokes/lib/cart.py
@@ -89,13 +89,13 @@ class SelectedDisksDialog(GUIObject):
         return rc
 
     def _update_disks(self):
-        for device_name in self._disks:
+        for disk_id in self._disks:
             device_data = DeviceData.from_structure(
-                self._device_tree.GetDeviceData(device_name)
+                self._device_tree.GetDeviceData(disk_id)
             )
 
             device_free_space = self._device_tree.GetDiskFreeSpace(
-                [device_name]
+                [disk_id]
             )
 
             self._store.append([
@@ -106,7 +106,7 @@ class SelectedDisksDialog(GUIObject):
                 ),
                 str(Size(device_data.size)),
                 str(Size(device_free_space)),
-                device_name
+                device_data.name
             ])
 
     def _update_summary(self):

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -104,6 +104,8 @@
       <column type="gchararray"/>
       <!-- column-name name_col -->
       <column type="gchararray"/>
+      <!-- column-name id_col -->
+      <column type="gchararray"/>
     </columns>
   </object>
   <object class="GtkDialog" id="disks_dialog">

--- a/pyanaconda/ui/gui/spokes/lib/resize.glade
+++ b/pyanaconda/ui/gui/spokes/lib/resize.glade
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkTreeStore" id="diskStore">
     <columns>
       <!-- column-name diskName -->
+      <column type="gchararray"/>
+      <!-- column-name diskID -->
       <column type="gchararray"/>
       <!-- column-name diskDesc -->
       <column type="gchararray"/>
@@ -26,41 +28,41 @@
   </object>
   <object class="GtkAdjustment" id="resizeAdjustment">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkDialog" id="resizeDialog">
-    <property name="height_request">550</property>
-    <property name="can_focus">False</property>
+    <property name="height-request">550</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_KEY_RELEASE_MASK | GDK_STRUCTURE_MASK</property>
-    <property name="border_width">6</property>
+    <property name="border-width">6</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
-    <property name="type_hint">dialog</property>
+    <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
     <signal name="key-release-event" handler="on_key_pressed" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area1">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="cancelButton">
                 <property name="label" translatable="yes" context="GUI|Reclaim Dialog">_Cancel</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
-                <property name="non_homogeneous">True</property>
+                <property name="non-homogeneous">True</property>
               </packing>
             </child>
             <child>
@@ -68,36 +70,36 @@
                 <property name="label" translatable="yes" context="GUI|Reclaim Dialog">_Reclaim space</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
                 <signal name="clicked" handler="on_resize_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
-                <property name="non_homogeneous">True</property>
+                <property name="non-homogeneous">True</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox" id="box1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="label1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_bottom">6</property>
+                <property name="can-focus">False</property>
+                <property name="margin-bottom">6</property>
                 <property name="label" translatable="yes">RECLAIM DISK SPACE</property>
                 <property name="xalign">0</property>
                 <attributes>
@@ -113,8 +115,8 @@
             <child>
               <object class="GtkLabel" id="reclaimDescLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_bottom">6</property>
+                <property name="can-focus">False</property>
+                <property name="margin-bottom">6</property>
                 <property name="label" translatable="yes">Description goes here.</property>
                 <property name="wrap">True</property>
                 <property name="xalign">0</property>
@@ -128,16 +130,16 @@
             <child>
               <object class="GtkScrolledWindow" id="scrolledwindow1">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="shadow_type">in</property>
+                <property name="can-focus">True</property>
+                <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkTreeView" id="diskView">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="model">diskStore</property>
-                    <property name="enable_search">False</property>
-                    <property name="enable_tree_lines">True</property>
-                    <property name="tooltip_column">7</property>
+                    <property name="enable-search">False</property>
+                    <property name="enable-tree-lines">True</property>
+                    <property name="tooltip-column">7</property>
                     <signal name="row-activated" handler="on_row_clicked" swapped="no"/>
                     <child internal-child="selection">
                       <object class="GtkTreeSelection" id="diskView-selection">
@@ -151,7 +153,7 @@
                         <child>
                           <object class="GtkCellRendererText" id="diskRenderer"/>
                           <attributes>
-                            <attribute name="markup">1</attribute>
+                            <attribute name="markup">2</attribute>
                           </attributes>
                         </child>
                       </object>
@@ -173,7 +175,7 @@
                         <child>
                           <object class="GtkCellRendererText" id="fsRenderer"/>
                           <attributes>
-                            <attribute name="text">2</attribute>
+                            <attribute name="text">3</attribute>
                           </attributes>
                         </child>
                       </object>
@@ -184,7 +186,7 @@
                         <child>
                           <object class="GtkCellRendererText" id="reclaimableRenderer"/>
                           <attributes>
-                            <attribute name="markup">3</attribute>
+                            <attribute name="markup">4</attribute>
                           </attributes>
                         </child>
                       </object>
@@ -195,7 +197,7 @@
                         <child>
                           <object class="GtkCellRendererText" id="actionRenderer"/>
                           <attributes>
-                            <attribute name="text">4</attribute>
+                            <attribute name="text">5</attribute>
                           </attributes>
                         </child>
                       </object>
@@ -212,16 +214,16 @@
             <child>
               <object class="GtkBox" id="box2">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">6</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">6</property>
                 <child>
                   <object class="GtkButton" id="preserveButton">
                     <property name="label" translatable="yes" context="GUI|Reclaim Dialog">_Preserve</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <property name="valign">center</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <signal name="clicked" handler="on_preserve_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -234,10 +236,10 @@
                   <object class="GtkButton" id="deleteButton">
                     <property name="label" translatable="yes" context="GUI|Reclaim Dialog">_Delete</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <property name="valign">center</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <signal name="clicked" handler="on_delete_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -250,10 +252,10 @@
                   <object class="GtkButton" id="shrinkButton">
                     <property name="label" translatable="yes" context="GUI|Reclaim Dialog">_Shrink</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
                     <property name="valign">center</property>
-                    <property name="use_underline">True</property>
+                    <property name="use-underline">True</property>
                     <signal name="clicked" handler="on_shrink_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -266,15 +268,15 @@
                   <object class="GtkButton" id="deleteAllButton">
                     <property name="label" translatable="yes" context="GUI|Reclaim Dialog">Delete _all</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="use_underline">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="use-underline">True</property>
                     <signal name="clicked" handler="on_delete_all_clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="pack_type">end</property>
+                    <property name="pack-type">end</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
@@ -288,9 +290,9 @@
             <child>
               <object class="GtkScale" id="resizeSlider">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="margin_top">12</property>
-                <property name="margin_bottom">12</property>
+                <property name="can-focus">True</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
                 <property name="adjustment">resizeAdjustment</property>
                 <signal name="format-value" handler="on_resize_slider_format" swapped="no"/>
                 <signal name="value-changed" handler="on_resize_value_changed" swapped="no"/>
@@ -304,11 +306,11 @@
             <child>
               <object class="GtkLabel" id="reclaimableSpaceLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin_bottom">6</property>
+                <property name="margin-bottom">6</property>
                 <property name="label">&lt;b&gt;%s disks; %s reclaimable space&lt;/b&gt; (in file systems)</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -319,11 +321,11 @@
             <child>
               <object class="GtkLabel" id="selectedSpaceLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="margin_bottom">6</property>
+                <property name="margin-bottom">6</property>
                 <property name="label">Total selected space to reclaim:  &lt;b&gt;%s&lt;/b&gt;</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -334,11 +336,11 @@
             <child>
               <object class="GtkLabel" id="requiredSpaceLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="margin_bottom">6</property>
+                <property name="margin-bottom">6</property>
                 <property name="label">Installation requires a total of &lt;b&gt;%s&lt;/b&gt; for system data.</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/pyanaconda/ui/lib/format_dasd.py
+++ b/pyanaconda/ui/lib/format_dasd.py
@@ -68,16 +68,16 @@ class DasdFormatting(object):
         """Returns a string summary of DASDs to format."""
         return "\n".join(map(self.get_dasd_info, self.dasds))
 
-    def get_dasd_info(self, disk_name):
+    def get_dasd_info(self, disk_id):
         """Returns a string with description of a DASD."""
         data = DeviceData.from_structure(
-            self._device_tree.GetDeviceData(disk_name)
+            self._device_tree.GetDeviceData(disk_id)
         )
         return "{} ({})".format(data.path, data.attrs.get("bus-id"))
 
-    def search_disks(self, disk_names):
+    def search_disks(self, disk_ids):
         """Search for a list of disks for DASDs to format."""
-        self._dasds = self._dasd_module.FindFormattable(disk_names)
+        self._dasds = self._dasd_module.FindFormattable(disk_ids)
 
     def should_run(self):
         """Should we run the formatting?"""

--- a/pyanaconda/ui/lib/payload.py
+++ b/pyanaconda/ui/lib/payload.py
@@ -143,25 +143,25 @@ def find_potential_hdiso_sources():
     Return a generator yielding Device instances that may have HDISO install
     media somewhere. Candidate devices are simply any that we can mount.
 
-    :return: a list of device names
+    :return: a list of device IDs
     """
     device_tree = STORAGE.get_proxy(DEVICE_TREE)
     return device_tree.FindMountablePartitions()
 
 
-def get_hdiso_source_info(device_tree, device_name):
+def get_hdiso_source_info(device_tree, device_id):
     """Get info about a potential HDISO source.
 
     :param device_tree: a proxy of a device tree
-    :param device_name: a device name
+    :param device_id: a device ID
     :return: a dictionary with a device info
     """
     device_data = DeviceData.from_structure(
-        device_tree.GetDeviceData(device_name)
+        device_tree.GetDeviceData(device_id)
     )
 
     format_data = DeviceFormatData.from_structure(
-        device_tree.GetFormatData(device_name)
+        device_tree.GetFormatData(device_id)
     )
 
     disk_data = DeviceData.from_structure(

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -64,13 +64,13 @@ class FileSystemSpaceChecker(object):
         :param needed: a needed space
         :return: a deficit size or None
         """
-        root_name = self.device_tree.GetRootDevice()
+        root_id = self.device_tree.GetRootDevice()
 
-        if not root_name:
+        if not root_id:
             return None
 
         root_data = DeviceData.from_structure(
-            self.device_tree.GetDeviceData(root_name)
+            self.device_tree.GetDeviceData(root_id)
         )
 
         current = root_data.size

--- a/pyanaconda/ui/lib/storage.py
+++ b/pyanaconda/ui/lib/storage.py
@@ -376,11 +376,11 @@ def ignore_oemdrv_disks():
             disk_select_proxy.IgnoredDisks = ignored_disks
 
 
-def filter_disks_by_names(disks, names):
-    """Filter disks by the given names.
+def filter_disks_by_names(disks, disk_ids):
+    """Filter disks by the given disk_ids.
 
-    :param disks: a list of disks name
-    :param names: a list of names to filter
-    :return: a list of filtered disk names
+    :param disks: a list of disks IDs
+    :param disk_ids: a list of disk_IDs to filter
+    :return: a list of filtered disk IDs
     """
-    return list(filter(lambda name: name in disks, names))
+    return list(filter(lambda disk_id: disk_id in disks, disk_ids))

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -32,6 +32,7 @@ from pyanaconda.payload.manager import payloadMgr
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.ui.lib.payload import find_potential_hdiso_sources, get_hdiso_source_info, \
     get_hdiso_source_description
+from pyanaconda.modules.common.structures.storage import DeviceData
 
 from pyanaconda.core.constants import THREAD_SOURCE_WATCHER, THREAD_PAYLOAD, PAYLOAD_TYPE_DNF, \
     SOURCE_TYPE_URL, SOURCE_TYPE_NFS, SOURCE_TYPE_HMC, PAYLOAD_STATUS_SETTING_SOURCE, \
@@ -410,9 +411,11 @@ class SelectDeviceSpoke(NormalTUISpoke):
     def _get_mountable_devices(self):
         disks = []
 
-        for device_name in find_potential_hdiso_sources():
-            device_info = get_hdiso_source_info(self._device_tree, device_name)
+        for device_id in find_potential_hdiso_sources():
+            device_info = get_hdiso_source_info(self._device_tree, device_id)
             device_desc = get_hdiso_source_description(device_info)
+            device_data = DeviceData.from_structure(self._device_tree.GetDeviceData(device_id))
+            device_name = device_data.name
             disks.append([device_name, device_desc])
 
         return disks

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -708,13 +708,12 @@ class MountPointAssignSpoke(NormalTUISpoke):
     def _get_request_description(self, request):
         """Get description of the given mount info."""
         # Get the device data.
-        device_name = self._device_tree.ResolveDevice(request.device_spec)
         device_data = DeviceData.from_structure(
-            self._device_tree.GetDeviceData(device_name)
+            self._device_tree.GetDeviceData(request.device_spec)
         )
 
         # Generate the description.
-        description = "{} ({})".format(request.device_spec, Size(device_data.size))
+        description = "{} ({})".format(device_data.name, Size(device_data.size))
 
         if request.format_type:
             description += "\n {}".format(request.format_type)
@@ -759,7 +758,12 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
 
     def __init__(self, data, storage, payload, device_tree, request):
         super().__init__(data, storage, payload)
-        self.title = N_("Configure device: %s") % request.device_spec
+
+        device_data = DeviceData.from_structure(
+            device_tree.GetDeviceData(request.device_spec)
+        )
+
+        self.title = N_("Configure device: %s") % device_data.name
         self._container = None
         self._device_tree = device_tree
         self._request = request
@@ -874,11 +878,8 @@ class ConfigureDeviceSpoke(NormalTUISpoke):
 
     def _switch_reformat(self, data):
         """Change value of reformat."""
-        device_name = self._device_tree.ResolveDevice(
-            self._request.device_spec
-        )
         format_data = DeviceFormatData.from_structure(
-            self._device_tree.GetFormatData(device_name)
+            self._device_tree.GetFormatData(self._request.device_spec)
         )
         device_format = format_data.type
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -686,8 +686,9 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
         proxy_mock = storage_mock.get_proxy()
         proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
         proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
-        proxy_mock.GetRootDevice.return_value = "device-name"
+        proxy_mock.GetRootDevice.return_value = "device-id"
         devdata_mock.from_structure.return_value.type = "btrfs subvolume"
+        devdata_mock.from_structure.return_value.name = "device-name"
 
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(sysroot + "/boot/grub2")
@@ -723,8 +724,9 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
         proxy_mock = storage_mock.get_proxy()
         proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
         proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
-        proxy_mock.GetRootDevice.return_value = "device-name"
+        proxy_mock.GetRootDevice.return_value = "device-id"
         devdata_mock.from_structure.return_value.type = "something-non-btrfs-subvolume-ish"
+        devdata_mock.from_structure.return_value.name = "device-name"
 
         with tempfile.TemporaryDirectory() as sysroot:
             os.makedirs(sysroot + "/boot/grub2")
@@ -762,11 +764,12 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
         proxy_mock = storage_mock.get_proxy()
         proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
         proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
-        proxy_mock.GetRootDevice.return_value = "device-name"
+        proxy_mock.GetRootDevice.return_value = "device-id"
         proxy_mock.Drive = "btldr-drv"
         proxy_mock.KeepBootOrder = False
         devdata_mock.from_structure.return_value.type = "something-non-btrfs-subvolume-ish"
         devdata_mock.from_structure.return_value.path = "/dev/btldr-drv"
+        devdata_mock.from_structure.return_value.name = "device-name"
 
         with tempfile.TemporaryDirectory() as sysroot:
             task = ConfigureBootloader(sysroot)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_cdrom.py
@@ -47,13 +47,13 @@ class CdromSourceInterfaceTestCase(unittest.TestCase):
 
     def test_device(self):
         """Test CD-ROM source Device API."""
-        assert self.interface.DeviceName == ""
+        assert self.interface.DeviceID == ""
 
         task = self.module.set_up_with_tasks()[0]
         task.get_result = Mock(return_value="top_secret")
         task.succeeded_signal.emit()
 
-        assert self.interface.DeviceName == "top_secret"
+        assert self.interface.DeviceID == "top_secret"
 
 
 class CdromSourceTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
@@ -226,7 +226,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
 
         request = utils.generate_device_factory_request(self.storage, lv)
         assert DeviceFactoryRequest.to_structure(request) == {
-            "device-spec": get_variant(Str, "testvg-testlv"),
+            "device-spec": get_variant(Str, lv.device_id),
             "disks": get_variant(List[Str], []),
             "mount-point": get_variant(Str, ""),
             "reformat": get_variant(Bool, True),
@@ -238,7 +238,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "device-size": get_variant(UInt64, Size("508 MiB").get_bytes()),
             "device-encrypted": get_variant(Bool, False),
             "device-raid-level": get_variant(Str, ""),
-            "container-spec": get_variant(Str, "testvg"),
+            "container-spec": get_variant(Str, vg.device_id),
             "container-name": get_variant(Str, "testvg"),
             "container-size-policy": get_variant(Int64, Size("1.5 GiB")),
             "container-encrypted": get_variant(Bool, False),
@@ -263,8 +263,8 @@ class InteractiveUtilsTestCase(unittest.TestCase):
 
         request = utils.generate_device_factory_request(self.storage, device)
         assert DeviceFactoryRequest.to_structure(request) == {
-            "device-spec": get_variant(Str, "dev3"),
-            "disks": get_variant(List[Str], ["dev1", "dev2"]),
+            "device-spec": get_variant(Str, device.device_id),
+            "disks": get_variant(List[Str], [disk1.device_id, disk2.device_id]),
             "mount-point": get_variant(Str, ""),
             "reformat": get_variant(Bool, True),
             "format-type": get_variant(Str, ""),
@@ -303,7 +303,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
 
         request = utils.generate_device_factory_request(self.storage, dev3)
         assert DeviceFactoryRequest.to_structure(request) == {
-            "device-spec": get_variant(Str, dev3.name),
+            "device-spec": get_variant(Str, dev3.device_id),
             "disks": get_variant(List[Str], []),
             "mount-point": get_variant(Str, "/boot"),
             "reformat": get_variant(Bool, True),
@@ -315,7 +315,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "device-size": get_variant(UInt64, Size("10 GiB").get_bytes()),
             "device-encrypted": get_variant(Bool, False),
             "device-raid-level": get_variant(Str, ""),
-            "container-spec": get_variant(Str, dev2.name),
+            "container-spec": get_variant(Str, dev2.device_id),
             "container-name": get_variant(Str, dev2.name),
             "container-size-policy": get_variant(Int64, Size("10 GiB").get_bytes()),
             "container-encrypted": get_variant(Bool, False),

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -26,6 +26,7 @@ import pytest
 from unittest.mock import patch, Mock, PropertyMock
 
 from blivet.formats.fs import BTRFS
+from blivet.devices import StorageDevice
 from dasbus.typing import *  # pylint: disable=wildcard-import
 from pykickstart.base import RemovedCommand
 from pykickstart.errors import KickstartParseError
@@ -107,6 +108,10 @@ class StorageInterfaceTestCase(unittest.TestCase):
         self.storage_module.created_partitioning_changed.connect(
             self.storage_module._set_applied_partitioning
         )
+
+    def _add_device(self, device):
+        """Add a device to the device tree."""
+        self.storage_module.storage.devicetree._add_device(device)
 
     def test_initialization(self):
         """Test the Blivet initialization."""
@@ -904,6 +909,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         # Mount points configuration
         mount /dev/sda1 /boot
         """
+        self._add_device(StorageDevice("sda1"))
         self._apply_partitioning_when_created()
         self._test_kickstart(ks_in, ks_out)
         self._check_dbus_partitioning(publisher, PartitioningMethod.MANUAL)
@@ -918,6 +924,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         # Mount points configuration
         mount /dev/sda1 none
         """
+        self._add_device(StorageDevice("sda1"))
         self._apply_partitioning_when_created()
         self._test_kickstart(ks_in, ks_out)
         self._check_dbus_partitioning(publisher, PartitioningMethod.MANUAL)
@@ -932,6 +939,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         # Mount points configuration
         mount /dev/sda1 /boot --mountoptions="user"
         """
+        self._add_device(StorageDevice("sda1"))
         self._apply_partitioning_when_created()
         self._test_kickstart(ks_in, ks_out)
         self._check_dbus_partitioning(publisher, PartitioningMethod.MANUAL)
@@ -946,6 +954,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         # Mount points configuration
         mount /dev/sda1 /boot --reformat
         """
+        self._add_device(StorageDevice("sda1"))
         self._apply_partitioning_when_created()
         self._test_kickstart(ks_in, ks_out)
         self._check_dbus_partitioning(publisher, PartitioningMethod.MANUAL)
@@ -960,6 +969,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
         # Mount points configuration
         mount /dev/sda1 /boot --reformat=xfs --mkfsoptions="-L BOOT"
         """
+        self._add_device(StorageDevice("sda1"))
         self._apply_partitioning_when_created()
         self._test_kickstart(ks_in, ks_out)
         self._check_dbus_partitioning(publisher, PartitioningMethod.MANUAL)
@@ -980,6 +990,10 @@ class StorageInterfaceTestCase(unittest.TestCase):
         mount /dev/sdb1 /home
         mount /dev/sdb2 none
         """
+        self._add_device(StorageDevice("sda1"))
+        self._add_device(StorageDevice("sda2"))
+        self._add_device(StorageDevice("sdb1"))
+        self._add_device(StorageDevice("sdb2"))
         self._apply_partitioning_when_created()
         self._test_kickstart(ks_in, ks_out)
         self._check_dbus_partitioning(publisher, PartitioningMethod.MANUAL)

--- a/widgets/python/AnacondaWidgets.py
+++ b/widgets/python/AnacondaWidgets.py
@@ -29,7 +29,7 @@ Anaconda = modules['AnacondaWidgets']._introspection_module
 __all__ = []
 
 class MountpointSelector(Anaconda.MountpointSelector):
-    def __init__(self, name=None, size=None, mountpoint=None):
+    def __init__(self, name=None, size=None, mountpoint=None, device_id=None):
         Anaconda.MountpointSelector.__init__(self)
 
         if name:
@@ -40,6 +40,8 @@ class MountpointSelector(Anaconda.MountpointSelector):
 
         if mountpoint:
             self.set_property("mountpoint", mountpoint)
+
+        self.device_id = device_id
 
 MountpointSelector = override(MountpointSelector)
 __all__.append('MountpointSelector')
@@ -61,13 +63,15 @@ SpokeSelector = override(SpokeSelector)
 __all__.append('SpokeSelector')
 
 class DiskOverview(Anaconda.DiskOverview):
-    def __init__(self, description, kind, capacity, free, name, popup=None):
+    def __init__(self, description, kind, capacity, free, name, device_id, popup=None):
         Anaconda.DiskOverview.__init__(self)
         self.set_property("description", description)
         self.set_property("kind", kind)
         self.set_property("free", free)
         self.set_property("capacity", capacity)
         self.set_property("name", name)
+
+        self.device_id = device_id
 
         if popup:
             self.set_property("popup-info", popup)


### PR DESCRIPTION
Anaconda currently uses name to identify devices internally which causes a lot of problems because multiple devices can share the same name. To fix this blivet introduced a new "device ID" which is unique even for devices with the same name (for technologies that support multiple devices with the same name and for devices sharing the same name but using a different storage technology).

-----

This is not yet finished, but it should be usable for testing and further development on the WebUI side. The blivet change (https://github.com/storaged-project/blivet/pull/1182) is merged but not yet released. Unit tests should be passing on this, I also tried running manual installation with mount point assignment in TUI and also running (most of) kickstart tests and everything seems to be working so far. The Gtk custom partitioning is not yet adjusted to this change but is somewhat working if you ignore the weird "names" displayed in the UI.
