### PR TITLE
Create annotated tag instead of lightweight in makebumpver

### DIFF
--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -441,7 +441,7 @@ class MakeBumpVer:
         # make the release commit
         run_program(['git', 'commit', '-m', commit_message])
         # tag the release
-        run_program(['git', 'tag', release_tag])
+        run_program(['git', 'tag', '-a', '-m', commit_message, release_tag])
         # log the commit message & tag
         log.info("commit message: %s", commit_message)
         log.info("tag: %s", release_tag)


### PR DESCRIPTION
We want to use annotated tag because, first, it seems appropriate for release tagging and second it will allow us to use `git push --follow-tags`.