### PR TITLE
Disable preexec for vtActivate()

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -585,7 +585,7 @@ def vtActivate(num):
     """
 
     try:
-        ret = execWithRedirect("chvt", [str(num)])
+        ret = execWithRedirect("chvt", [str(num)], do_preexec=False)
     except OSError as oserr:
         ret = -1
         log.error("Failed to run chvt: %s", oserr.strerror)


### PR DESCRIPTION
We need to explicitely disable the preexec when vtActivate() calls execWithRedirect().

This is needed as vtActivate() is called from the exit handler & that apparently does not support preexec functions. If we don't do this, we would get the following error:

"RuntimeError: preexec_fn not supported at interpreter shutdown"

This is a backport of #5518 for Fedora 40.