### PR TITLE
startup: Set up the session bus on the boot.iso

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -440,6 +440,9 @@ if __name__ == "__main__":
         target=wait_for_connecting_NM_thread
     )
 
+    # Start the user instance of systemd and the session bus.
+    display.start_user_systemd()
+
     # now start the interface
     display.setup_display(anaconda, opts)
     if anaconda.gui_startup_failed:

--- a/pyanaconda/core/dbus.py
+++ b/pyanaconda/core/dbus.py
@@ -18,7 +18,7 @@
 #
 import os
 
-from dasbus.connection import SystemMessageBus, MessageBus
+from dasbus.connection import SystemMessageBus, MessageBus, SessionMessageBus
 from dasbus.constants import DBUS_STARTER_ADDRESS
 from dasbus.error import ErrorMapper, get_error_decorator, AbstractErrorRule
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -27,7 +27,7 @@ from pyanaconda.modules.common.errors import register_errors
 
 log = get_module_logger(__name__)
 
-__all__ = ["DBus", "SystemBus", "error_mapper", "dbus_error"]
+__all__ = ["DBus", "SystemBus", "SessionBus", "error_mapper", "dbus_error"]
 
 
 class AnacondaMessageBus(MessageBus):
@@ -113,6 +113,9 @@ class DefaultNameErrorRule(AbstractErrorRule):
 
 # System bus.
 SystemBus = SystemMessageBus()
+
+# Session bus.
+SessionBus = SessionMessageBus()
 
 # The mapper of DBus errors.
 error_mapper = AnacondaErrorMapper()

--- a/tests/unit_tests/pyanaconda_tests/test_display.py
+++ b/tests/unit_tests/pyanaconda_tests/test_display.py
@@ -1,0 +1,54 @@
+#
+# Copyright (C) 2024  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from pyanaconda.display import start_user_systemd
+
+
+class DisplayUtilsTestCase(TestCase):
+    """Test the display utils."""
+
+    @patch.dict("os.environ", clear=True)
+    @patch("pyanaconda.display.WatchProcesses")
+    @patch("pyanaconda.display.conf")
+    @patch("pyanaconda.display.util")
+    def test_start_user_systemd(self, util_mock, conf_mock, watch_mock):
+        """Start a user instance of systemd on a boot.iso."""
+        # Don't start systemd --user if this is not a boot.iso.
+        conf_mock.system.can_start_user_systemd = False
+        start_user_systemd()
+
+        util_mock.startProgram.assert_not_called()
+        util_mock.reset_mock()
+
+        # Start systemd --user on a boot.iso.
+        os.environ["XDG_RUNTIME_DIR"] = "/my/xdg/path"
+        conf_mock.system.can_start_user_systemd = True
+        util_mock.startProgram.return_value = 100
+        start_user_systemd()
+
+        util_mock.startProgram.assert_called_once_with(
+            ["/usr/lib/systemd/systemd", "--user"]
+        )
+        watch_mock.watch_process.assert_called_once_with(
+            100, "systemd"
+        )
+        assert os.environ["DBUS_SESSION_BUS_ADDRESS"] == \
+            "unix:path=/my/xdg/path/bus"


### PR DESCRIPTION
The user instance of systemd that we start from Anaconda on the boot.iso runs a session bus at `XDG_RUNTIME_DIR/bus`. Other services started by Anaconda might call `bus-launch --autolaunch` to find the existing session bus (or start a new one), but `dbus-launch` ignores the `XDG_RUNTIME_DIR` environment variable.

* Let's set the `DBUS_SESSION_BUS_ADDRESS` environment variable to fix that.
* Create the `SessionBus` object for an easy access to the session bus.
* Always start the user instance of systemd on a boot.iso for consistency.
