### PR TITLE
webui: Disable unsupported use cases and installation environments

### DIFF
--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -176,3 +176,8 @@ class SystemSection(Section):
     def can_use_driver_disks(self):
         """Can the system use driver disks?"""
         return self._is_boot_iso
+
+    @property
+    def supports_web_ui(self):
+        """Can we run Web UI on this system?"""
+        return self._is_boot_iso or self._is_live_os


### PR DESCRIPTION
Make sure that Web UI cannot be used in an unsupported way. The missing support
might be temporary, but such functionality should be enabled only when the team
is ready to fully support it.