### PR TITLE
Do not write newline to the webui pid file

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -150,7 +150,7 @@ start_anaconda_web_ui() {
     # early execution of Firefox to reduce starting time
     mkdir -p /run/anaconda
     /usr/libexec/webui-desktop -t live /cockpit/@localhost/anaconda-webui/index.html &
-    echo "$!" > /run/anaconda/webui_script.pid
+    echo -n "$!" > /run/anaconda/webui_script.pid
 }
 
 start_anaconda() {


### PR DESCRIPTION
This is a fix to issue introduced in https://github.com/rhinstaller/anaconda/commit/1843885f6b70278790bdb3cd2ecfe43a2cb35846 .

With this change the logic in Web UI to quit the installation stopped working.

Robustness fix to https://github.com/rhinstaller/anaconda-webui/pull/159.

Resolves: rhbz#2262413