### PR TITLE
infra: Use devel repos in ISO build container

### DIFF
--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -30,6 +30,11 @@ FROM ${image}
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
+# Add development repositories instead of the production ones
+# We need development repositories to get our dependencies sooner
+RUN rm -f /etc/yum.repos.d/*.repo
+COPY ["anaconda-centos.repo", "/etc/yum.repos.d/"]
+
 # Prepare environment and install build dependencies
 RUN set -ex; \
   dnf update -y; \

--- a/dockerfile/anaconda-iso-creator/anaconda-centos.repo
+++ b/dockerfile/anaconda-iso-creator/anaconda-centos.repo
@@ -1,0 +1,21 @@
+[baseos-development]
+name=CentOS Stream $releasever - BaseOS - development
+baseurl=https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/BaseOS/$basearch/os
+#metalink=https://mirrors.centos.org/metalink?repo=centos-baseos-$stream&arch=$basearch&protocol=https,http
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+gpgcheck=0
+repo_gpgcheck=0
+metadata_expire=6h
+countme=1
+enabled=1
+
+[appstream-development]
+name=CentOS Stream $releasever - AppStream - development
+baseurl=https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/AppStream/$basearch/os
+#metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-$stream&arch=$basearch&protocol=https,http
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+gpgcheck=0
+repo_gpgcheck=0
+metadata_expire=6h
+countme=1
+enabled=1


### PR DESCRIPTION
We need to get our dependencies fast so using production (default) repositories could be blocker for our workflows. Instead using a development repositories in our containers will enable us to be closer to the CentOS Stream "Rawhide" variant.

Ideally we want to do this change everywhere but right now let's fix this case as the most problematic one.

Replacement of https://github.com/rhinstaller/anaconda/pull/5612