### PR TITLE
NOT READY: infra: make labeler workflow look only into master branch config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,8 +8,20 @@
 # File to automatically label pull requests
 # See https://github.com/actions/labeler
 
-# Always apply target fedora version to any changes
-f41:
+rawhide:
+- base-branch: master
+- any:
+  - changed-files:
+    - any-glob-to-any-file: ['**']
+
+rhel-9:
+- base-branch: rhel-9
+- any:
+  - changed-files:
+    - any-glob-to-any-file: ['**']
+
+rhel-10:
+- base-branch: rhel-10
 - any:
   - changed-files:
     - any-glob-to-any-file: ['**']

--- a/.github/labeler.yml.j2
+++ b/.github/labeler.yml.j2
@@ -1,17 +1,19 @@
 # File to automatically label pull requests
 # See https://github.com/actions/labeler
 
-# Always apply target fedora version to any changes
-{% if distro_name == "fedora" and distro_release == "rawhide" %}
-f{$ rawhide_fedora_version $}:
-{% elif distro_name == "fedora" %}
-f{$ distro_release $}:
-{% elif distro_name == "rhel" %}
-rhel-{$ distro_release $}:
-{% endif %}
+rawhide:
+- base-branch: master
 - any:
   - changed-files:
     - any-glob-to-any-file: ['**']
+{% for branch in supported_branches %}
+
+{$ branch|first $}:
+- base-branch: {$ branch|first $}
+- any:
+  - changed-files:
+    - any-glob-to-any-file: ['**']
+{% endfor %}
 
 documentation:
 - any:


### PR DESCRIPTION
This way do not need to manually update this workflow when new branches appear, or when the action version bumps,
as it autogenerates the labels from the supported_branches file.

