### PR TITLE
RHEL-9: lower perms for tmp files

### DIFF
--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -127,8 +127,12 @@ class AnacondaSocketHandler(_AnacondaLogFixer, SocketHandler):
 
 
 class AnacondaFileHandler(_AnacondaLogFixer, logging.FileHandler):
-    pass
+    def __init__(self, file_dest):
+        logging.FileHandler.__init__(self, file_dest)
 
+        # do the import here to prevent circular imports
+        from pyanaconda.core.util import set_mode
+        set_mode(file_dest)
 
 class AnacondaStreamHandler(_AnacondaLogFixer, logging.StreamHandler):
     pass

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -1197,6 +1197,19 @@ def touch(file_path):
         os.mknod(file_path)
 
 
+def set_mode(file_path, perm=0o600):
+    """Set file permission to a given file
+
+    In case the file doesn't exists - create it.
+
+    :param str file_path: Path to a file
+    :param int perm: File permissions in format of os.chmod()
+    """
+    if not os.path.exists(file_path):
+        touch(file_path)
+    os.chmod(file_path, perm)
+
+
 def collect(module_pattern, path, pred):
     """Traverse the directory (given by path), import all files as a module
        module_pattern % filename and find all classes within that match

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -112,7 +112,7 @@ class AnacondaKSScript(KSScript):
             # chroot later.
             messages = "/tmp/%s.log" % os.path.basename(path)
 
-        with open(messages, "w") as fp:
+        with util.open_with_perm(messages, "w", 0o600) as fp:
             rc = util.execWithRedirect(self.interp, ["/tmp/%s" % os.path.basename(path)],
                                        stdout=fp,
                                        root=scriptRoot)

--- a/pyanaconda/modules/common/__init__.py
+++ b/pyanaconda/modules/common/__init__.py
@@ -41,6 +41,10 @@ def init(log_filename=None, log_stream=sys.stderr):
         )
 
     if log_filename:
+        # Set correct permissions on log files from security reasons
+        from pyanaconda.core.util import set_mode
+        set_mode(log_filename)
+
         handlers.append(
             logging.FileHandler(log_filename)
         )

--- a/scripts/anaconda-pre-log-gen
+++ b/scripts/anaconda-pre-log-gen
@@ -12,7 +12,7 @@ DEBUG_ENABLED=`cat $BOOT_OPTIONS_FILE | egrep -c "\<debug\>|\<inst\.debug\>"`
 # do not produce any logs unless debug is enabled
 [ $DEBUG_ENABLED == '0' ] && exit 0
 
-mkdir ${TARGET_DIRECTORY}
+mkdir -m 700 ${TARGET_DIRECTORY}
 
 lsblk -a > ${TARGET_DIRECTORY}/block_devices.log
 dmesg > ${TARGET_DIRECTORY}/kernel_ring_buffer.log

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -36,7 +36,7 @@ RPM_RELEASE_DIR_TEMPLATE = "for_%s"
 SITE_PACKAGES_PATH = "./usr/lib64/python3.9/site-packages/"
 
 # Anaconda scripts that should be installed into the libexec folder
-LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates"]
+LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates", "anaconda-pre-log-gen"]
 
 
 def get_archive_tag(configure, spec):

--- a/tests/unit_tests/pyanaconda_tests/core/test_util.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_util.py
@@ -751,6 +751,28 @@ class MiscTests(unittest.TestCase):
         finally:
             shutil.rmtree(test_dir)
 
+    def test_set_mode(self):
+        """Test if the set_mode function"""
+        test_dir = tempfile.mkdtemp()
+        try:
+            file_path = os.path.join(test_dir, "EMPTY_FILE")
+
+            # test default mode - file will be created when it doesn't exists
+            util.set_mode(file_path)
+
+            # check if it exists & is a file
+            assert os.path.isfile(file_path)
+            # check if the file is empty
+            assert os.stat(file_path).st_mode == 0o100600
+
+            # test change of mode on already created file
+            util.set_mode(file_path, 0o744)
+
+            # check if the file is empty
+            assert os.stat(file_path).st_mode == 0o100744
+        finally:
+            shutil.rmtree(test_dir)
+
     def test_item_counter(self):
         """Test the item_counter generator."""
         # normal usage


### PR DESCRIPTION
Reduce permissions to files stored in /tmp to avoid security vulnerabilities.

This is additional work on top of https://github.com/rhinstaller/anaconda/commit/9cb6f74a5db63ae1568fba92f1bab25f2c573185 .

Resolves: RHEL-23345

Backport of https://github.com/rhinstaller/anaconda/pull/5466