### PR TITLE
Deprecate timezone --isUtc, --ntpservers and --nontp kickstart options

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -38,7 +38,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.51-1
+%define pykickstartver 3.52-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.8.2-2
 %define rpmver 4.15.0

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -72,7 +72,7 @@ from pykickstart.commands.snapshot import F26_Snapshot as Snapshot
 from pykickstart.commands.sshpw import F24_SshPw as SshPw
 from pykickstart.commands.sshkey import F22_SshKey as SshKey
 from pykickstart.commands.syspurpose import RHEL8_Syspurpose as Syspurpose
-from pykickstart.commands.timezone import F33_Timezone as Timezone
+from pykickstart.commands.timezone import F40_Timezone as Timezone
 from pykickstart.commands.timesource import F33_Timesource as Timesource
 from pykickstart.commands.updates import F34_Updates as Updates
 from pykickstart.commands.url import F30_Url as Url


### PR DESCRIPTION
The future deprecation of these kickstart options was announced in Fedora 32 and
33. The support for these options was removed in the commit 51fcd02.

Resolves: INSTALLER-3887

**TODO:**
- [x] Test with the pykickstart changes.
- [x] Document in the release notes.

**Depends on:**
* https://github.com/pykickstart/pykickstart/pull/474
* https://github.com/rhinstaller/anaconda/pull/5437