### PR TITLE
Remove deprecated warnings for inst prefix

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -114,16 +114,14 @@ def parse_arguments(argv=None, boot_cmdline=None):
 
     :param argv: command like arguments
     :param boot_cmdline: boot options
-    :returns: namespace of parsed options and a list of deprecated
-              anaconda options that have been found
+    :returns: namespace of parsed options.
     """
     from pyanaconda.argument_parsing import getArgumentParser
     from pyanaconda.core.util import get_anaconda_version_string
 
     ap = getArgumentParser(get_anaconda_version_string(), boot_cmdline)
 
-    namespace = ap.parse_args(argv, boot_cmdline=boot_cmdline)
-    return (namespace, ap.removed_no_inst_bootargs)
+    return ap.parse_args(argv, boot_cmdline=boot_cmdline)
 
 
 def setup_environment():
@@ -204,7 +202,7 @@ if __name__ == "__main__":
     # do this early so we can set flags before initializing logging
     from pyanaconda.flags import flags
     from pyanaconda.core.kernel import kernel_arguments
-    (opts, removed_no_inst_args) = parse_arguments(boot_cmdline=kernel_arguments)
+    opts = parse_arguments(boot_cmdline=kernel_arguments)
 
     from pyanaconda.core.configuration.anaconda import conf
     conf.set_from_opts(opts)
@@ -243,15 +241,6 @@ if __name__ == "__main__":
 
     if opts.updates_url:
         log.info("Using updates from: %s", opts.updates_url)
-
-    # warn users that they should use inst. prefix all the time
-    for arg in removed_no_inst_args:
-        stdout_log.warning("Kernel boot argument '%s' detected. "
-                           "Did you want to use 'inst.%s' for the installer instead?",
-                           arg, arg)
-    if removed_no_inst_args:
-        stdout_log.warning("All Anaconda kernel boot arguments are now required to use "
-                           "'inst.' prefix!")
 
     # print errors encountered during boot
     startup_utils.print_dracut_errors(stdout_log)

--- a/docs/release-notes/remove-deprecated-warnings-for-inst-prefix.rst
+++ b/docs/release-notes/remove-deprecated-warnings-for-inst-prefix.rst
@@ -1,0 +1,12 @@
+:Type: Core
+:Summary: Remove deprecation warnings for kernel boot options without prefix
+
+:Description:
+    Removing the deprecation warnings for kernel boot options without ``inst.``
+    prefix. This was left for a couple of releases to advise users to switch
+    their options to use ``inst.*`` instead. We are now removing them to not
+    warn as it should be always used ``inst.`` as prefix.
+
+:Links:
+    - https://issues.redhat.com/browse/INSTALLER-2363
+    - https://github.com/rhinstaller/anaconda/pull/5723/

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -59,15 +59,6 @@ check_removed_arg() {
     fi
 }
 
-check_removed_no_inst_arg() {
-    local removed_arg="$1" new_arg="$2"
-    check_removed_arg "$removed_arg" "All usage of Anaconda boot arguments without 'inst.' prefix \
-was removed. Please use $new_arg instead."
-}
-
-# ssh
-check_removed_no_inst_arg "sshd" "inst.sshd"
-
 # serial was never supposed to be used for anything!
 check_removed_arg serial "To change the console use 'console=' instead."
 # USB is built-in and can't be disabled anymore. DEAL WITH IT.
@@ -80,21 +71,8 @@ check_removed_arg ethtool
 check_removed_arg askmethod "Use an appropriate 'inst.repo=' argument instead."
 check_removed_arg asknetwork "Use an appropriate 'ip=' argument instead."
 
-# lang & keymap
-check_removed_no_inst_arg "lang" "inst.lang"
-check_removed_no_inst_arg "keymap" "inst.keymap"
-
 # repo
 check_depr_arg "method=" "repo=%s"
-check_removed_no_inst_arg "repo" "inst.repo"
-
-# stage2
-check_removed_no_inst_arg "stage2" "inst.stage2"
-
-# kickstart
-check_removed_no_inst_arg "ks" "inst.ks"
-check_removed_no_inst_arg "kssendmac" "inst.ks.sendmac"
-check_removed_no_inst_arg "kssendsn" "inst.ks.sendsn"
 
 # mpath
 check_removed_arg "inst.nompath"
@@ -104,7 +82,6 @@ check_removed_arg "inst.dmraid"
 check_removed_arg "inst.nodmraid"
 
 # Ignore self-signed SSL certs
-check_removed_no_inst_arg "noverifyssl" "inst.noverifyssl"
 if getargbool 0 inst.noverifyssl; then
     # Tell dracut to use curl --insecure
     echo "rd.noverifyssl" >> /etc/cmdline.d/75-anaconda-options.conf
@@ -116,7 +93,6 @@ if proxy=$(getarg inst.proxy); then
 fi
 
 # updates
-check_removed_no_inst_arg "updates" "inst.updates"
 if updates=$(getarg inst.updates); then
     if [ -n "$updates" ]; then
         export anac_updates=$updates
@@ -131,11 +107,7 @@ if updates=$(getarg inst.updates); then
 fi
 
 # for vnc bring network up in initramfs so that cmdline configuration is used
-check_removed_no_inst_arg "vnc" "inst.vnc"
 getargbool 0 inst.vnc && warn "anaconda requiring network for vnc" && set_neednet
-
-# Driver Update Disk
-check_removed_no_inst_arg "dd" "inst.dd"
 
 # re-read the commandline args
 unset CMDLINE

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -94,7 +94,6 @@ class AnacondaArgumentParser(ArgumentParser):
         """
         help_width = get_help_width()
         self._boot_arg = dict()
