### PR TITLE
Consider network spoke complete also in connecting state.

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -1540,6 +1540,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalSpoke):
         # TODO: check also if source requires updates when implemented
         # If we can't configure network, don't require it
         return (not conf.system.can_configure_network
+                or self._network_module.IsConnecting
                 or self._network_module.Connected)
 
     @property
@@ -1692,6 +1693,7 @@ class NetworkStandaloneSpoke(StandaloneSpoke):
     def completed(self):
         return (not conf.system.can_configure_network
                 or self._network_module.Connected
+                or self._network_module.IsConnecting
                 or not (self.payload.source_type != conf.payload.default_source
                         and self.payload.needs_network))
 

--- a/pyanaconda/ui/tui/spokes/network.py
+++ b/pyanaconda/ui/tui/spokes/network.py
@@ -255,6 +255,7 @@ class NetworkSpoke(FirstbootSpokeMixIn, NormalTUISpoke):
         """ Check whether this spoke is complete or not."""
         # If we can't configure network, don't require it
         return (not conf.system.can_configure_network
+                or self._network_module.IsConnecting
                 or self._network_module.Connected)
 
     @property


### PR DESCRIPTION
Follow-up of https://github.com/rhinstaller/anaconda/pull/5394 which caused this kickstart-test failure:
https://github.com/rhinstaller/kickstart-tests/issues/1046