### PR TITLE
Use the RHEL 10 version of the vnc kickstart command

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libreportanacondaver 2.0.21-1
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.52.4-1
+%define pykickstartver 3.52.5-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.9.0-1
 %define rpmver 4.15.0

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -75,7 +75,7 @@ from pykickstart.commands.timesource import F33_Timesource as Timesource
 from pykickstart.commands.updates import F34_Updates as Updates
 from pykickstart.commands.url import F30_Url as Url
 from pykickstart.commands.user import F24_User as User
-from pykickstart.commands.vnc import F9_Vnc as Vnc
+from pykickstart.commands.vnc import RHEL10_Vnc as Vnc
 from pykickstart.commands.volgroup import RHEL10_VolGroup as VolGroup
 from pykickstart.commands.xconfig import F14_XConfig as XConfig
 from pykickstart.commands.zerombr import F9_ZeroMbr as ZeroMbr


### PR DESCRIPTION
The VNC kickstart command has been marked as deprecated in RHEL 10, so make sure to use this new version in Anaconda for RHEL 10 as well.

Resolves: RHEL-41219

**NOTE:** Should be merged only after the [PyKickstart PR](https://github.com/pykickstart/pykickstart/pull/497) for RHEL10_Vnc is merged and a package with it is released. Also, until that PyKickstart PR is merged, unit tests on this PR will most likely fail due to the missing command.