### PR TITLE
infra: Remove npm dependency from anaconda-ci

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -52,7 +52,6 @@ RUN set -ex; \
   # Install rest of the dependencies
   dnf install -y \
   /usr/bin/xargs \
-  npm \
   rpm-build \
   git \
   bzip2 \


### PR DESCRIPTION
This is leftover dependency from time when web UI was part of this repository. Let's remove it.