### PR TITLE
infra: Prepare templating to support RHEL-10

### DIFF
--- a/.branch-variables.yml
+++ b/.branch-variables.yml
@@ -10,5 +10,13 @@ distro_name: "fedora" # "fedora" or "rhel"
 distro_release: "rawhide" # "rawhide" or a number without quotation marks
 
 # The following only applies for rawhide.
-branched_fedora_version: 40 # number without quotation marks, or nothing if CI should not run for branched Fedora
-rawhide_fedora_version: 41 # ditto
+rawhide_fedora_version: 41 # number without quotation marks, or nothing if CI should not run for branched Fedora
+
+# List of all the branches which are currently supported and CI should be executed on these.
+supported_branches:
+  - fedora-40:
+    variant: "fedora"
+  - rhel-9:
+    variant: "rhel"
+  - rhel-10:
+    variant: "rhel"

--- a/.github/labeler.yml.j2
+++ b/.github/labeler.yml.j2
@@ -2,10 +2,12 @@
 # See https://github.com/actions/labeler
 
 # Always apply target fedora version to any changes
-{% if distro_release == "rawhide" %}
+{% if distro_name == "fedora" and distro_release == "rawhide" %}
 f{$ rawhide_fedora_version $}:
-{% else %}
+{% elif distro_name == "fedora" %}
 f{$ distro_release $}:
+{% elif distro_name == "rhel" %}
+rhel-{$ distro_release $}:
 {% endif %}
 - any:
   - changed-files:

--- a/.github/workflows/container-autoupdate-fedora.yml.j2
+++ b/.github/workflows/container-autoupdate-fedora.yml.j2
@@ -20,12 +20,12 @@ jobs:
       container-tag: master
       branch: master
 
-  {% if branched_fedora_version is defined and branched_fedora_version %}
-  fedora-{$ branched_fedora_version $}:
+  {% for branch in supported_branches if branch.variant == "fedora" %}
+  {$ branch|first $}:
     uses: ./.github/workflows/container-rebuild-action.yml
     secrets: inherit
     with:
-      container-tag: fedora-{$ branched_fedora_version $}
-      branch: fedora-{$ branched_fedora_version $}
-  {% endif %}
+      container-tag: {$ branch|first $}
+      branch: {$ branch|first $}
+  {% endfor %}
 {% endif %}

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -75,6 +75,9 @@ jobs:
           elif echo "$TARGET_BRANCH" | grep -qE "rhel-9(\.[[:digit:]]+)?$"; then
             echo "skip_tests=skip-on-rhel,skip-on-rhel-9" >> $GITHUB_OUTPUT
             echo "platform=rhel9" >> $GITHUB_OUTPUT
+          elif echo "$TARGET_BRANCH! | grep -qE "rhel-10(\.[[:digit:]]+)?$"; then
+            echo "skip_tests=skip-on-rhel,skip-on-rhel-10" >> $GITHUB_OUTPUT
+            echo "platform=rhel10" >> $GITHUB_OUTPUT
           else
             echo "Branch $TARGET_BRANCH is not supported by kickstart tests yet!"
             exit 1

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -69,6 +69,9 @@ jobs:
           elif echo "$TARGET_BRANCH" | grep -qE "rhel-9(\.[[:digit:]]+)?$"; then
             echo "skip_tests=skip-on-rhel,skip-on-rhel-9" >> $GITHUB_OUTPUT
             echo "platform=rhel9" >> $GITHUB_OUTPUT
+          elif echo "$TARGET_BRANCH! | grep -qE "rhel-10(\.[[:digit:]]+)?$"; then
+            echo "skip_tests=skip-on-rhel,skip-on-rhel-10" >> $GITHUB_OUTPUT
+            echo "platform=rhel10" >> $GITHUB_OUTPUT
           else
             echo "Branch $TARGET_BRANCH is not supported by kickstart tests yet!"
             exit 1

--- a/.github/workflows/l10n-po-update.yml
+++ b/.github/workflows/l10n-po-update.yml
@@ -25,8 +25,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        branch: ['master', 'fedora-40']
-        #branch: ['master']
+        branch: ['master', 'fedora-40', 'rhel-9', 'rhel-10']
 
     steps:
       - name: Set up dependencies

