### PR TITLE
Rhel 10 make libreport optional

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -88,7 +88,9 @@ Requires: python3-dnf >= %{dnfver}
 Requires: python3-blivet >= %{pythonblivetver}
 Requires: python3-blockdev >= %{libblockdevver}
 Requires: python3-meh >= %{mehver}
+%if 0%{?rhel} < 10 || 0%{?fedora}
 Requires: libreport-anaconda >= %{libreportanacondaver}
+%endif
 Requires: libselinux-python3
 Requires: python3-rpm >= %{rpmver}
 Requires: python3-pyparted >= %{pypartedver}


### PR DESCRIPTION
The first commit makes libreport optional. The second commit makes CI functional. ;-)

**TODO**

- [x] adjust UX for missing libreport (we should then port the changes to the upstream PR: #5610)
- [x] Lorax templates PR
- [x] corresponding python-meh package release