### PR TITLE
LUKS support fixes in DeviceTreeSchedulerModule and tests

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/scheduler_module.py
@@ -64,7 +64,7 @@ class DeviceTreeSchedulerModule(DeviceTreeModule):
         :return: True or False
         """
         device = self._get_device(device_name)
-        return device.format.type == "luks" and device.format.exists
+        return device.format.type == "luks" and device.format.exists and not device.children
 
     def is_device_editable(self, device_name):
         """Is the specified device editable?

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -653,16 +653,16 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         """Test IsDeviceLocked."""
         dev1 = StorageDevice(
             "dev1",
-            fmt=get_format("ext4"),
+            fmt=get_format("luks"),
             size=Size("10 GiB")
         )
         dev2 = LUKSDevice(
             "dev2",
             parents=[dev1],
-            fmt=get_format("luks"),
+            fmt=get_format("ext4"),
             size=Size("10 GiB"),
         )
-        dev3 = LUKSDevice(
+        dev3 = StorageDevice(
             "dev3",
             parents=[dev1],
             fmt=get_format("luks", exists=True),


### PR DESCRIPTION
Found some issues with LUKS support in Anaconda (mostly in tests) when working on https://github.com/storaged-project/blivet/pull/1262