### PR TITLE
Gather also newly added virt-install command log.

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -304,7 +304,7 @@ jobs:
           name: 'logs'
           # skip the /anaconda subdirectories, too large
           path: |
-            kickstart-tests/data/logs/kstest.log
+            kickstart-tests/data/logs/kstest*.log
             kickstart-tests/data/logs/kstest-*/*.log
             kickstart-tests/data/additional_repo/*.rpm
             permian/permian.log


### PR DESCRIPTION
Follow-up on https://github.com/rhinstaller/kickstart-tests/pull/1067 which should make it easier to debug kickstart test issues we hit for example on new branches (like F40 https://github.com/rhinstaller/anaconda/actions/runs/8047809280/job/21977845706, RHEL 10).