### PR TITLE
Change location of rescue mode flag file

### DIFF
--- a/data/post-scripts/80-setfilecons.ks
+++ b/data/post-scripts/80-setfilecons.ks
@@ -8,7 +8,7 @@
 #   responsibility (see https://github.com/ostreedev/ostree/pull/872 )
 # - OSTree variants of the traditional mounts if present
 
-RESCUE_MODE=/tmp/RESCUE_MODE
+RESCUE_MODE=/run/install/RESCUE_MODE
 
 # Do not automatically modify files on the system being rescued.
 if [ -e ${RESCUE_MODE} ]; then

--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -7,7 +7,7 @@ NOSAVE_INPUT_KS_FILE=/tmp/NOSAVE_INPUT_KS
 NOSAVE_LOGS_FILE=/tmp/NOSAVE_LOGS
 PRE_ANA_LOGS=/tmp/pre-anaconda-logs
 DNF_DEBUG_LOGS=/root/debugdata
-RESCUE_MODE=/tmp/RESCUE_MODE
+RESCUE_MODE=/run/install/RESCUE_MODE
 
 # Do not copy log files from the rescue environment to the system being rescued to avoid
 # rewriting logs from the original installation of the system.

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -540,4 +540,4 @@ TIMEZONE_PRIORITY_KICKSTART = 70
 TIMEZONE_PRIORITY_USER = 90
 
 # A flag file indicated the installation is running in rescue mode
-RESCUE_MODE_PATH = "/tmp/RESCUE_MODE"
+RESCUE_MODE_PATH = "/run/install/RESCUE_MODE"


### PR DESCRIPTION
The file indicating that the installer is running is rescue mode needs to be accessible for `%post` scripts running in nochroot as well as in chroot. Create the file in `/run/install/`, so that both `80-setfilecons.ks` and `99-copy-logs.ks` work correctly.

Resolves: RHEL-4794

This is a correction of https://github.com/rhinstaller/anaconda/pull/5640