### PR TITLE
Stop pretending liveinst+vnc is supported (#678354)

### DIFF
--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -100,7 +100,7 @@ vnc
 Enable VNC-based installation. You will need to connect to the machine using a VNC client application.
 A VNC install implies that the installed system will boot up in runlevel 3 instead of to the graphical
 login screen. The VNC session will be shared. Consider setting a VNC password using the vncpassword
-option.
+option. This option is not supported for live installations.
 
 vncconnect
 Once installation is up and running, connect to the VNC client named HOST, and optionally use port PORT.

--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -116,6 +116,17 @@ for opt in $(cat /proc/cmdline) "$@"; do
          fi
          exit 1
         ;;
+    vnc|--vnc)
+        title="Configuration not supported"
+        text="VNC is not supported on live media."
+        if which zenity &> /dev/null; then
+            zenity --warning --title="$title" --text="$text"
+         else
+            echo "$title" >&2
+            echo "$text" >&2
+         fi
+         exit 1
+        ;;
     esac
 done
 


### PR DESCRIPTION
Anaconda runs as an app on Live images and can hardly control remote access there.

