### PR TITLE
Move hardcoded flatpak remote to configuration

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -105,6 +105,13 @@ enable_closest_mirror = True
 #
 default_source = CLOSEST_MIRROR
 
+# Default remote source after deployment of local Flatpaks from the ISO.
+# Only one value can be set.
+# Supported format:
+#   remote-name  remote-flatpak-repository
+flatpak_remote =
+    fedora  oci+https://registry.fedoraproject.org
+
 # Enable ssl verification for all HTTP connection
 verify_ssl = True
 

--- a/docs/release-notes/flatpak-remote-is-configurable.rst
+++ b/docs/release-notes/flatpak-remote-is-configurable.rst
@@ -1,0 +1,10 @@
+:Type: Flatpak
+:Summary: Remote repository for Flatpaks after deployment are now configurable
+
+:Description:
+    Currently when OSTree installation detects Flatpak repository in the installation media
+    these Flatpaks are deployed and the remote was hardcoded to remote Fedora. This remote
+    is then used for updating the Flatpaks after installation.
+
+    After this change Flatpak remote can be set by ``flatpak_remote`` key in the configuration
+    file.

--- a/pyanaconda/core/configuration/payload.py
+++ b/pyanaconda/core/configuration/payload.py
@@ -106,6 +106,28 @@ class PayloadSection(Section):
         return value
 
     @property
+    def flatpak_remote(self):
+        """Default remote source after deployment of local Flatpaks from the ISO.
+
+        Only one value can be set.
+        Supported format:
+            remote-name  remote-flatpak-repository
+
+        :return: a tuple with (name, URL)
+        """
+        return self._get_option("flatpak_remote", self._convert_flatpak_remote)
+
+    @classmethod
+    def _convert_flatpak_remote(cls, value):
+        """Convert flatpak remote from string to tuple."""
+        value = value.split()
+        if len(value) != 2:
+            raise ValueError("Flatpak remote needs to be in format 'name URL': {}".format(value))
+
+        return tuple(value)
+
+
+    @property
     def verify_ssl(self):
         """Global option if the ssl verification is enabled.
 

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_installation.py
@@ -15,6 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.payloads.payload.rpm_ostree.flatpak_manager import FlatpakManager
@@ -50,8 +51,9 @@ class InstallFlatpaksTask(Task):
         flatpak_manager.install_all()
 
         self.report_progress(_("Performing post-installation Flatpak tasks"))
-        flatpak_manager.add_remote("fedora", "oci+https://registry.fedoraproject.org")
-        flatpak_manager.replace_installed_refs_remote("fedora")
+        remote_name, remote_url = conf.payload.flatpak_remote
+        flatpak_manager.add_remote(remote_name, remote_url)
+        flatpak_manager.replace_installed_refs_remote(remote_name)
         flatpak_manager.remove_remote(FlatpakManager.LOCAL_REMOTE_NAME)
 
         self.report_progress(_("Flatpak installation has finished"))

--- a/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_configuration.py
@@ -33,6 +33,7 @@ from pyanaconda.core.configuration.base import create_parser, read_config, write
     get_option, set_option, ConfigurationError, ConfigurationDataError, ConfigurationFileError, \
     Configuration
 from pyanaconda.core.configuration.storage import StorageSection
+from pyanaconda.core.configuration.payload import PayloadSection
 from pyanaconda.core.configuration.ui import UserInterfaceSection
 from pyanaconda.modules.common.constants import services, namespaces
 from pyanaconda.core.constants import SOURCE_TYPE_CLOSEST_MIRROR, GEOLOC_DEFAULT_PROVIDER, \
@@ -461,6 +462,29 @@ class AnacondaConfigurationTestCase(unittest.TestCase):
     def test_default_installation_source(self):
         conf = AnacondaConfiguration.from_defaults()
         assert conf.payload.default_source == SOURCE_TYPE_CLOSEST_MIRROR
+
+    def test_default_flatpak_remote(self):
+        conf = AnacondaConfiguration.from_defaults()
+        assert conf.payload.flatpak_remote == ('fedora', 'oci+https://registry.fedoraproject.org')
+
+    def test_covert_flatpak_remote(self):
+        convert = PayloadSection._convert_flatpak_remote
+
+        assert convert("test_remote URL") == ("test_remote", "URL")
+
+        # only a pair of two values is supported
+        # test three values raising an error
+        with pytest.raises(ValueError):
+            convert("test remote URL")
+
+        # test one value is raising an error
+        with pytest.raises(ValueError):
+            convert("URL")
+
+        # test that multiple lines are not supported
+        with pytest.raises(ValueError):
+            convert("""test remote
+            test URL""")
 
     def test_default_password_policies(self):
         conf = AnacondaConfiguration.from_defaults()


### PR DESCRIPTION
Without this change Anaconda always set the remote after flatpak
deployment to

```
name: fedora
remote: oci+https://registry.fedoraproject.org/
```

that worked until now. However, uBlue[1] want's to use Flathub registry as the remote source.

To enable this we should move the flatpak remote from code to configuration files and they should create this configuration file during the ISO creation.

Another use-case for this are ISO images for container based OSTree deployments. The tool to create an ISO could also enable user to set their own set of flatpaks from any remote source to the ISO image with installer for offline deployment and changing this configuration to set the correct remote after installation.


Please check that your PR follows these rules:

* [x] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.

* [x] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.

* [x] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.
  *If you don't know how, ask us for help!*

* [x] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
  *If you don't know how, ask us for help!*

*Note: This is community contribution in my free time - not a team effort* :grin: 