### PR TITLE
GUI: Correctly display device label

### DIFF
--- a/pyanaconda/ui/gui/spokes/installation_source.py
+++ b/pyanaconda/ui/gui/spokes/installation_source.py
@@ -37,7 +37,7 @@ from pyanaconda.modules.common.constants.objects import DEVICE_TREE
 from pyanaconda.modules.common.constants.services import NETWORK, STORAGE
 from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
-from pyanaconda.modules.common.structures.storage import DeviceData
+from pyanaconda.modules.common.structures.storage import DeviceFormatData
 from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.modules.payloads.source.utils import verify_valid_repository
 from pyanaconda.payload import utils as payload_utils
@@ -543,10 +543,10 @@ class SourceSpoke(NormalSpoke, GUISpokeInputCheckHandler, SourceSwitchHandler):
         if not device_name:
             return
 
-        device_data = DeviceData.from_structure(
-            self._device_tree.GetDeviceData(device_name)
+        device_format_data = DeviceFormatData.from_structure(
+            self._device_tree.GetFormatData(device_name)
         )
-        device_label = device_data.attrs.get("label", "")
+        device_label = device_format_data.attrs.get("label", "")
         self._show_cdrom_box(device_name, device_label)
 
     def _show_cdrom_box(self, device_name, device_label):


### PR DESCRIPTION
ISO：Fedora-Server-dvd-aarch64-33-1.3.iso

before fix，Label：NULL
![iso9660-1](https://github.com/rhinstaller/anaconda/assets/105339732/a36b604a-152c-476d-a6af-8df647c86f16)

after fix，Label：Fedora-S-dvd-aarch64-33
![iso9660-2](https://github.com/rhinstaller/anaconda/assets/105339732/e5fbbd6f-1a9c-461f-907b-05324e1e1302)
