### PR TITLE
infra: Remove python3-polib dependency from anaconda-release container

### DIFF
--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -11,12 +11,10 @@ RUN set -e; \
   dnf update -y; \
   dnf install -y \
   git \
-  python3-pip; \
   dnf clean all;
 
 RUN pip3 install --no-cache-dir --upgrade pip; \
   pip3 install --no-cache-dir \
-  polib \
   pocketlint
 
 WORKDIR /anaconda


### PR DESCRIPTION
polib is used for testing po files.
Let pip install it indirectly through pocketlint pip dependency.

Cherry-picked commit from master PR: https://github.com/rhinstaller/anaconda/pull/5591
