### PR TITLE
Add ping tool to Dracut

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -298,6 +298,7 @@ Requires: dracut-network
 Requires: dracut-live
 Requires: xz
 Requires: python3-kickstart
+Requires: iputils
 
 %description dracut
 The 'anaconda' dracut module handles installer-specific boot tasks and

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -21,6 +21,8 @@ installkernel() {
 }
 
 install() {
+    # binaries for easier debugging (requested by https://issues.redhat.com/browse/RHEL-5719)
+    dracut_install ping
     # binaries we want in initramfs
     dracut_install eject -o pigz
     dracut_install depmod blkid


### PR DESCRIPTION
It will simplify debugging of Dracut issues for installer for a cost of about 200 kB size of the initrd image.

Backport of https://github.com/rhinstaller/anaconda/pull/5500

*Resolves: [RHEL-5719](https://issues.redhat.com/browse/RHEL-5719)*