### PR TITLE
Use InconsistentParentSectorSize instead of InconsistentPVSectorSize

### DIFF
--- a/pyanaconda/modules/storage/partitioning/base_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/base_partitioning.py
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 from abc import abstractmethod, ABCMeta
-from blivet.errors import StorageError, InconsistentPVSectorSize
+from blivet.errors import StorageError, InconsistentParentSectorSize
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
@@ -51,7 +51,7 @@ class PartitioningTask(Task, metaclass=ABCMeta):
         """Do the partitioning and handle the errors."""
         try:
             self._run(self._storage)
-        except InconsistentPVSectorSize as e:
+        except InconsistentParentSectorSize as e:
             self._handle_storage_error(e, "\n\n".join([
                 _("Failed to proceed with the installation."),
                 str(e).strip(),

--- a/pyanaconda/modules/storage/partitioning/interactive/add_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/add_device.py
@@ -16,7 +16,7 @@
 # Red Hat, Inc.
 #
 from blivet import devicefactory
-from blivet.errors import StorageError, InconsistentPVSectorSize
+from blivet.errors import StorageError, InconsistentParentSectorSize
 from blivet.size import Size
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
@@ -66,7 +66,7 @@ class AddDeviceTask(Task):
             # Trying to use a new container.
             self._add_device(self._storage, self._request, use_existing_container=False)
             return
-        except InconsistentPVSectorSize as e:
+        except InconsistentParentSectorSize as e:
             exception = e
             message = "\n\n".join([
                 _("Failed to add a device."),

--- a/pyanaconda/modules/storage/partitioning/interactive/change_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/change_device.py
@@ -15,7 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from blivet.errors import StorageError, InconsistentPVSectorSize
+from blivet.errors import StorageError, InconsistentParentSectorSize
 from blivet.size import Size
 
 from dasbus.structure import compare_data
@@ -82,7 +82,7 @@ class ChangeDeviceTask(Task):
             else:
                 self._change_device()
 
-        except InconsistentPVSectorSize as e:
+        except InconsistentParentSectorSize as e:
             self._handle_storage_error(e, "\n\n".join([
                 _("Failed to change a device."),
                 str(e).strip(),


### PR DESCRIPTION
Newest blivet will introduce a new exception for inconsistent sector sizes when creating new VGs and Stratis pools so we should use it.

----

This needs to wait for https://github.com/storaged-project/blivet/pull/1222 to be merged and build, but the change is backwards compatible (catching `InconsistentPVSectorSize` will still work) so we don't need to build and release blivet and anaconda together.