### PR TITLE
Lower permissions for kickstart logs in /tmp

### DIFF
--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -30,6 +30,7 @@ from contextlib import contextmanager
 
 from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger
 from pyanaconda.core import util
+from pyanaconda.core.path import open_with_perm
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.kickstart import VERSION, commands as COMMANDS
 from pyanaconda.core.kickstart.specification import KickstartSpecification
@@ -110,7 +111,7 @@ class AnacondaKSScript(KSScript):
             # chroot later.
             messages = "/tmp/%s.log" % os.path.basename(path)
 
-        with open(messages, "w") as fp:
+        with open_with_perm(messages, "w", 0o600) as fp:
             rc = util.execWithRedirect(self.interp, ["/tmp/%s" % os.path.basename(path)],
                                        stdout=fp,
                                        root=scriptRoot)


### PR DESCRIPTION
These logs could potentially contain sensitive data so let's set these logs as accessible by root only.

This is extension to https://github.com/rhinstaller/anaconda/pull/5466 .