### PR TITLE
Do not use systemd-resolved in installer environment on RHEL

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -122,7 +122,9 @@ Requires: NetworkManager-team
 Requires: kbd
 Requires: chrony
 Requires: systemd
+%if ! 0%{?rhel}
 Requires: systemd-resolved
+%endif
 Requires: python3-pid
 
 # Required by the systemd service anaconda-fips.


### PR DESCRIPTION
Resolves: RHEL-26320

(Related past pull requests: https://github.com/rhinstaller/anaconda/pull/3783, https://github.com/rhinstaller/anaconda/pull/3814, https://github.com/rhinstaller/anaconda/pull/3818)