### PR TITLE
infra: Tweak rhel-10 repository files

### DIFF
--- a/dockerfile/anaconda-ci/rhel-10.repo
+++ b/dockerfile/anaconda-ci/rhel-10.repo
@@ -19,11 +19,9 @@ enabled=1
 gpgcheck=0
 install_weak_deps=0
 
-# This is a workaround because of missing pykickstart build with rhel-10 support
-# TODO: Remove this when it's not necessary
-[test-fallback-repository]
-name=test-fallback
-baseurl=http://10.43.136.2/trees/tests_fallback_repos/rhel10/
+[COPR-pam]
+name=Fallback for python-pam
+baseurl=https://download.copr.fedorainfracloud.org/results/m4rtink/python-pam-rebuild/centos-stream-10-x86_64/
 enabled=1
 gpgcheck=0
 install_weak_deps=0

--- a/dockerfile/anaconda-rpm/rhel-10.repo
+++ b/dockerfile/anaconda-rpm/rhel-10.repo
@@ -18,3 +18,10 @@ baseurl=http://download.devel.redhat.com/rhel-10/nightly/RHEL-10-Public-Beta/lat
 enabled=1
 gpgcheck=0
 install_weak_deps=0
+
+[COPR-pam]
+name=Fallback for python-pam
+baseurl=https://download.copr.fedorainfracloud.org/results/m4rtink/python-pam-rebuild/centos-stream-10-x86_64/
+enabled=1
+gpgcheck=0
+install_weak_deps=0


### PR DESCRIPTION
Remove not required dependency on a new pykickstart which is already part of the CentOS Stream 10 official repository.

Add new missing dependency on python3-pam which for the test purpose will be temporarily taken from the COPR repository.