### PR TITLE
infra: Always store logs of action Live ISO build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -261,7 +261,6 @@ jobs:
           mkdir -p images
           make -f Makefile.am container-live-iso-build CI_TAG=$CONTAINER_TAG
           mv result/iso/Fedora-Workstation.iso "images/${{ needs.pr-info.outputs.image_description }}-Fedora-Workstation.iso"
-          mv result/iso/logs images/
 
       - name: Make artefacts created by sudo cleanable
         if: always()
@@ -273,8 +272,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'logs'
-          path: |
-           images/logs/*
+          path: result/iso/logs/*
 
       - name: Upload image artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-image.yml.j2
+++ b/.github/workflows/build-image.yml.j2
@@ -255,7 +255,6 @@ jobs:
           mkdir -p images
           make -f Makefile.am container-live-iso-build CI_TAG=$CONTAINER_TAG
           mv result/iso/Fedora-Workstation.iso "images/${{ needs.pr-info.outputs.image_description }}-Fedora-Workstation.iso"
-          mv result/iso/logs images/
 
       - name: Make artefacts created by sudo cleanable
         if: always()
@@ -267,8 +266,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'logs'
-          path: |
-           images/logs/*
+          path: result/iso/logs/*
 
       - name: Upload image artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Currently, it seems that if Makefile command to build Live ISO fails it will stop execution of the next mv commands. Let's not move logs and instead store them where they are created so we always collect them in the next task.

Tested and artifacts are collected this way:
https://github.com/jkonecny12/anaconda/actions/runs/9381340656 