### PR TITLE
po: Don't try to delete extra.pot

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -110,7 +110,7 @@ dist-hook:
 
 pot:
 	$(MAKE) -C po $(PACKAGE_NAME).pot-update
-	rm $(srcdir)/po/{main,extra}.pot
+	rm $(srcdir)/po/main.pot
 
 pot-update-check: pot
 # This check is used by github action for auto update of pot file


### PR DESCRIPTION
It is no longer generated since 919be1d50949d6a18e25a5a2c7df965c23ea1c33 which is PR #5044.

(cherry picked from commit a3916dc6df49ae0f6304acee8860d857270664cf)

Fixing current automatic pot file updates:
https://github.com/rhinstaller/anaconda-l10n/actions/runs/9359503155/job/25763320616