### PR TITLE
infra: trigger-webui: Migrate to DNF5 copr plugin install

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -39,9 +39,9 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y git-core dnf-plugins-core || {
+          dnf install -y git-core 'dnf5-command(copr)' || {
             sleep 60
-            dnf install -y git-core dnf-plugins-core
+            dnf install -y git-core 'dnf5-command(copr)'
           }
 
       # Naively this should wait for github.event.pull_request.head.sha, but

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -33,9 +33,9 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y git-core dnf-plugins-core || {
+          dnf install -y git-core 'dnf5-command(copr)' || {
             sleep 60
-            dnf install -y git-core dnf-plugins-core
+            dnf install -y git-core 'dnf5-command(copr)'
           }
 
       # Naively this should wait for github.event.pull_request.head.sha, but


### PR DESCRIPTION
Fixes: https://github.com/rhinstaller/anaconda/actions/runs/9153819274/job/25163393418?pr=5653