### PR TITLE
infra: Drop libxklavier from packit dependencies

### DIFF
--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -13,7 +13,11 @@ srpm_build_deps:
   - python3-polib
   - gobject-introspection-devel
   - glade-devel
+{% if distro_name == "fedora" %}
   - libxklavier-devel
+{% elif distro_name == "rhel" and distro_release < 10 %}
+  - libxklavier-devel
+{% endif %}
   - libarchive-devel
   - rpm-devel
   - nss_wrapper


### PR DESCRIPTION
Once we merge the Wayland PRs on RHEL 10, we can drop the libxklavier dependency from our Packit config.