### PR TITLE
infra: run webui tests only on master branch

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -18,6 +18,8 @@ on:
       - 'data/conf.d/**/'
       - 'data/profile.d/**'
       - 'po/l10n-config.mk'
+    branches:
+      - 'master'
 jobs:
   trigger:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
anaconda-webui is not supported in any released fedora version, therefore there is not reason to run tests there.

