### PR TITLE
infra: specfile: convert source to URL

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -10,7 +10,7 @@ URL:     http://fedoraproject.org/wiki/Anaconda
 # git checkout -b archive-branch anaconda-%%{version}-%%{release}
 # ./autogen.sh
 # make dist
-Source0: %{name}-%{version}.tar.bz2
+Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{version}-1/%{name}-%{version}.tar.bz2
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).


### PR DESCRIPTION
This aligns the spec file with master branch and enables further packit integration for the propose_downstream job.

Backport of: https://github.com/rhinstaller/anaconda/commit/6164a07a7b990fc83ba7ce4c937a9339213566ac