### PR TITLE
infra: Do not propose-downstream by Packit service

### DIFF
--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -97,6 +97,8 @@ jobs:
 
   - job: propose_downstream
     trigger: release
+    # Tarballs are not uploaded to GitLab PR on CentOS (https://github.com/packit/packit-service/issues/2436)
+    manual_trigger: True
     packages: [anaconda-centos]
     dist_git_branches: c{$ distro_release $}s
 


### PR DESCRIPTION
Packit service is unfortunately not yet able to upload tarballs which makes it less beneficial. We decided to use packit CLI for this so disable manual triggering of this job.

(cherry picked from commit 4a78dc77ad48885ad0204c6774973571d48871ef)