### PR TITLE
Remove deprecated kickstart commands and options

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -38,7 +38,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.51-1
+%define pykickstartver 3.52-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.8.2-2
 %define rpmver 4.15.0

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -58,7 +58,7 @@ from pykickstart.commands.partition import F34_Partition as Partition
 from pykickstart.commands.raid import F29_Raid as Raid
 from pykickstart.commands.realm import F19_Realm as Realm
 from pykickstart.commands.reboot import F23_Reboot as Reboot
-from pykickstart.commands.repo import F33_Repo as Repo
+from pykickstart.commands.repo import F40_Repo as Repo
 from pykickstart.commands.reqpart import F23_ReqPart as ReqPart
 from pykickstart.commands.rescue import F10_Rescue as Rescue
 from pykickstart.commands.rhsm import RHEL8_RHSM as RHSM

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -48,7 +48,6 @@ from pykickstart.commands.liveimg import F19_Liveimg as Liveimg
 from pykickstart.commands.logging import F34_Logging as Logging
 from pykickstart.commands.logvol import F29_LogVol as LogVol
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
-from pykickstart.commands.method import F34_Method as Method
 from pykickstart.commands.mount import F27_Mount as Mount
 from pykickstart.commands.network import F39_Network as Network
 from pykickstart.commands.nfs import FC6_NFS as NFS

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -25,7 +25,6 @@
 # Supported kickstart commands.
 from pykickstart.commands.authselect import F28_Authselect as Authselect
 from pykickstart.commands.autopart import F38_AutoPart as AutoPart
-from pykickstart.commands.autostep import F34_AutoStep as AutoStep
 from pykickstart.commands.bootloader import F39_Bootloader as Bootloader
 from pykickstart.commands.btrfs import F23_BTRFS as BTRFS
 from pykickstart.commands.cdrom import FC3_Cdrom as Cdrom

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -70,7 +70,7 @@ from pykickstart.commands.snapshot import F26_Snapshot as Snapshot
 from pykickstart.commands.sshpw import F24_SshPw as SshPw
 from pykickstart.commands.sshkey import F22_SshKey as SshKey
 from pykickstart.commands.syspurpose import RHEL8_Syspurpose as Syspurpose
-from pykickstart.commands.timezone import F33_Timezone as Timezone
+from pykickstart.commands.timezone import F40_Timezone as Timezone
 from pykickstart.commands.timesource import F33_Timesource as Timesource
 from pykickstart.commands.updates import F34_Updates as Updates
 from pykickstart.commands.url import F30_Url as Url

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -45,7 +45,7 @@ from pykickstart.commands.iscsiname import FC6_IscsiName as IscsiName
 from pykickstart.commands.keyboard import F18_Keyboard as Keyboard
 from pykickstart.commands.lang import F19_Lang as Lang
 from pykickstart.commands.liveimg import F19_Liveimg as Liveimg
-from pykickstart.commands.logging import F34_Logging as Logging
+from pykickstart.commands.logging import F40_Logging as Logging
 from pykickstart.commands.logvol import F29_LogVol as LogVol
 from pykickstart.commands.mediacheck import FC4_MediaCheck as MediaCheck
 from pykickstart.commands.mount import F27_Mount as Mount

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -191,7 +191,6 @@ class AnacondaKickstartSpecification(KickstartSpecification):
     """The kickstart specification of the main process."""
 
     commands = {
-        "autostep": COMMANDS.AutoStep,
         "cmdline": COMMANDS.DisplayMode,
         "eula": COMMANDS.Eula,
         "graphical": COMMANDS.DisplayMode,

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -196,7 +196,6 @@ class AnacondaKickstartSpecification(KickstartSpecification):
         "graphical": COMMANDS.DisplayMode,
         "halt": COMMANDS.Reboot,
         "logging": COMMANDS.Logging,
-        "method": COMMANDS.Method,
         "poweroff": COMMANDS.Reboot,
         "reboot": COMMANDS.Reboot,
         "rescue": COMMANDS.Rescue,


### PR DESCRIPTION
Remove the following deprecated kickstart commands and options:

- `autostep`
- `method`
- `logging --level`
- `repo --ignoregroups`

Resolves: INSTALLER-3849

**TODO:**
- [x] Test with the pykickstart changes.
- [x] Document in the release notes.

**Depends on:** https://github.com/pykickstart/pykickstart/pull/473