### PR TITLE
Determine UUID of the filesystem containing the GRUB config

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -182,13 +182,11 @@ class EFIGRUB(EFIBase, GRUB2):
 
         with open(config_path, "w") as fd:
             grub_dir = self.config_dir
-            if self.stage2_device.format.type != "btrfs":
-                fs_uuid = self.stage2_device.format.uuid
-            else:
-                fs_uuid = self.stage2_device.format.vol_uuid
 
-            if fs_uuid is None:
-                raise BootLoaderError("Could not get stage2 filesystem UUID")
+            fs_uuid = util.execWithCapture("grub2-probe", ["--target", "fs_uuid", grub_dir],
+                                           root=conf.target.system_root)
+            if not fs_uuid:
+                raise BootLoaderError("Could not get GRUB filesystem UUID")
 
             grub_dir = util.execWithCapture("grub2-mkrelpath", [grub_dir],
                                             root=conf.target.system_root)


### PR DESCRIPTION
When /boot/grub2 is on a dedicated partition, using the stage2 UUID will result in an invalid config being generated on the ESP and the system won't be able to boot.

Putting /boot/grub2 on a dedicated partition allows to put the kernels onto a btrfs partition (and snapshot them), while keeping the contents of /boot/grub2 writeable for GRUB.