### PR TITLE
infra: Migrate to DNF5 copr plugin install

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -33,7 +33,7 @@ COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 # Prepare environment and install build dependencies
 RUN set -ex; \
   dnf install -y \
-  'dnf-command(copr)'; \
+  'dnf5-command(copr)'; \
   # Enable COPR repositories
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     BRANCH="${git_branch}"; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
   dnf update -y; \
   # Install dependencies
   dnf install -y \
-  'dnf-command(copr)' \
+  'dnf5-command(copr)' \
   git \
   curl \
   python3-polib \


### PR DESCRIPTION
There was a switch to DNF5 on Rawhide (Fedora 41) so we need to adjust our containers.

This PR will block Dockerfile backport to `rhel-9` and `rhel-10` branches but I think these don't have to be consistent across branches.