### PR TITLE
infra: fix up template file for kickstart-tests

### DIFF
--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -298,7 +298,7 @@ jobs:
           name: 'logs'
           # skip the /anaconda subdirectories, too large
           path: |
-            kickstart-tests/data/logs/kstest.log
+            kickstart-tests/data/logs/kstest*.log
             kickstart-tests/data/logs/kstest-*/*.log
             kickstart-tests/data/additional_repo/*.rpm
             permian/permian.log


### PR DESCRIPTION
Fix up follow up to e9b5989 for keeping the template file synced.

