### PR TITLE
infra: fix labeler workflow not working for non master branch

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -14,6 +14,11 @@ jobs:
   add-label:
     runs-on: ubuntu-20.04
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          repository: rhinstaller/anaconda
+
       - name: Add labels
         uses: actions/labeler@v5
         with:


### PR DESCRIPTION
Because of missing configuration file.

See: https://github.com/actions/labeler#using-configuration-path-input-together-with-the-actionscheckout-action

See example failure on rhel-10 branch: https://github.com/rhinstaller/anaconda/actions/runs/8778814812/job/24085865251?pr=5596
and suggestion: https://github.com/actions/labeler/issues/628