### PR TITLE
RHEL-10: Add ping to Dracut

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -331,6 +331,7 @@ Requires: dracut-network
 Requires: dracut-live
 Requires: xz
 Requires: python3-kickstart
+Requires: iputils
 
 %description dracut
 The 'anaconda' dracut module handles installer-specific boot tasks and

--- a/docs/release-notes/support-ping-in-dracut.rst
+++ b/docs/release-notes/support-ping-in-dracut.rst
@@ -1,0 +1,11 @@
+:Type: Dracut
+:Summary: Add ping command line tool to Anaconda Dracut image (RHEL-5719)
+
+:Description:
+    Sometimes boot of the installer ISO will fail because remote source can't be reached, if this
+    happens, it can be hard to debug because of the limited toolset inside the Dracut shell.
+    For these reasons, we are adding a ping command line tool which can help with debugging.
+
+:Links:
+    - https://issues.redhat.com/browse/RHEL-5719
+    - https://github.com/rhinstaller/anaconda/pull/5500

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -22,6 +22,8 @@ installkernel() {
 }
 
 install() {
+    # binaries for easier debugging (requested by https://issues.redhat.com/browse/RHEL-5719)
+    dracut_install ping
     # binaries we want in initramfs
     dracut_install eject -o pigz
     dracut_install depmod blkid


### PR DESCRIPTION
Add ping command into dracut for debugging.

Resolves: [RHEL-32760](https://issues.redhat.com/browse/RHEL-32760)

Backport of https://github.com/rhinstaller/anaconda/pull/5500