### PR TITLE
Fix starting anaconda on z/VM and LPAR s390x

### DIFF
--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -254,7 +254,7 @@ def prompt_for_ssh(options):
     if options.ksfile:
         return False
 
-    if options.rdp:
+    if options.rdp_enabled:
         return False
 
     # Do some work here to get the ip addr / hostname to pass


### PR DESCRIPTION
The Wayland/RDP support broke the installer running on s390x z/VM and LPAR.

Resolves: RHEL-45516