### PR TITLE
Fix link on ci-status page

### DIFF
--- a/docs/ci-status.rst
+++ b/docs/ci-status.rst
@@ -56,8 +56,8 @@ Anaconda Web UI
 
 .. _Dependabot: https://github.com/rhinstaller/anaconda-webui/network/updates
 
-|container-autoupdate-fedora|
-  Fedora CI test container images, built daily. The containers are used in unit and rpm tests.
+|container-autoupdate|
+  Fedora and CentOS Stream CI test container images, built daily. The containers are used in unit and rpm tests.
 
 |container-autoupdate-eln|
   Same as above but for ELN. It is expected this can often fail.


### PR DESCRIPTION
The container autoupdate workflow was renamed so the link is broken now.

Another fix for https://github.com/rhinstaller/anaconda/pull/5630