### PR TITLE
gui: fix setting timezone from locale in the Welcome spoke

### DIFF
--- a/pyanaconda/ui/gui/spokes/welcome.py
+++ b/pyanaconda/ui/gui/spokes/welcome.py
@@ -312,4 +312,9 @@ class WelcomeLanguageSpoke(StandaloneSpoke, LangLocaleHandler):
 
     def _try_set_timezone(self, locale):
         loc_timezones = localization.get_locale_timezones(locale)
+
+        # Some locales like 'Esperanto' don't have a timezone
+        if len(loc_timezones) == 0:
+            return
+
         self._tz_module.SetTimezoneWithPriority(loc_timezones[0], TIMEZONE_PRIORITY_LANGUAGE)


### PR DESCRIPTION
Not all locales have a timezone, ex Esperanto.

Resolves: rhbz#2283050

