### PR TITLE
infra: Move labeler to version 5

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Add labels
-        uses: actions/labeler@v4
+        uses: actions/labeler@v5
         with:
           dot: true


### PR DESCRIPTION
We already have configuration files for labeler for version 5 thanks to the migrations from `master` branch. However, the workflow is not using it. Let's fix that thus fix broken PR checks.