### PR TITLE
Add runtime deps to install_dependencies.sh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Check if rebuild of the container image is required
         id: check-dockerfile-changed
         run: |
-          changes=$(git diff $TARGET_BRANCH_NAME..HEAD -- dockerfile/anaconda-ci/ anaconda.spec.in scripts/testing/install_dependencies.sh)
+          changes=$(git diff $TARGET_BRANCH_NAME..HEAD -- dockerfile/anaconda-ci/ anaconda.spec.in)
           # print for debugging
           echo "$changes"
           [ -z "$changes" ] || echo "changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -71,7 +71,7 @@ jobs:
       - name: Check if rebuild of the container image is required
         id: check-dockerfile-changed
         run: |
-          changes=$(git diff $TARGET_BRANCH_NAME..HEAD -- dockerfile/anaconda-ci/ anaconda.spec.in scripts/testing/install_dependencies.sh)
+          changes=$(git diff $TARGET_BRANCH_NAME..HEAD -- dockerfile/anaconda-ci/ anaconda.spec.in)
           # print for debugging
           echo "$changes"
           [ -z "$changes" ] || echo "changed=true" >> $GITHUB_OUTPUT

--- a/scripts/testing/install_dependencies.sh
+++ b/scripts/testing/install_dependencies.sh
@@ -39,9 +39,13 @@ sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' ./
 # get all build requires dependencies from the spec file and strip out version
 # version could be problematic because of fedora version you are running and
 # they are mostly not important for automake
-deps=$(rpmspec -q --buildrequires $TEMP | sed 's/>=.*$//')
+build_deps=$(rpmspec -q --buildrequires $TEMP | sed 's/>=.*$//')
+# add also runtime dependencies for the local development
+# remove anaconda packages and also '(glibc-langpack-en or glibc-all-langpacks)' which will fail otherwise
+requires_deps=$(rpmspec -q --requires $TEMP | grep -v -E "(anaconda-|-widgets| or )" | sed 's/>=.*$//')
+
 # shellcheck disable=SC2068
-dnf install $@ $deps  # do NOT quote the list or it falls apart
+dnf install $@ $build_deps $requires_deps  # do NOT quote the list or it falls apart
 
 # clean up the temp file
 rm $TEMP


### PR DESCRIPTION
This script is to prepare development environment. For that reason the runtime dependencies might be handy.