### PR TITLE
Resolve symlinks in ostree install bind mount destinations (#2262892)

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -160,6 +160,10 @@ class PrepareOSTreeMountTargetsTask(Task):
 
         # Canonicalize dest to the full path
         dest = self._sysroot + dest
+        # Resolve symlinks as bind mounting over symlinks does not
+        # seem to work on btrfs:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2262892
+        dest = os.path.realpath(dest)
 
         if bind_ro:
             safe_exec_with_redirect("mount", ["--bind", src, src])


### PR DESCRIPTION
util-linux 2.40 no longer automatically does this for us, since the kernel can bind mount over symlinks in some cases - see
https://github.com/util-linux/util-linux/commit/1b2d818 . However, it seems that this does not work at least for anaconda when doing ostree bind mounts on a btrfs install - see https://bugzilla.redhat.com/show_bug.cgi?id=2262892 . So we should resolve any symlinks in targets ourselves instead.