### PR TITLE
infra: Disable Fedora 40 in automation

### DIFF
--- a/.branch-variables.yml
+++ b/.branch-variables.yml
@@ -14,8 +14,6 @@ rawhide_fedora_version: 41 # number without quotation marks, or nothing if CI sh
 
 # List of all the branches which are currently supported and CI should be executed on these.
 supported_branches:
-  - fedora-40:
-    variant: "fedora"
   - rhel-9:
     variant: "rhel"
   - rhel-10:

--- a/.github/workflows/container-autoupdate-fedora.yml
+++ b/.github/workflows/container-autoupdate-fedora.yml
@@ -26,9 +26,3 @@ jobs:
       container-tag: master
       branch: master
 
-  fedora-40:
-    uses: ./.github/workflows/container-rebuild-action.yml
-    secrets: inherit
-    with:
-      container-tag: fedora-40
-      branch: fedora-40

--- a/.github/workflows/l10n-po-update.yml
+++ b/.github/workflows/l10n-po-update.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        branch: ['master', 'fedora-40', 'rhel-9', 'rhel-10']
+        branch: ['master', 'rhel-9', 'rhel-10']
 
     steps:
       - name: Set up dependencies

--- a/.github/workflows/tests-daily.yml
+++ b/.github/workflows/tests-daily.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['master', 'fedora-40']
+        release: ['master']
         include:
           - release: 'master'
             target_branch: 'master'
@@ -52,9 +52,6 @@ jobs:
           #  target_branch: 'master'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
-          - release: 'fedora-40'
-            target_branch: 'fedora-40'
-            ci_tag: 'fedora-40'
 
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
@@ -87,14 +84,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['master', 'fedora-40']
+        release: ['master']
         include:
           - release: 'master'
             target_branch: 'master'
             ci_tag: 'master'
-          - release: 'fedora-40'
-            target_branch: 'fedora-40'
-            ci_tag: 'fedora-40'
 
     env:
       CI_TAG: '${{ matrix.ci_tag }}'

--- a/.github/workflows/try-release-daily.yml
+++ b/.github/workflows/try-release-daily.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master', 'fedora-40', 'rhel-9', 'rhel-10']
+        branch: ['master', 'rhel-9', 'rhel-10']
 
     steps:
       - name: Check out repo


### PR DESCRIPTION
Fedora 40 is GA now so we are going to focus on Fedora 41 instead.