### PR TITLE
infra: move to Fedora 40 container image

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -32,16 +32,16 @@ jobs:
     runs-on: ubuntu-22.04
     # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
     environment: gh-cockpituous
-    container: registry.fedoraproject.org/fedora:rawhide
+    container: registry.fedoraproject.org/fedora:40
     # this polls for a COPR build, which can take long
     timeout-minutes: 120
 
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y git-core 'dnf5-command(copr)' || {
+          dnf install -y git-core 'dnf-plugins-core' || {
             sleep 60
-            dnf install -y git-core 'dnf5-command(copr)'
+            dnf install -y git-core 'dnf-plugins-core'
           }
 
       # Naively this should wait for github.event.pull_request.head.sha, but

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-22.04
     # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
     environment: gh-cockpituous
-    container: registry.fedoraproject.org/fedora:rawhide
+    container: registry.fedoraproject.org/fedora:40
     # this polls for a COPR build, which can take long
     timeout-minutes: 120
 
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y git-core 'dnf5-command(copr)' || {
+          dnf install -y git-core 'dnf-plugins-core' || {
             sleep 60
-            dnf install -y git-core 'dnf5-command(copr)'
+            dnf install -y git-core 'dnf-plugins-core'
           }
 
       # Naively this should wait for github.event.pull_request.head.sha, but


### PR DESCRIPTION
The rawhide started giving the following error:
/usr/bin/env: 'python3': No such file or directory

See https://github.com/cockpit-project/cockpit/pull/20478

