### PR TITLE
Remove unused certificate from container (#infra)

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -51,9 +51,6 @@ RUN mkdir actions-runner && cd actions-runner && \
   LATEST_VER=$(basename $(curl -Ls -o /dev/null -w '%{url_effective}' $URL_BASE/latest)) && \
   curl -L "$URL_BASE/download/$LATEST_VER/actions-runner-linux-x64-${LATEST_VER#v}.tar.gz" | tar xvz
 
-RUN curl https://password.corp.redhat.com/RH-IT-Root-CA.crt -o /etc/pki/ca-trust/source/anchors/Red_Hat_IT_Root_CA.crt && \
-  update-ca-trust
-
 RUN mkdir /anaconda
 
 WORKDIR /anaconda


### PR DESCRIPTION
It was here for copr builder but we are not using that for quite some time. Last build was 9 months ago. Also download of this certificate is now failing.

Let's simplify our life and remove this completely.