### PR TITLE
gui: Log information about blivet-gui failed import

### DIFF
--- a/pyanaconda/ui/gui/spokes/blivet_gui.py
+++ b/pyanaconda/ui/gui/spokes/blivet_gui.py
@@ -27,8 +27,8 @@ try:
     from blivetgui.osinstall import BlivetGUIAnaconda  # pylint: disable=import-error
     from blivetgui.communication.client import BlivetGUIClient  # pylint: disable=import-error
     from blivetgui.config import config  # pylint: disable=import-error
-except ImportError:
-    raise RemovedModuleError("This module is not supported!") from None
+except ImportError as e:
+    raise RemovedModuleError("This module is not supported: {}".format(e)) from None
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.ui.gui.spokes import NormalSpoke

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -163,7 +163,8 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
             # pylint:disable=unused-import
             # ruff: noqa: F401
             import pyanaconda.ui.gui.spokes.blivet_gui
-        except ImportError:
+        except ImportError as e:
+            log.info("Blivet-GUI is not supported: %s", str(e))
             return False
 
         return True


### PR DESCRIPTION
When blivet-gui cannot be imported the option to start the spoke is removed without logging anything. This makes sense for RHEL whenre blivet-gui isn't available but on Fedora no information is logged even when the blivet-gui import fails because of a bug making debugging harder.