--- a/.github/workflows/l10n-po-update.yml.j2
+++ b/.github/workflows/l10n-po-update.yml.j2
@@ -18,12 +18,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        {% if branched_fedora_version is defined and branched_fedora_version %}
-        branch: ['master', 'fedora-{$ branched_fedora_version $}']
-        #branch: ['master']
-        {% else %}
-        branch: ['master']
-        {% endif %}
+        branch: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
 
     steps:
       - name: Set up dependencies

--- a/.github/workflows/tests-daily.yml.j2
+++ b/.github/workflows/tests-daily.yml.j2
@@ -43,11 +43,7 @@ jobs:
         # * This is still a matrix because we might re-enable ELN one day and then we will need
         #   a matrix here.
         #}
-        {% if branched_fedora_version is defined and branched_fedora_version %}
-        release: ['master', 'fedora-{$ branched_fedora_version $}']
-        {% else %}
-        release: ['master']
-        {% endif %}
+        release: ['master'{% for branch in supported_branches if branch.variant == "fedora" %}, '{$ branch|first $}'{% endfor %}]
         include:
           - release: 'master'
             target_branch: 'master'
@@ -57,11 +53,11 @@ jobs:
           #  target_branch: 'master'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
-        {% if branched_fedora_version is defined and branched_fedora_version %}
-          - release: 'fedora-{$ branched_fedora_version $}'
-            target_branch: 'fedora-{$ branched_fedora_version $}'
-            ci_tag: 'fedora-{$ branched_fedora_version $}'
-        {% endif %}
+        {% for branch in supported_branches if branch.variant == "fedora" %}
+          - release: '{$ branch|first $}'
+            target_branch: '{$ branch|first $}'
+            ci_tag: '{$ branch|first $}'
+        {% endfor %}
 
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
@@ -95,20 +91,16 @@ jobs:
       fail-fast: false
       matrix:
         {# For matrix details, see comments for the unit tests above. #}
-        {% if branched_fedora_version is defined and branched_fedora_version %}
-        release: ['master', 'fedora-{$ branched_fedora_version $}']
-        {% else %}
-        release: ['master']
-        {% endif %}
+        release: ['master'{% for branch in supported_branches if branch.variant == "fedora" %}, '{$ branch|first $}'{% endfor %}]
         include:
           - release: 'master'
             target_branch: 'master'
             ci_tag: 'master'
-        {% if branched_fedora_version is defined and branched_fedora_version %}
-          - release: 'fedora-{$ branched_fedora_version $}'
-            target_branch: 'fedora-{$ branched_fedora_version $}'
-            ci_tag: 'fedora-{$ branched_fedora_version $}'
-        {% endif %}
+        {% for branch in supported_branches if branch.variant == "fedora" %}
+          - release: '{$ branch|first $}'
+            target_branch: '{$ branch|first $}'
+            ci_tag: '{$ branch|first $}'
+        {% endfor %}
 
     env:
       CI_TAG: '${{ matrix.ci_tag }}'

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -28,9 +28,9 @@ jobs:
         # * This is still a matrix because we might re-enable ELN one day and then we will need
         #   a matrix here.
         #}
-        {% if distro_name == "fedora" and distro_release == "rawhide" %}
         release: ['']
         include:
+        {% if distro_name == "fedora" and distro_release == "rawhide" %}
           - release: ''
             target_branch: 'master'
             ci_tag: 'master'
@@ -40,14 +40,10 @@ jobs:
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
         {% elif distro_name == "fedora" and distro_release is number %}
-        release: ['']
-        include:
           - release: ''
             target_branch: 'fedora-{$ distro_release $}'
             ci_tag: 'fedora-{$ distro_release $}'
         {% elif distro_name == "rhel" %}
-        release: ['']
-        include:
           - release: ''
             target_branch: 'rhel-{$ distro_release $}'
             ci_tag: 'rhel-{$ distro_release $}'

--- a/.github/workflows/try-release-daily.yml
+++ b/.github/workflows/try-release-daily.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master', 'rhel-8', 'rhel-9', 'fedora-40']
+        branch: ['master', 'fedora-40', 'rhel-9', 'rhel-10']
 
     steps:
       - name: Check out repo

--- a/.github/workflows/try-release-daily.yml.j2
+++ b/.github/workflows/try-release-daily.yml.j2
@@ -19,11 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        {% if branched_fedora_version is defined and branched_fedora_version %}
-        branch: ['master', 'rhel-8', 'rhel-9', 'fedora-{$ branched_fedora_version $}']
-        {% else %}
-        branch: ['master', 'rhel-8', 'rhel-9']
-        {% endif %}
+        branch: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
 
     steps:
       - name: Check out repo

--- a/Makefile.am
+++ b/Makefile.am
@@ -226,6 +226,8 @@ anaconda-iso-creator-build:
 	$(ISO_CREATOR_DOCKERFILE)
 
 anaconda-live-iso-creator-build:
+	@test "$(GIT_BRANCH)" != "rhel-10" || ( echo "The Live ISO builds are not supported on rhel-10!"; exit 99 )
+
 	@sudo -nv 2>/dev/null || echo "You will be prompted for sudo password because this container has to be used under root!"
 
 	sudo $(CONTAINER_ENGINE) build \
@@ -382,10 +384,14 @@ container-iso-build:
 
 # Build WebUI ISO from Anaconda RPM files build here
 container-webui-iso-build:
+	@test "$(GIT_BRANCH)" != "rhel-10" || ( echo "The webui ISO builds are not supported on rhel-10!"; exit 99 )
+
 	$(MAKE) -f ./Makefile.am container-iso-build CONTAINER_ADD_ARGS="--entrypoint=/lorax-build-webui"
 
 # Build LIVE ISO from Anaconda RPM files build here
 container-live-iso-build:
+	@test "$(GIT_BRANCH)" != "rhel-10" || ( echo "The Live ISO builds are not supported on rhel-10!"; exit 99 )
+
 	@sudo -nv 2>/dev/null || echo "You will be prompted for sudo password because of loop device mounting in Lorax!"
 
 	@if ! ls $(srcdir)/result/build/01-rpm-build/anaconda-*.rpm >/dev/null 2>/dev/null; then \

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,9 +74,11 @@ TEMPLATE_RENDERER = scripts/jinja-render
 
 CONTAINER_ENGINE ?= podman
 # build/run tweaks for all containers, such as --cap-add
-CONTAINER_BUILD_ARGS ?= --no-cache
+# Network needs to use host configuration so it is sharing VPN connection
+CONTAINER_BUILD_ARGS ?= --no-cache --network=host
 # run tweaks for all containers
-CONTAINER_RUN_ARGS ?= --tty --interactive
+# Network needs to use host configuration so it is sharing VPN connection
+CONTAINER_RUN_ARGS ?= --tty --interactive --network=host
 # HACK: bash's builtin `test -r` fails when running on Ubuntu host (GitHub) due to incompatible seccomp profile
 CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --security-opt=seccomp=unconfined)
 CONTAINER_REGISTRY ?= quay.io