-        self.removed_no_inst_bootargs = []
         self.bootarg_prefix = kwargs.pop("bootarg_prefix", "")
         self.require_prefix = kwargs.pop("require_prefix", True)
 
@@ -158,10 +157,6 @@ class AnacondaArgumentParser(ArgumentParser):
 
         option = self._boot_arg.get(arg)
 
-        if option and self.bootarg_prefix and not prefixed_option:
-            if arg not in self._require_prefix_ignore_list:
-                self.removed_no_inst_bootargs.append(arg)
-
         # From Fedora 34 this prefix is required. However, leave the code here for some time to
         # tell users that we are ignoring the old variants.
         if self.require_prefix and not prefixed_option:
@@ -200,7 +195,6 @@ class AnacondaArgumentParser(ArgumentParser):
         else:
             bootargs = boot_cmdline
 
-        self.removed_no_inst_bootargs = []
         # go over all options corresponding to current boot cmdline
         # and do any modifications necessary
         # NOTE: program cmdline overrides boot cmdline

--- a/tests/unit_tests/pyanaconda_tests/test_argparse.py
+++ b/tests/unit_tests/pyanaconda_tests/test_argparse.py
@@ -28,67 +28,61 @@ import unittest
 class ArgparseTest(unittest.TestCase):
     def _parseCmdline(self, argv=None, boot_cmdline=None):
         ap = argument_parsing.getArgumentParser("", boot_cmdline)
-        opts = ap.parse_args(argv, boot_cmdline=boot_cmdline)
-        return (opts, ap.removed_no_inst_bootargs)
+        return ap.parse_args(argv, boot_cmdline=boot_cmdline)
 
     def test_without_inst_prefix(self):
         boot_cmdline = KernelArguments.from_string("stage2=http://cool.server.com/test")
-        opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
         assert opts.stage2 is None
-        assert removed == ["stage2"]
 
         boot_cmdline = KernelArguments.from_string("stage2=http://cool.server.com/test "
                                                    "vnc")
-        opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
         assert opts.stage2 is None
         assert not opts.vnc
-        assert removed == ["stage2", "vnc"]
 
     def test_with_inst_prefix(self):
         boot_cmdline = KernelArguments.from_string("inst.stage2=http://cool.server.com/test")
-        opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
         assert opts.stage2 == "http://cool.server.com/test"
-        assert removed == []
 
         boot_cmdline = KernelArguments.from_string("inst.stage2=http://cool.server.com/test "
                                                    "inst.vnc")
-        opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
         assert opts.stage2 == "http://cool.server.com/test"
         assert opts.vnc
-        assert removed == []
 
     def test_inst_prefix_mixed(self):
         boot_cmdline = KernelArguments.from_string("inst.stage2=http://cool.server.com/test "
                                                    "vnc")
-        opts, removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
         assert opts.stage2 == "http://cool.server.com/test"
         assert not opts.vnc
-        assert removed == ["vnc"]
 
     def test_display_mode(self):
-        opts, _removed = self._parseCmdline(['--cmdline'])
+        opts = self._parseCmdline(['--cmdline'])
         assert opts.display_mode == DisplayModes.TUI
         assert opts.noninteractive
 
-        opts, _removed = self._parseCmdline(['--graphical'])
+        opts = self._parseCmdline(['--graphical'])
         assert opts.display_mode == DisplayModes.GUI
         assert not opts.noninteractive
 
-        opts, _removed = self._parseCmdline(['--text'])
+        opts = self._parseCmdline(['--text'])
         assert opts.display_mode == DisplayModes.TUI
         assert not opts.noninteractive
 
-        opts, _removed = self._parseCmdline(['--noninteractive'])
+        opts = self._parseCmdline(['--noninteractive'])
         assert opts.noninteractive
 
         # Test the default
