### PR TITLE
gui:Fix potential index error for _remove_treeinfo_repositories()

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1656,6 +1656,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             if repo_item[REPO_OBJ].treeinfo_origin:
                 removal_repo_list.append(repo_item.path)
 
+        # Using reverse order to ensure that the previous repositories
+        # will not be removed before _remove_repository(), otherwise it
+        # will get a wrong index to use after the first loop.
+        removal_repo_list.reverse()
+
         for path in removal_repo_list:
             self._remove_repository(path)
 


### PR DESCRIPTION
The _remove_treeinfo_repositories() try to remove treeinfo repositories from _repo_store[],the index 'path' is saved in removal_repo_list[] and arranged in order.

The problem is that _remove_repository(path) will remove the previous repositories,and the subsequent loops will get a wrong index for _repo_store[].

Fix it by reversing the removal_repo_list[], to secure previous repositories will not be removed before _remove_repository().

**Thank you** for your contribution!

Please check that your PR follows these rules:

* [x] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.

* [x] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.

* [x] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.
  *If you don't know how, ask us for help!*

* [x] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
  *If you don't know how, ask us for help!*

* [ ] **RHEL** rules: If your PR is for a `rhel-*` branch, pay special attention to commit messages. Make sure **all** commit messages include a line linking the commit to a bug, such as `Resolves: rhbz#123456`. For more information, see [the complete rules](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html).
  *If you don't know how, ask us for help!*

Don't forget - *if you don't know how, ask us for help!*

And now that you read this all, you can delete it and type your own description of your changes :-)