--- a/widgets/configure.ac
+++ b/widgets/configure.ac
@@ -67,7 +67,8 @@ AC_ARG_ENABLE([glade],
 
 AS_IF([test "x$enable_glade" != "xno"],
       [ANACONDA_PKG_CHECK_MODULES([GLADEUI], [gladeui-2.0 >= 3.10])
-       AC_SUBST(GLADE_SUBDIR, "glade")],
+       AC_SUBST(GLADE_SUBDIR, "glade"),
+       AC_CONFIG_FILES([glade/Makefile])],
       [AC_SUBST(GLADE_SUBDIR, "")])
 
 ANACONDA_PKG_CHECK_MODULES([GTK], [gtk+-x11-3.0 >= 3.11.3])
@@ -88,7 +89,6 @@ AC_CHECK_FUNCS([setlocale],
 
 AC_CONFIG_FILES([Makefile
                  doc/Makefile
-                 glade/Makefile
                  src/Makefile
                  python/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Current teplamting solution was to strict about having Rawhide, one Fedora and everything else was hardcoded. Intead of that let's change the logic to have a list of supported branches and this list will generate required tasks for each item on the list based on the data.

The main branch is not included because it helps us to recognize current branch.

**A few notable changes:**
* Solution for po update will now apply also for rhel-9 branch - this should be verified even thought it should work out of the box
* Dropping support from CI for rhel-8 which should be fine because rhel-8 won't get any new spins with the new installer
* Adding RHEL-10 branch support

**This have to be merged after RHEL-10 branch is created!**