-        opts, _removed = self._parseCmdline([])
+        opts = self._parseCmdline([])
         assert opts.display_mode == DisplayModes.GUI
         assert not opts.noninteractive
 
         # console=whatever in the boot args defaults to --text
         boot_cmdline = KernelArguments.from_string("console=/dev/ttyS0")
-        opts, _removed = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
         assert opts.display_mode == DisplayModes.TUI
 
     def test_selinux(self):
@@ -96,43 +90,43 @@ class ArgparseTest(unittest.TestCase):
         from pyanaconda.core.constants import SELINUX_DEFAULT
 
         # with no arguments, use SELINUX_DEFAULT
-        opts, _removed = self._parseCmdline([])
+        opts = self._parseCmdline([])
         assert opts.selinux == SELINUX_DEFAULT
 
         # --selinux or --selinux=1 means SELINUX_ENFORCING
-        opts, _removed = self._parseCmdline(['--selinux'])
+        opts = self._parseCmdline(['--selinux'])
         assert opts.selinux == SELINUX_ENFORCING
 
         # --selinux=0 means SELINUX_DISABLED
-        opts, _removed = self._parseCmdline(['--selinux=0'])
+        opts = self._parseCmdline(['--selinux=0'])
         assert opts.selinux == SELINUX_DISABLED
 
         # --noselinux means SELINUX_DISABLED
-        opts, _removed = self._parseCmdline(['--noselinux'])
+        opts = self._parseCmdline(['--noselinux'])
         assert opts.selinux == SELINUX_DISABLED
 
     def test_dirinstall(self):
         # when not specified, dirinstall should evaluate to False
-        opts, _removed = self._parseCmdline([])
+        opts = self._parseCmdline([])
         assert not opts.dirinstall
 
         # with no argument, dirinstall should default to /mnt/sysimage
-        opts, _removed = self._parseCmdline(['--dirinstall'])
+        opts = self._parseCmdline(['--dirinstall'])
         assert opts.dirinstall == "/mnt/sysimage"
 
         # with an argument, dirinstall should use that
-        opts, _removed = self._parseCmdline(['--dirinstall=/what/ever'])
+        opts = self._parseCmdline(['--dirinstall=/what/ever'])
         assert opts.dirinstall == "/what/ever"
 
     def test_storage(self):
         conf = AnacondaConfiguration.from_defaults()
 
-        opts, _removed = self._parseCmdline([])
+        opts = self._parseCmdline([])
         conf.set_from_opts(opts)
 
         assert conf.storage.ibft is True
 
-        opts, _removed = self._parseCmdline(['--ibft'])
+        opts = self._parseCmdline(['--ibft'])
         conf.set_from_opts(opts)
 
         assert conf.storage.ibft is True
@@ -140,7 +134,7 @@ class ArgparseTest(unittest.TestCase):
     def test_target(self):
         conf = AnacondaConfiguration.from_defaults()
 
-        opts, _removed = self._parseCmdline([])
+        opts = self._parseCmdline([])
         conf.set_from_opts(opts)
 
         assert conf.target.is_hardware is True
@@ -148,7 +142,7 @@ class ArgparseTest(unittest.TestCase):
         assert conf.target.is_directory is False
         assert conf.target.physical_root == "/mnt/sysimage"
 
-        opts, _removed = self._parseCmdline(['--image=/what/ever.img'])
+        opts = self._parseCmdline(['--image=/what/ever.img'])
         conf.set_from_opts(opts)
 
         assert conf.target.is_hardware is False
@@ -156,7 +150,7 @@ class ArgparseTest(unittest.TestCase):
         assert conf.target.is_directory is False
         assert conf.target.physical_root == "/mnt/sysimage"
 
-        opts, _removed = self._parseCmdline(['--dirinstall=/what/ever'])
+        opts = self._parseCmdline(['--dirinstall=/what/ever'])
         conf.set_from_opts(opts)
 
         assert conf.target.is_hardware is False
@@ -166,7 +160,7 @@ class ArgparseTest(unittest.TestCase):
 
     def test_target_nosave(self):
         conf = AnacondaConfiguration.from_defaults()
-        opts, _removed = self._parseCmdline([])
+        opts = self._parseCmdline([])
         conf.set_from_opts(opts)
 
         assert conf.target.can_copy_input_kickstart is True
@@ -174,7 +168,7 @@ class ArgparseTest(unittest.TestCase):
         assert conf.target.can_save_output_kickstart is True
 
         conf = AnacondaConfiguration.from_defaults()
-        opts, _removed = self._parseCmdline(['--nosave=all'])
+        opts = self._parseCmdline(['--nosave=all'])
         conf.set_from_opts(opts)
 
         assert conf.target.can_copy_input_kickstart is False
