### PR TITLE
RHEL 10: bootupd update firmware

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -520,6 +520,7 @@ class ConfigureBootloader(Task):
                 "install",
                 "--auto",
                 "--write-uuid",
+                "--update-firmware",
                 "--device",
                 dev_data.path,
                 "/",

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -513,14 +513,22 @@ class ConfigureBootloader(Task):
         device_tree = STORAGE.get_proxy(DEVICE_TREE)
         dev_data = DeviceData.from_structure(device_tree.GetDeviceData(bootloader.Drive))
 
+        bootupdctl_args = [
+                "--auto",
+                "--write-uuid",
+        ]
+
+        # do not insert UEFI entry if leavebootorder was requested
+        if not bootloader.KeepBootOrder:
+            log.debug("Adding --update-firmware to bootupdctl call")
+            bootupdctl_args.append("--update-firmware")
+
         rc = execWithRedirect(
             "bootupctl",
             [
                 "backend",
                 "install",
-                "--auto",
-                "--write-uuid",
-                "--update-firmware",
+                *bootupdctl_args,
                 "--device",
                 dev_data.path,
                 "/",

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -777,8 +777,8 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             exec_mock.assert_has_calls([
                 call(
                     "bootupctl",
-                    ["backend", "install", "--auto", "--write-uuid", "--device",
-                     "/dev/btldr-drv", "/"],
+                    ["backend", "install", "--auto", "--write-uuid", "--update-firmware",
+                     "--device", "/dev/btldr-drv", "/"],
                     root=sysroot
                 ),
                 call(

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -764,6 +764,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
         proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
         proxy_mock.GetRootDevice.return_value = "device-name"
         proxy_mock.Drive = "btldr-drv"
+        proxy_mock.KeepBootOrder = False
         devdata_mock.from_structure.return_value.type = "something-non-btrfs-subvolume-ish"
         devdata_mock.from_structure.return_value.path = "/dev/btldr-drv"
 
@@ -778,6 +779,48 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                 call(
                     "bootupctl",
                     ["backend", "install", "--auto", "--write-uuid", "--update-firmware",
+                     "--device", "/dev/btldr-drv", "/"],
+                    root=sysroot
+                ),
+                call(
+                    "ostree",
+                    ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
+                    root=sysroot
+                )
+            ])
+
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.have_bootupd")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
+    def test_bootupd_run_with_leavebootorder(self, devdata_mock, storage_mock, symlink_mock,
+                                             rename_mock, exec_mock, have_bootupd_mock):
+        """Test OSTree bootloader config task, bootupd"""
+        exec_mock.return_value = 0
+        have_bootupd_mock.return_value = True
+
+        proxy_mock = storage_mock.get_proxy()
+        proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
+        proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
+        proxy_mock.GetRootDevice.return_value = "device-name"
+        proxy_mock.Drive = "btldr-drv"
+        proxy_mock.KeepBootOrder = True
+        devdata_mock.from_structure.return_value.type = "something-non-btrfs-subvolume-ish"
+        devdata_mock.from_structure.return_value.path = "/dev/btldr-drv"
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            task = ConfigureBootloader(sysroot)
+            task.run()
+
+            rename_mock.assert_not_called()
+            symlink_mock.assert_not_called()
+            assert exec_mock.call_count == 2
+            exec_mock.assert_has_calls([
+                call(
+                    "bootupctl",
+                    ["backend", "install", "--auto", "--write-uuid",
                      "--device", "/dev/btldr-drv", "/"],
                     root=sysroot
                 ),


### PR DESCRIPTION
Enable installation of the EFI entry from the bootupd project.

Backport of the https://github.com/rhinstaller/anaconda/pull/5508.

Resolves: [RHEL-40896](https://issues.redhat.com/browse/RHEL-40896)

* [ ] Blocked on RHEL-40897 still being in PLANNING