### PR TITLE
Fix signature of the method passed to DNF

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/download_progress.py
+++ b/pyanaconda/modules/payloads/payload/dnf/download_progress.py
@@ -92,6 +92,7 @@ class DownloadProgress(dnf.callback.DownloadProgress):
         self.downloads[nevra] = done
         self._report_progress()
 
-    def start(self, total_files, total_size, _total_drpms=0):
+    def start(self, total_files, total_size, total_drpms=0):
+        del total_drpms
         self.total_files = total_files
         self.total_size = Size(total_size)


### PR DESCRIPTION
We don't use this variable ourselves so we renamed it with prefix `_total_drpms`, however, DNF is using this with keyword so it broken installation.