### PR TITLE
gui:Fix index error for _remove_treeinfo_repositories()

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -1656,6 +1656,11 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
             if repo_item[REPO_OBJ].treeinfo_origin:
                 removal_repo_list.append(repo_item.path)
 
+        # Using reverse order to ensure that the previous repositories
+        # will not be removed before _remove_repository(), otherwise it
+        # will get a wrong index to use after the first loop.
+        removal_repo_list.reverse()
+
         for path in removal_repo_list:
             self._remove_repository(path)
 


### PR DESCRIPTION
The _remove_treeinfo_repositories() try to remove treeinfo repositories from _repo_store[],the index 'path' is saved in removal_repo_list[] and arranged in order.

The problem is that _remove_repository(path) will remove the previous repositories,and the subsequent loops will get a wrong index for _repo_store[].

Fix it by reversing the removal_repo_list[], to secure previous repositories will not be removed before _remove_repository().

Resolves: RHEL-29561