### PR TITLE
Fix broken locale support in console check

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -106,7 +106,11 @@ def locale_supported_in_console(locale):
     :raise InvalidLocaleSpec: if an invalid locale is given (see is_valid_langcode)
     """
     locale_scripts = get_locale_scripts(locale)
-    return set(locale_scripts).issubset(SCRIPTS_SUPPORTED_BY_CONSOLE)
+
+    if not locale_scripts:
+        return False
+
+    return locale_scripts[0] in SCRIPTS_SUPPORTED_BY_CONSOLE
 
 
 def find_best_locale_match(locale, langcodes):

--- a/tests/unit_tests/pyanaconda_tests/test_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/test_localization.py
@@ -62,6 +62,10 @@ class LangcodeLocaleParsingTests(unittest.TestCase):
         assert localization.locale_supported_in_console("en")
         assert localization.locale_supported_in_console("en_US")
 
+        with patch("pyanaconda.localization.get_locale_scripts") as locale_scripts_mock:
+            locale_scripts_mock.return_value = []
+            assert localization.locale_supported_in_console("en") is False
+
     def test_native_name(self):
         assert localization.get_native_name("de") == "Deutsch"
         assert localization.get_native_name("cs_CZ") == "Čeština (Česko)"


### PR DESCRIPTION
New langtable-0.0.67-2 version introduced new scripts for some languages. That broke our tests because our code is expecting to have all the scripts supported by the console for the given locale.

Based on the discussion with Mike Fabian who is maintainer of langtable we come to conclusion that we should check only for the first script for the given locale because it's the most significant one.

This should fix our broken tests and mainly the code. https://github.com/rhinstaller/anaconda/actions/runs/9574624471

*Suggested-by: mike-fabian*