### PR TITLE
exclude iso9660 disk in unused devices

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -94,6 +94,7 @@ def collect_unused_devices(storage):
         and not d.partitioned
         and (d.direct or d.isleaf)
         and d not in used_devices
+        and d.format.type != "iso9660"
     ]
 
     # Add incomplete VGs and MDs


### PR DESCRIPTION
ISO version：Fedora-Server-dvd-aarch64-39-1.5.iso 
use USB flash：dd if=Fedora-Server-dvd-aarch64-39-1.5.iso  of=/dev/sdb

When I install the system on the hard drive, I select a custom partition and an unknown device appears in the spoke.
![iso9660-1](https://github.com/rhinstaller/anaconda/assets/105339732/b7f1ce87-5d4e-414f-9b35-e9d5df44cfc1)
And I was refused to remove this device.
![iso9660-3](https://github.com/rhinstaller/anaconda/assets/105339732/35a84138-e5be-4fb1-8661-226453f8dfa0)
So let's exclude it from the unused device list.
After adding code:
![iso9660-2](https://github.com/rhinstaller/anaconda/assets/105339732/40123d5d-4a89-47f8-b4c1-db41685f5c20)