@@ -182,7 +176,7 @@ class ArgparseTest(unittest.TestCase):
         assert conf.target.can_save_output_kickstart is False
 
         conf = AnacondaConfiguration.from_defaults()
-        opts, _removed = self._parseCmdline(['--nosave=all_ks'])
+        opts = self._parseCmdline(['--nosave=all_ks'])
         conf.set_from_opts(opts)
 
         assert conf.target.can_copy_input_kickstart is False
@@ -190,7 +184,7 @@ class ArgparseTest(unittest.TestCase):
         assert conf.target.can_save_output_kickstart is False
 
         conf = AnacondaConfiguration.from_defaults()
-        opts, _removed = self._parseCmdline(['--nosave=logs'])
+        opts = self._parseCmdline(['--nosave=logs'])
         conf.set_from_opts(opts)
 
         assert conf.target.can_copy_input_kickstart is True
@@ -198,7 +192,7 @@ class ArgparseTest(unittest.TestCase):
         assert conf.target.can_save_output_kickstart is True
 
         conf = AnacondaConfiguration.from_defaults()
-        opts, _removed = self._parseCmdline(['--nosave=input_ks'])
+        opts = self._parseCmdline(['--nosave=input_ks'])
         conf.set_from_opts(opts)
 
         assert conf.target.can_copy_input_kickstart is False
@@ -206,7 +200,7 @@ class ArgparseTest(unittest.TestCase):
         assert conf.target.can_save_output_kickstart is True
 
         conf = AnacondaConfiguration.from_defaults()
-        opts, _removed = self._parseCmdline(['--nosave=output_ks'])
+        opts = self._parseCmdline(['--nosave=output_ks'])
         conf.set_from_opts(opts)
 
         assert conf.target.can_copy_input_kickstart is True
@@ -216,28 +210,28 @@ class ArgparseTest(unittest.TestCase):
     def test_system(self):
         conf = AnacondaConfiguration.from_defaults()
 
-        opts, _removed = self._parseCmdline([])
+        opts = self._parseCmdline([])
         conf.set_from_opts(opts)
 
         assert conf.system._is_boot_iso is True
         assert conf.system._is_live_os is False
         assert conf.system._is_unknown is False
 
-        opts, _removed = self._parseCmdline(['--liveinst'])
+        opts = self._parseCmdline(['--liveinst'])
         conf.set_from_opts(opts)
 
         assert conf.system._is_boot_iso is False
         assert conf.system._is_live_os is True
         assert conf.system._is_unknown is False
 
-        opts, _removed = self._parseCmdline(['--dirinstall=/what/ever'])
+        opts = self._parseCmdline(['--dirinstall=/what/ever'])
         conf.set_from_opts(opts)
 
         assert conf.system._is_boot_iso is False
         assert conf.system._is_live_os is False
         assert conf.system._is_unknown is True
 
-        opts, _removed = self._parseCmdline(['--image=/what/ever.img'])
+        opts = self._parseCmdline(['--image=/what/ever.img'])
         conf.set_from_opts(opts)
 
         assert conf.system._is_boot_iso is False
@@ -253,14 +247,14 @@ class ArgparseTest(unittest.TestCase):
             self._parseCmdline(["--addrepo=http://url/1"])
 
         # Test cmdline options.
-        opts, _removed = self._parseCmdline([
+        opts = self._parseCmdline([
             "--addrepo=r1,http://url/1"
         ])
         assert opts.addRepo == [
             ("r1", "http://url/1")
         ]
 
-        opts, _removed = self._parseCmdline([
+        opts = self._parseCmdline([
             "--addrepo=r1,http://url/1",
             "--addrepo=r2,http://url/2",
             "--addrepo=r3,http://url/3",
@@ -294,7 +288,7 @@ class ArgparseTest(unittest.TestCase):
         boot_cmdline = KernelArguments.from_string(
             "inst.addrepo=r1,http://url/1"
         )
-        opts, _removed = self._parseCmdline([], boot_cmdline)
+        opts = self._parseCmdline([], boot_cmdline)
         assert opts.addRepo == [
             ("r1", "http://url/1")
         ]
@@ -304,7 +298,7 @@ class ArgparseTest(unittest.TestCase):
             "inst.addrepo=r2,http://url/2 "
             "inst.addrepo=r3,http://url/3 "
         )
-        opts, _removed = self._parseCmdline([], boot_cmdline)
+        opts = self._parseCmdline([], boot_cmdline)
         assert opts.addRepo == [
             ("r1", "http://url/1"),
             ("r2", "http://url/2"),


### PR DESCRIPTION
There were a couple of places were warnings were left behind to warn the users that using `inst.` was now required for some boot options. This patch removes the warnings as it is mandatory to have the prefix for those options.
