### PR TITLE
infra: Make consistent RHEL workflows as on Fedora

### DIFF
--- a/.github/workflows/tests-daily.yml
+++ b/.github/workflows/tests-daily.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['master']
+        release: ['master', 'rhel-9', 'rhel-10']
         include:
           - release: 'master'
             target_branch: 'master'
@@ -52,6 +52,12 @@ jobs:
           #  target_branch: 'master'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
+          - release: 'rhel-9'
+            target_branch: 'rhel-9'
+            ci_tag: 'rhel-9'
+          - release: 'rhel-10'
+            target_branch: 'rhel-10'
+            ci_tag: 'rhel-10'
 
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
@@ -84,11 +90,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['master']
+        release: ['master', 'rhel-9', 'rhel-10']
         include:
           - release: 'master'
             target_branch: 'master'
             ci_tag: 'master'
+          - release: 'rhel-9'
+            target_branch: 'rhel-9'
+            ci_tag: 'rhel-9'
+          - release: 'rhel-10'
+            target_branch: 'rhel-10'
+            ci_tag: 'rhel-10'
 
     env:
       CI_TAG: '${{ matrix.ci_tag }}'

--- a/.github/workflows/tests-daily.yml.j2
+++ b/.github/workflows/tests-daily.yml.j2
@@ -43,7 +43,7 @@ jobs:
         # * This is still a matrix because we might re-enable ELN one day and then we will need
         #   a matrix here.
         #}
-        release: ['master'{% for branch in supported_branches if branch.variant == "fedora" %}, '{$ branch|first $}'{% endfor %}]
+        release: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
         include:
           - release: 'master'
             target_branch: 'master'
@@ -53,7 +53,7 @@ jobs:
           #  target_branch: 'master'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
-        {% for branch in supported_branches if branch.variant == "fedora" %}
+        {% for branch in supported_branches %}
           - release: '{$ branch|first $}'
             target_branch: '{$ branch|first $}'
             ci_tag: '{$ branch|first $}'
@@ -91,12 +91,12 @@ jobs:
       fail-fast: false
       matrix:
         {# For matrix details, see comments for the unit tests above. #}
-        release: ['master'{% for branch in supported_branches if branch.variant == "fedora" %}, '{$ branch|first $}'{% endfor %}]
+        release: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
         include:
           - release: 'master'
             target_branch: 'master'
             ci_tag: 'master'
-        {% for branch in supported_branches if branch.variant == "fedora" %}
+        {% for branch in supported_branches %}
           - release: '{$ branch|first $}'
             target_branch: '{$ branch|first $}'
             ci_tag: '{$ branch|first $}'

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -68,7 +68,6 @@ jobs:
           git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
           git rebase ${{ env.TARGET_BRANCH_NAME }}
 
-      {% if distro_name == "fedora" %}
       - name: Check if rebuild of the container image is required
         id: check-dockerfile-changed
         run: |
@@ -81,10 +80,6 @@ jobs:
       - name: Build anaconda-ci container
         if: steps.check-dockerfile-changed.outputs.changed
         run: make -f Makefile.am anaconda-ci-build
-      {% elif distro_name == "rhel" %}
-      - name: Build anaconda-ci container
-        run: make -f Makefile.am anaconda-ci-build
-      {% endif %}
 
       - name: Run tests in anaconda-ci container
         run: |
@@ -104,11 +99,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   rpm-tests:
-    {% if distro_name == "fedora" %}
     runs-on: ubuntu-20.04
-    {% elif distro_name == "rhel" %}
-    runs-on: [self-hosted, kstest]
-    {% endif %}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -162,7 +153,6 @@ jobs:
           git log --oneline -1 ${{ env.TARGET_BRANCH_NAME }}
           git rebase ${{ env.TARGET_BRANCH_NAME }}
 
-      {% if distro_name == "fedora" %}
       - name: Check if container rebuild is needed
         id: need_rebuild
         run: |
@@ -187,10 +177,6 @@ jobs:
       - name: Build RPM test container
         if: ${{ steps.need_rebuild.outputs.rebuild == 'true' }}
         run: make -f Makefile.am anaconda-rpm-build
-      {% elif distro_name == "rhel" %}
-      - name: Build RPM test container
-        run: make -f Makefile.am anaconda-rpm-build
-      {% endif %}
 
       - name: Run RPM tests in container
         run: make -f Makefile.am container-rpm-test


### PR DESCRIPTION
Thanks to our recent changes to move rhel-9 and rhel-10 containers to CentOS Stream we are able to make workflows between master and RHEL more consistent.

The benefits of this approach:
- simplify templates
- better error proof templates
- do not require self-hosted runners to run rhel tests