### PR TITLE
Fix whitespace chars broke Dracut config parsing

### DIFF
--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -26,6 +26,10 @@ config_get() {
             \[*\]*) cursec="${line#[}"; cursec="${cursec%%]*}" ;;
             *=*) k="${line%%=*}"; v="${line#*=}" ;;
         esac
+        # trim leading and trailing whitespace characters
+        k=$(echo "$k" | sed 's/^ *//;s/ *$//')
+        v=$(echo "$v" | sed 's/^ *//;s/ *$//')
+
         if [ "$cursec" = "$section" ] && [ "$k" == "$key" ]; then
             echo "$v"
             break


### PR DESCRIPTION
With commit 0785531e40c20404d24f1511b37a797b4fca3d7f the `get_config` function in anaconda-lib.sh was broken because missing quotes removed leading and trailing whitespace characters automatically but after the fix in commit mentioned above this side effect was fixed which lead in broken code. In other words the key were never matched because of trailing whitespace.

Issue raised by this is not being able to read .treeinfo and .buildstamp files in Dracut. Example of such situation is broken boot when stage2 image is stored under special path mentioned in .treeinfo file.