### PR TITLE
infra: Remove npm from rpm container

### DIFF
--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -31,7 +31,6 @@ RUN set -ex; \
   # Install dependencies
   dnf install -y \
   'dnf-command(copr)' \
-  npm \
   git \
   curl \
   python3-polib \


### PR DESCRIPTION
It is leftover from time when web UI was part of the Anaconda main repository. It is not required anymore.