### PR TITLE
Revert "infra: Packit fix empty jobs field"

### DIFF
--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -34,9 +34,7 @@ actions:
     - "make release"
     - 'bash -c "ls -1 anaconda-*.tar.bz2"'
 
-{% if distro_name != "rhel" %}
 jobs:
-{% endif %}
 {% if distro_release == "rawhide" %}
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
This reverts commit 0a4f9e68ab6851a3cbdb15ff0c3d67f293376c7f.

There is already a propose-downstream job existing for RHEL, this was breaking RHEL configuration.

