### PR TITLE
infra: Always rebuild RPM test container on RHEL

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,29 +107,7 @@ jobs:
           git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
           git rebase ${{ env.TARGET_BRANCH_NAME }}
 
-      - name: Check if container rebuild is needed
-        id: need_rebuild
-        run: |
-          changed_files=$(git diff --name-only ${{ env.TARGET_BRANCH_NAME }}..HEAD)
-          echo -e "Changed files: \n$changed_files\n"
-
-          . .structure-config
-
-          echo "Paths forcing the rebuild:"
-          rebuild="false"
-          for iter_f in $changed_files ; do
-                  for rebuild_f in "${RPM_REBUILD_PATHS[@]}"; do
-                          if [[ "$iter_f" =~ "$rebuild_f" ]]; then
-                                  echo "$iter_f"
-                                  rebuild="true"
-                                  break
-                          fi
-                  done
-          done
-          echo "rebuild=$rebuild" >> $GITHUB_OUTPUT
-
       - name: Build RPM test container
-        if: ${{ steps.need_rebuild.outputs.rebuild == 'true' }}
         run: make -f Makefile.am anaconda-rpm-build
 
       - name: Run RPM tests in container

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -166,6 +166,7 @@ jobs:
           git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
           git rebase ${{ env.TARGET_BRANCH_NAME }}
 
+      {% if distro_name == "fedora" %}
       - name: Check if container rebuild is needed
         id: need_rebuild
         run: |
@@ -190,6 +191,10 @@ jobs:
       - name: Build RPM test container
         if: ${{ steps.need_rebuild.outputs.rebuild == 'true' }}
         run: make -f Makefile.am anaconda-rpm-build
+      {% elif distro_name == "rhel" %}
+      - name: Build RPM test container
+        run: make -f Makefile.am anaconda-rpm-build
+      {% endif %}
 
       - name: Run RPM tests in container
         run: make -f Makefile.am container-rpm-test


### PR DESCRIPTION
We need to rebuild RPM test container on RHEL because our RHEL containers are not stored in the repository.
