### PR TITLE
anaconda-diskroot: wait before dying on media check fail

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -24,12 +24,16 @@ run_checkisomd5() {
                 rc=$?
                 state="inactive"
             fi
-            if [ "$rc" == "1" ]; then
-                die "CD check failed!"
+            if [ "$rc" = "1" ]; then
+                warn "Media check failed! We do not recommend using this medium. System will halt in 12 hours"
+                sleep 43200
+                die "Media check failed!"
                 exit 1
             fi
             if [ "$state" = "failed" ]; then
-                die "CD check failed!"
+                warn "Media check failed! We do not recommend using this medium. System will halt in 12 hours"
+                sleep 43200
+                die "Media check failed!"
                 exit 1
             fi
             [ -x /bin/plymouth ] && /bin/plymouth --show-splash


### PR DESCRIPTION
If a modesetting driver has been loaded by the time the media check happens, halting the system (as we currently do immediately if the check fails) blanks the screen, which is confusing for the user. This adds a warning message and a 12-hour wait before the system is eventually halted, so the user can see the media check failure and (presumably) reboot and fix the medium.

It also tweaks the text of the failure message not to call it a "CD check", since it's not 1998 any more.

**Resolves: [RHEL-4790](https://issues.redhat.com/browse/RHEL-4790)**

Signed-off-by: Adam Williamson <awilliam@redhat.com>
Backport of https://github.com/rhinstaller/anaconda/pull/5362