### PR TITLE
infra: Remove python3-polib dependency from anaconda-release container

### DIFF
--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -18,7 +18,6 @@ RUN set -e; \
   dnf update -y; \
   dnf install -y \
   git \
-  python3-polib \
   python3-pip; \
   dnf clean all;
 


### PR DESCRIPTION
polib is used for testing po files.
Let pip install it indirectly through pocketlint pip dependency.

Cherry-picked commit from master PR: https://github.com/rhinstaller/anaconda/pull/5591
