### PR TITLE
infra: Packit fix empty jobs field

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -33,5 +33,4 @@ actions:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 
-jobs:
 

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -26,7 +26,9 @@ actions:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 
+{% if distro_name != "rhel" %}
 jobs:
+{% endif %}
 
 {% if distro_release == "rawhide" %}
 


### PR DESCRIPTION
Packit will fail on empty `jobs` field in the configuration file. Let's fix that by removing this field on RHEL.