### PR TITLE
infra: fix --kstest-pr option of /kickstart-test workflow

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -83,12 +83,15 @@ jobs:
         run: |
           # extract first line and cut out the "/kickstart-tests" first word
           ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p' | sed 's/[[:space:]]*$//')
+          # parse --kstest-pr option
           OPTS="$(getopt -q -o "" --long kstest-pr: -- $ARGS)" || true
           PR=${OPTS#" --kstest-pr '"}
           PR=$(echo $PR | cut -d " " -f1)
           PR=${PR%"'"}
           PR=${PR%"--"}
-          echo "workflow arguments are: $ARGS"
+          # remove --kstest-pr option
+          ARGS=$(echo "$ARGS" | sed -r -e "s#--kstest-pr( +|=)$PR ##" | sed 's/[[:space:]]*$//')
+          echo "test selection arguments are: $ARGS"
           echo "comment_args=${ARGS}" >> $GITHUB_OUTPUT
           echo "kickstart-tests PR: $PR"
           echo "kstest_pr=${PR}" >> $GITHUB_OUTPUT

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -77,12 +77,15 @@ jobs:
         run: |
           # extract first line and cut out the "/kickstart-tests" first word
           ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p' | sed 's/[[:space:]]*$//')
+          # parse --kstest-pr option
           OPTS="$(getopt -q -o "" --long kstest-pr: -- $ARGS)" || true
           PR=${OPTS#" --kstest-pr '"}
           PR=$(echo $PR | cut -d " " -f1)
           PR=${PR%"'"}
           PR=${PR%"--"}
-          echo "workflow arguments are: $ARGS"
+          # remove --kstest-pr option
+          ARGS=$(echo "$ARGS" | sed -r -e "s#--kstest-pr( +|=)$PR ##" | sed 's/[[:space:]]*$//')
+          echo "test selection arguments are: $ARGS"
           echo "comment_args=${ARGS}" >> $GITHUB_OUTPUT
           echo "kickstart-tests PR: $PR"
           echo "kstest_pr=${PR}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Instead of passing and ignoring the option when generating launch options (reverted in https://github.com/rhinstaller/kickstart-tests/pull/1264) which makes the option value (PR number) being erroneously passed to test selection as argument (as for example in https://github.com/rhinstaller/anaconda/actions/runs/10042025231/job/27751476633), remove it completely after parsing it.