### PR TITLE
Do not write LVM devices file during image installation

### DIFF
--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -343,6 +343,10 @@ class WriteConfigurationTask(Task):
         :param Blivet storage: instance of Blivet or a subclass
         :param str sysroot: path to the target OS installation
         """
+        if conf.target.is_image:
+            log.debug("Don't write the LVM devices file during image installation.")
+            return
+
         if not HAVE_LVMDEVICES:
             return
 


### PR DESCRIPTION
Follow up for #5325 which disables the LVM devices file usage on blivet side but we also need to skip writing the file when writing the storage configuration post install.

Resolves: rhbz#2247872