### PR TITLE
Do not include teamd on RHEL

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -112,13 +112,15 @@ Requires: subscription-manager >= %{subscriptionmanagerver}
 # which is apparently great for containers but unhelpful for the rest of us
 Requires: cracklib-dicts
 
+%if 0%{?rhel} < 10 || 0%{?fedora}
 Requires: teamd
+Requires: NetworkManager-team
+%endif
 %ifarch s390 s390x
 Requires: openssh
 %endif
 Requires: NetworkManager >= %{nmver}
 Requires: NetworkManager-libnm >= %{nmver}
-Requires: NetworkManager-team
 Requires: kbd
 Requires: chrony
 Requires: systemd


### PR DESCRIPTION
Anaconda with removed packages was tested in: https://github.com/rhinstaller/anaconda/pull/5461