### PR TITLE
Remove the inst.nompath boot option

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -874,15 +874,6 @@ ksdevice
 ``ksdevice=<DEV>``
     Replaced with `bootdev`_
 
-.. inst.nompath:
-
-inst.nompath
-^^^^^^^^^^^^
-
-This was used to disable support for multipath devices. Anaconda did not
-support proper multipath disabling for a long time, the only thing this did
-was disable parts of GUI.
-
 Removed Options
 ---------------
 
@@ -1037,6 +1028,15 @@ inst.nodmraid
 
 Anaconda no longer supports dmraid, BIOS/Firmware RAID devices are now handled by
 ``mdadm``.
+
+.. inst.nompath:
+
+inst.nompath
+^^^^^^^^^^^^
+
+This was used to disable support for multipath devices. Anaconda did not
+support proper multipath disabling for a long time, the only thing this did
+was disable parts of GUI.
 
 .. inst.product:
 

--- a/docs/release-notes/remove-inst-nompath.rst
+++ b/docs/release-notes/remove-inst-nompath.rst
@@ -1,0 +1,8 @@
+:Type: Boot options
+:Summary: Remove the ``inst.nompath`` boot option
+
+:Description:
+    The ``inst.nompath`` boot option was deprecated in Fedora 36. It is now marked as removed.
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/5439

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -527,8 +527,6 @@ def getArgumentParser(version_string, boot_cmdline=None):
 
     ap.add_argument("--selinux", action=ParseSelinux, nargs="?", help=help_parser.help_text("selinux"))
 
-    ap.add_argument("--nompath", dest="mpath", action="store_false", default=True,
-                    help=help_parser.help_text("nompath"))
     ap.add_argument("--mpath", action="store_true", help=help_parser.help_text("mpath"))
 
     ap.add_argument("--disklabel", default=SUPPRESS, help=help_parser.help_text("disklabel"))


### PR DESCRIPTION
The boot option was deprecated in Fedora 36. It is now marked as removed.

Resolves: INSTALLER-3889