### PR TITLE
docs: Add a release note for removed/deprecated kickstart commands and options

### DIFF
--- a/docs/release-notes/remove-kickstart-commands.rst
+++ b/docs/release-notes/remove-kickstart-commands.rst
@@ -1,0 +1,23 @@
+:Type: Kickstart
+:Summary: Remove and deprecate selected kickstart commands and options
+
+:Description:
+    The following deprecated kickstart commands and options are removed:
+
+    - ``autostep``
+    - ``method``
+    - ``logging --level``
+    - ``repo --ignoregroups``
+
+    The following kickstart options are deprecated:
+
+    - ``timezone --isUtc``
+    - ``timezone --ntpservers``
+    - ``timezone --nontp``
+    - ``%packages --instLangs``
+    - ``%packages --excludeWeakdeps``
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/5436
+    - https://github.com/rhinstaller/anaconda/pull/5438
+    - https://github.com/pykickstart/pykickstart/pull/475


### PR DESCRIPTION
Document commands and options that are being removed or deprecated in Fedora 40.

**Related pull requests:**
- https://github.com/rhinstaller/anaconda/pull/5436
- https://github.com/rhinstaller/anaconda/pull/5438
- https://github.com/pykickstart/pykickstart/pull/475
