### PR TITLE
network: Avoid creating link files for 'nbft' interfaces

### DIFF
--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -186,6 +186,9 @@ Name={}
 
         for ifname_value in ifname_option_values:
             iface, mac = ifname_value.split(":", 1)
+            # Avoid link files for 'nbft' interfaces as it breaks Boot from NVM over TCP
+            if iface.startswith('nbft'):
+                continue
             content = self.INTERFACE_RENAME_FILE_CONTENT_TEMPLATE.format(mac, iface)
             config_file = self.INTERFACE_RENAME_FILE_TEMPLATE.format(iface)
             config_file_path = join_paths(self.SYSTEMD_NETWORK_CONFIG_DIR, config_file)


### PR DESCRIPTION
The dracut networking and the 95nvmf module are using ifname= kernel commandline arguments to pass desired network interface setup as parsed from the ACPI NBFT table. These are highly volatile values and often changing upon each boot.

Thus avoid writing /etc/systemd/network interface link files by Anaconda for any 'nbft*' network interface as these are getting packed in initramfs, creating havoc and conflicts with the actual networking setup during early boot.

----

This is a clone of #5733. 