### PR TITLE
gui: Enforce the non-interactive text mode for dir and image installations

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -258,6 +258,17 @@ if __name__ == "__main__":
         util.ipmi_report(constants.IPMI_ABORTED)
         sys.exit(1)
 
+    if (opts.images or opts.dirinstall) and not opts.ksfile:
+        stdout_log.error("--images and --dirinstall cannot be used without --kickstart")
+        util.ipmi_report(constants.IPMI_ABORTED)
+        sys.exit(1)
+
+    if opts.images or opts.dirinstall:
+        log.debug("Dir and image installations can run only in the non-interactive text mode.")
+        stdout_log.info("Enforcing the non-interactive text mode for dir and image installations.")
+        opts.display_mode = constants.DisplayModes.TUI
+        opts.noninteractive = True
+
     from pyanaconda import vnc
     from pyanaconda import kickstart
     # we are past the --version and --help shortcut so we can import display &
@@ -445,11 +456,6 @@ if __name__ == "__main__":
 
     # now start the interface
     display.setup_display(anaconda, opts)
-    if anaconda.gui_startup_failed:
-        # we need to reinitialize the locale if GUI startup failed,
-        # as we might now be in text mode, which might not be able to display
-        # the characters from our current locale
-        startup_utils.reinitialize_locale(text_mode=anaconda.tui_mode)
 
     # we now know in which mode we are going to run so store the information
     from pykickstart import constants as pykickstart_constants

--- a/docs/release-notes/dir_image_installation_in_cmdline_mode.rst
+++ b/docs/release-notes/dir_image_installation_in_cmdline_mode.rst
@@ -1,0 +1,18 @@
+:Type: GUI
+:Summary: Dir and image installations run only in the non-interactive text mode now
+
+:Description:
+    Anaconda now requires a fully defined kickstart file for installations into a local image
+    (via the ``--image`` cmdline option) or a local directory (via the ``--dirinstall`` cmdline
+    option) and these installations can run only in a non-interactive text-based user interface.
+    The ``anaconda`` and ``livemedia-creator`` tools can be used for these types of installations
+    with the following changes:
+
+    * If a user requests a dir or image installation, Anaconda runs in the text mode.
+    * If the user doesn't specify a kickstart file, Anaconda reports an error and aborts.
+    * If the specified kickstart file is incomplete, Anaconda reports an error and aborts.
+    * All options for specifying the user interface are ignored.
+
+:Links:
+    - https://fedoraproject.org/wiki/Changes/Anaconda_dir_and_image_installations_in_automated_text_mode
+    - https://github.com/rhinstaller/anaconda/pull/5447

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -202,7 +202,7 @@ class Anaconda(object):
         """The user interface."""
         return self._intf
 
-    def initInterface(self):
+    def initialize_interface(self):
         if self._intf:
             raise RuntimeError("Second attempt to initialize the InstallInterface")
 


### PR DESCRIPTION
If a user requests a dir or image installation, enforce the non-interactive text mode and ignore all options for specifying the user interface. Skip some parts of the code that might try to modify the selected display mode.

If the user doesn't specify a kickstart file, report an error and abort. The installer will automatically abort the installation if the file is incomplete due to the non-interactive flag.

See: https://fedoraproject.org/wiki/Changes/Anaconda_dir_and_image_installations_in_automated_text_mode

**TODO:**
- [x] Test with `livemedia-creator`.
- [x] Test a dir installation.
- [x] Test an image installation.
- [x] Test the rescue mode.
