### PR TITLE
Fix makebumpver wrong jira lang

### DIFF
--- a/.structure-config
+++ b/.structure-config
@@ -11,6 +11,9 @@ INFRASTRUCTURE_FILES=(
 dockerfile/
 scripts/testing/
 scripts/jinja-render
+scripts/makebumpver
+scripts/rhel_version.py
+scripts/rhel_version.py.j2
 dracut/.shellcheckrc
 docs/ci-status.rst
 )

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -242,7 +242,7 @@ class MakeBumpVer:
         self.git_branch = None
 
         # RHEL release number or None (also fills in self.git_branch)
-        self.rhel = self._is_RHEL()
+        self.rhel = True if rhel_version else False
 
     def _git_config(self, field):
         proc = run_program(['git', 'config', field])
@@ -259,31 +259,6 @@ class MakeBumpVer:
             fields[-1] = str(int(fields[-1]) + VERSION_NUMBER_INCREMENT)
         new = ".".join(fields)
         return new
-
-    def _is_RHEL(self):
-        proc = run_program(['git', 'branch'])
-        lines = [x for x in proc[0].strip('\n').split('\n') if x.startswith('*')]
-
-        if lines == [] or len(lines) > 1:
-            return False
-
-        fields = lines[0].split(' ')
-
-        if len(fields) == 2:
-            self.git_branch = fields[1]
-        else:
-            return False
-
-        if self.git_branch.startswith('rhel'):
-            branch_pattern = r"^rhel(\d+)-(.*)"
-            m = re.match(branch_pattern, self.git_branch)
-            if m:
-                return m.group(1)
-            rhel_branch_pattern = r"^rhel-(\d+)(.*)"
-            m = re.match(rhel_branch_pattern, self.git_branch)
-            if m:
-                return m.group(1)
-        return False
 
     def _get_commit_detail(self, commit, field):
         proc = run_program(['git', 'log', '-1', "--pretty=format:%s" % field, commit])

--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -121,10 +121,14 @@ class JIRAValidator:
     def validate_RHEL_issue_status(self, bug):
         issue = self._query_RHEL_issue(bug)
 
-        valid_statuses = ("Planning", "In Progress")
-        status = issue.fields.status.name
-        if status not in valid_statuses:
-            return False, f"incorrect status '{status}'! Valid values: {valid_statuses}"
+        # translation from status id to name because JIRA is using locale set in the JIRA account
+        # that can't be changed from REST API
+        valid_status_map = {13521: "Planning",
+                            10018: "In Progress"}
+
+        status = issue.fields.status
+        if int(status.id) not in valid_status_map:
+            return False, f"incorrect status! Valid values: {', '.join(valid_status_map.values())}"
 
         return True, ""
 

--- a/scripts/rhel_version.py
+++ b/scripts/rhel_version.py
@@ -24,6 +24,5 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 # on Fedora we don't use this
 rhel_version = ""

--- a/scripts/rhel_version.py.j2
+++ b/scripts/rhel_version.py.j2
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 {% if distro_name == "fedora" %}
 # on Fedora we don't use this
 rhel_version = ""


### PR DESCRIPTION
JIRA account is the one what define responses locale. Unfortunately this can't be changed from REST API. At the end it means that we need to use ID of the statuses instead of their name.

Side changes:
- improve detection of RHEL in makebumpver script
- add makebumpver and related scripts as infrastructure files

Backport of https://github.com/rhinstaller/anaconda/pull/5432 with a small change of blank lines in rhel_version script.