### PR TITLE
Don't use tmpfs in build if not enough RAM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -367,7 +367,8 @@ container-iso-build:
 	sudo $(CONTAINER_ENGINE) run \
 	--rm \
 	--privileged \
-	--tmpfs /var/tmp:rw,mode=1777 \
+	$(shell test $(shell grep MemTotal /proc/meminfo | awk '{print $$2}') -gt 11000000 && \
+	  echo --tmpfs /var/tmp:rw,mode=1777) \
 	-v $(srcdir)/result/build/01-rpm-build:/anaconda-rpms:ro \
 	-v $(srcdir)/result/iso:/images:z \
 	$(CONTAINER_ADD_ARGS) \
@@ -397,7 +398,8 @@ container-live-iso-build:
 	--rm \
 	--tty \
 	--privileged \
-	--tmpfs /var/tmp:rw,mode=1777 \
+	$(shell test $(shell grep MemTotal /proc/meminfo | awk '{print $$2}') -gt 15000000 && \
+	  echo --tmpfs /var/tmp:rw,mode=1777) \
 	--device /dev/kvm \
 	-v $(srcdir)/result/build/01-rpm-build:/anaconda-rpms:ro \
 	-v $(srcdir)/result/iso:/images:z \


### PR DESCRIPTION
Make targets `container-iso-build` and `container-live-iso-build` were running out of memory on a 4GB machine. Check if the machine has more than 7.9GB of ram before giving podman a tmpfs for build.