### PR TITLE
Lower permissions on files stored in /tmp/

### DIFF
--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -27,6 +27,7 @@ import sys
 import warnings
 
 from pyanaconda.core import constants
+from pyanaconda.core.path import set_mode
 
 ENTRY_FORMAT = "%(asctime)s,%(msecs)03d %(levelname)s %(name)s: %(message)s"
 STDOUT_FORMAT = "%(asctime)s %(message)s"
@@ -117,8 +118,10 @@ class AnacondaSocketHandler(_AnacondaLogFixer, SocketHandler):
 
 
 class AnacondaFileHandler(_AnacondaLogFixer, logging.FileHandler):
-    pass
+    def __init__(self, file_dest):
+        logging.FileHandler.__init__(self, file_dest)
 
+        set_mode(file_dest)
 
 class AnacondaStreamHandler(_AnacondaLogFixer, logging.StreamHandler):
     pass

--- a/pyanaconda/core/path.py
+++ b/pyanaconda/core/path.py
@@ -128,3 +128,16 @@ def touch(file_path):
     """
     if not os.path.exists(file_path):
         os.mknod(file_path)
+
+
+def set_mode(file_path, perm=0o600):
+    """Set file permission to a given file
+
+    In case the file doesn't exists - create it.
+
+    :param str file_path: Path to a file
+    :param int perm: File permissions in format of os.chmod()
+    """
+    if not os.path.exists(file_path):
+        touch(file_path)
+    os.chmod(file_path, perm)

--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -21,7 +21,7 @@ import glob
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.path import make_directories, join_paths
+from pyanaconda.core.path import make_directories, join_paths, open_with_perm
 from pyanaconda.core.util import execWithRedirect, restorecon
 from pyanaconda.modules.common.task import Task
 
@@ -129,7 +129,7 @@ class CopyLogsTask(Task):
     def _dump_journal(self):
         """Dump journal from the installation environment"""
         tempfile = "/tmp/journal.log"
-        with open(tempfile, "w") as logfile:
+        with open_with_perm(tempfile, "w", perm=0o600) as logfile:
             execWithRedirect("journalctl", ["-b"], stdout=logfile, log_output=False)
         self._copy_file_to_sysroot(tempfile, join_paths(TARGET_LOG_DIR, "journal.log"))
 

--- a/pyanaconda/modules/common/__init__.py
+++ b/pyanaconda/modules/common/__init__.py
@@ -17,6 +17,8 @@
 #
 import sys
 
+from pyanaconda.core.path import set_mode
+
 __all__ = ["init"]
 
 
@@ -41,6 +43,9 @@ def init(log_filename=None, log_stream=sys.stderr):
         )
 
     if log_filename:
+        # Set correct permissions on log files from security reasons
+        set_mode(log_filename)
+
         handlers.append(
             logging.FileHandler(log_filename)
         )

--- a/scripts/anaconda-pre-log-gen
+++ b/scripts/anaconda-pre-log-gen
@@ -8,7 +8,7 @@ TARGET_DIRECTORY=/tmp/pre-anaconda-logs
 # do not produce any logs unless debug is enabled
 grep -E -q "\<debug\>|\<inst\.debug\>" /proc/cmdline || exit 0
 
-mkdir ${TARGET_DIRECTORY}
+mkdir -m 700 ${TARGET_DIRECTORY}
 
 lsblk -a > ${TARGET_DIRECTORY}/block_devices.log
 dmesg > ${TARGET_DIRECTORY}/kernel_ring_buffer.log

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -35,7 +35,7 @@ RPM_RELEASE_DIR_TEMPLATE = "for_%s"
 SITE_PACKAGES_PATH = "./usr/lib64/python3.12/site-packages/"
 
 # Anaconda scripts that should be installed into the libexec folder
-LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates"]
+LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates", "anaconda-pre-log-gen"]
 
 # Anaconda scripts that should be installed into /usr/bin
 USR_BIN_SCRIPTS = ["anaconda-disable-nm-ibft-plugin", "anaconda-nm-disable-autocons"]

--- a/tests/unit_tests/pyanaconda_tests/core/test_path.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_path.py
@@ -21,7 +21,7 @@ import unittest
 from unittest.mock import patch, call
 import pytest
 from pyanaconda.core.path import set_system_root, make_directories, get_mount_paths, \
-    open_with_perm, join_paths, touch
+    open_with_perm, join_paths, touch, set_mode
 
 
 class SetSystemRootTests(unittest.TestCase):
@@ -233,5 +233,27 @@ class MiscTests(unittest.TestCase):
 
             # check if the file is empty
             assert os.stat(file_path).st_size == 0
+        finally:
+            shutil.rmtree(test_dir)
+
+    def test_set_mode(self):
+        """Test if the set_mode function"""
+        test_dir = tempfile.mkdtemp()
+        try:
+            file_path = os.path.join(test_dir, "EMPTY_FILE")
+
+            # test default mode - file will be created when it doesn't exists
+            set_mode(file_path)
+
+            # check if it exists & is a file
+            assert os.path.isfile(file_path)
+            # check if the file is empty
+            assert os.stat(file_path).st_mode == 0o100600
+
+            # test change of mode on already created file
+            set_mode(file_path, 0o744)
+
+            # check if the file is empty
+            assert os.stat(file_path).st_mode == 0o100744
         finally:
             shutil.rmtree(test_dir)

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
@@ -26,7 +26,7 @@ class CopyLogsTaskTest(unittest.TestCase):
     @patch("pyanaconda.modules.boss.installation.restorecon")
     @patch("pyanaconda.modules.boss.installation.make_directories")
     @patch("pyanaconda.modules.boss.installation.conf")
-    @patch("pyanaconda.modules.boss.installation.open")
+    @patch("pyanaconda.modules.boss.installation.open_with_perm")
     def test_run_all(self, open_mock, conf_mock, mkdir_mock, restore_mock, exec_wr_mock,
                      glob_mock):
         """Test the log copying task."""
@@ -66,7 +66,7 @@ class CopyLogsTaskTest(unittest.TestCase):
         glob_mock.assert_has_calls([
             call("/tmp/ks-script*.log")
         ])
-        open_mock.assert_called_once_with("/tmp/journal.log", "w")
+        open_mock.assert_called_once_with("/tmp/journal.log", "w", perm=0o600)
         log_file = open_mock().__enter__.return_value
 
         # Warning: Constructing the argument to the exec... call requires a call to one of the
@@ -116,7 +116,7 @@ class CopyLogsTaskTest(unittest.TestCase):
     @patch("pyanaconda.modules.boss.installation.execWithRedirect")
     @patch("pyanaconda.modules.boss.installation.make_directories")
     @patch("pyanaconda.modules.boss.installation.conf")
-    @patch("pyanaconda.modules.boss.installation.open")
+    @patch("pyanaconda.modules.boss.installation.open_with_perm")
     def test_nosave_input_ks(self, open_mock, conf_mock, mkdir_mock, exec_wr_mock, glob_mock):
         """Test nosave for kickstart"""
         glob_mock.side_effect = [


### PR DESCRIPTION
Reduce permissions to files stored in `/tmp` to avoid security vulnerabilities.

This is additional work on top of https://github.com/rhinstaller/anaconda/commit/9cb6f74a5db63ae1568fba92f1bab25f2c573185 .

Resolves: RHEL-23345