### PR TITLE
infra: backported run tests.yml workflow on ubuntu runners also for rhel branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    runs-on: [self-hosted, kstest]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -11,11 +11,7 @@ concurrency:
 
 jobs:
   unit-tests:
-    {% if distro_name == "fedora" %}
-    runs-on: ubuntu-20.04
-    {% elif distro_name == "rhel" %}
-    runs-on: [self-hosted, kstest]
-    {% endif %}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/Makefile.am
+++ b/Makefile.am
@@ -85,7 +85,7 @@ CONTAINER_REGISTRY ?= quay.io
 # Add additional args to the existing ones to container engine
 CONTAINER_ADD_ARGS ?=
 # Glade was removed in RHEL from RHEL-10 -- let's put that as condition to container runs on CentOS or RHEL
-CONTAINER_CONFIGURE_ARGS ?= $(shell test $(GIT_BRANCH) == "rhel-10" && echo "--env=CONFIGURE_ARGS=--disable-glade")
+CONTAINER_CONFIGURE_ARGS ?= $(shell test "$(GIT_BRANCH)" = "rhel-10" && echo "--env=CONFIGURE_ARGS=--disable-glade")
 
 # anaconda-ci container
 CI_DOCKERFILE ?= $(srcdir)/dockerfile/anaconda-ci


### PR DESCRIPTION
backported: https://github.com/rhinstaller/anaconda/pull/5618