### PR TITLE
Do not use libxklavier to list keyboard layouts

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -270,7 +270,9 @@ ensure all Anaconda capabilities are supported in the resulting image.
 Summary: Graphical user interface for the Anaconda installer
 Requires: anaconda-core = %{version}-%{release}
 Requires: anaconda-widgets = %{version}-%{release}
+Requires: python3-iso639
 Requires: python3-meh-gui >= %{mehver}
+Requires: python3-xkbregistry
 Requires: adwaita-icon-theme
 Requires: tecla
 Requires: tigervnc-server-minimal


### PR DESCRIPTION
libxklavier is deprecated and X11 only.

Use python3-xkbregistry, a wrapper around xkbregistry, instead of libxklavier to get the keyboard layout information.

The methods migrated are:

 - get_available_layouts
 - get_common_layouts
 - get_switching_options
 - get_layout_variant_description
 - get_switch_opt_description
 - is_valid_layout

There are 2 small changes caused by the migration:

The first one is that get_available_layouts now returns the braille keyboard layouts. They are available in GNOME, so they are good to have.

The second one is the value returned by get_layout_variant_description for some layouts, that now match what GNOME Settings displays. Here is the list of changes:

```
Keyboard layout          | Old get_layout_variant_description  | New get_layout_variant_description
---------------------------------------------------------------------------------------------------
af                       | Afghanistan (Dari)                  | Dari
brai                     | N/A                                 | Braille
brai (left_hand)         | N/A                                 | Braille (left-handed)
brai (left_hand_invert)  | N/A                                 | Braille (left-handed inverted thumb)
brai (right_hand)        | N/A                                 | Braille (right-handed)
brai (right_hand_invert) | N/A                                 | Braille (right-handed inverted thumb)
cn (mon_todo_galik)      | China (Mongolian (Todo Galik))      | Mongolian (Todo Galik)
cn (mon_trad)            | China (Mongolian (Bichig))          | Mongolian (Bichig)
cn (mon_trad_galik)      | China (Mongolian (Galik))           | Mongolian (Galik)
cn (mon_trad_todo)       | China (Mongolian (Todo))            | Mongolian (Todo)
cn (mon_trad_xibe)       | China (Mongolian (Xibe))            | Mongolian (Xibe)
gh (avn)                 | Ghana (Avatime)                     | Avatime
lt (sgs)                 | Lithuania (Samogitian)              | Samogitian
ma (rif)                 | Morocco (Tarifit)                   | Tarifit
mm (mnw-a1)              | Myanmar (Mon (A1))                  | Mon (A1)
pl (szl)                 | Poland (Silesian)                   | Silesian
rs (rue)                 | Serbia (Pannonian Rusyn)            | Pannonian Rusyn
se (swl)                 | Sweden (Swedish Sign Language)      | Swedish Sign Language
```

cc @M4rtinK @Conan-Kudo