### PR TITLE
infra: Fix anaconda-release container typo

### DIFF
--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -9,8 +9,7 @@ LABEL maintainer=anaconda-list@redhat.com
 # Add missing dependencies required to do the build.
 RUN set -e; \
   dnf update -y; \
-  dnf install -y \
-  git \
+  dnf install -y git; \
   dnf clean all;
 
 RUN pip3 install --no-cache-dir --upgrade pip; \


### PR DESCRIPTION
Typo was introduced with 7026487219002326153c27ea91d6abb65d45b645