### PR TITLE
infra: use development repos in the release container

### DIFF
--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -7,11 +7,10 @@ ARG image
 FROM ${image}
 LABEL maintainer=anaconda-list@redhat.com
 
-# Enable CRB repository
-RUN set -ex; \
-  dnf install -y dnf-plugins-core; \
-  dnf config-manager --enable crb; \
-  dnf remove -y dnf-plugins-core
+# Add development repositories instead of the production ones
+# We need development repositories to get our dependencies sooner
+RUN rm -f /etc/yum.repos.d/*.repo
+COPY ["anaconda-centos.repo", "/etc/yum.repos.d/"]
 
 # Add missing dependencies required to do the build.
 RUN set -e; \

--- a/dockerfile/anaconda-release/anaconda-centos.repo
+++ b/dockerfile/anaconda-release/anaconda-centos.repo
@@ -1,0 +1,29 @@
+[baseos-development]
+name=CentOS Stream $releasever - BaseOS - development
+baseurl=https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/BaseOS/$basearch/os
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+gpgcheck=0
+repo_gpgcheck=0
+metadata_expire=6h
+countme=1
+enabled=1
+
+[appstream-development]
+name=CentOS Stream $releasever - AppStream - development
+baseurl=https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/AppStream/$basearch/os
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+gpgcheck=0
+repo_gpgcheck=0
+metadata_expire=6h
+countme=1
+enabled=1
+
+[crb-development]
+name=CentOS Stream $releasever - CRB - development
+baseurl=https://composes.stream.centos.org/stream-10/development/latest-CentOS-Stream/compose/CRB/$basearch/os
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+gpgcheck=0
+repo_gpgcheck=0
+metadata_expire=6h
+countme=1
+enabled=1


### PR DESCRIPTION
Follow up of 804c18d352a.

This fixes the broken release workflow:
https://github.com/rhinstaller/anaconda/actions/runs/9779722693