### PR TITLE
Remove 'linear' from list of expected MD RAID levels

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -34,7 +34,7 @@ if [ "$ARCH" = "ppc" ]; then
     MODULE_LIST+=" spufs "
 fi
 
-MODULE_LIST+=" raid0 raid1 raid5 raid6 raid456 raid10 linear dm-mod dm-zero  \
+MODULE_LIST+=" raid0 raid1 raid5 raid6 raid456 raid10 dm-mod dm-zero  \
               dm-mirror dm-snapshot dm-multipath dm-round-robin dm-crypt cbc \
               sha256 lrw xts "
 


### PR DESCRIPTION
RHEL 10 version of #5672