### PR TITLE
desired capacity tooltip text adapt language

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -255,7 +255,7 @@ class AddDialog(GUIObject):
         self._warning_label = self.builder.get_object("mountPointWarningLabel")
 
         self._size_entry = self.builder.get_object("addSizeEntry")
-        self._size_entry.set_tooltip_text(DESIRED_CAPACITY_HINT)
+        self._size_entry.set_tooltip_text(_(DESIRED_CAPACITY_HINT))
 
         self._populate_mount_points()
 


### PR DESCRIPTION
When we selected other language, desired capacity tooltip text with "DESIRED_CAPACITY_HINT" do not follow the language to change. They do not adapt the language, So to change they to adapt language.