### PR TITLE
Check if text mode was actually requested by kickstart (#2293672)

### DIFF
--- a/dockerfile/anaconda-live-iso-creator/lmc-build
+++ b/dockerfile/anaconda-live-iso-creator/lmc-build
@@ -38,7 +38,7 @@ start_http_server() {
     echo "$!" > $HTTP_PID
 
     # extract container IP
-    IP=$(ip -4 addr show scope global | grep -oP 'inet \K[\d.]+')
+    IP=$(ip -4 addr show scope global | grep -oP 'inet \K[\d.]+' | head -n1)
     echo "http://$IP:8000/"
 }
 

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -155,15 +155,20 @@ def check_vnc_can_be_started(anaconda):
                               (blivet.util.total_memory(), min_gui_ram))
         vnc_startup_possible = False
 
-    # disable VNC question if text mode is requested and this is a ks install
-    if anaconda.tui_mode and flags.automatedInstall:
-        error_messages.append("Not asking for VNC because of an automated install")
-        vnc_startup_possible = False
-
-    # disable VNC question if we were explicitly asked for text in kickstart
-    if anaconda.display_mode == constants.DisplayModes.TUI:
-        error_messages.append("Not asking for VNC because text mode was explicitly asked for in kickstart")
-        vnc_startup_possible = False
+    # if running in text mode, we might sometimes skip showing the VNC question
+    if anaconda.tui_mode:
+        # disable VNC question if we were explicitly asked for text mode in kickstart
+        ui_proxy = RUNTIME.get_proxy(USER_INTERFACE)
+        if ui_proxy.DisplayModeTextKickstarted:
+            error_messages.append(
+                "Not asking for VNC because text mode was explicitly asked for in kickstart"
+            )
+            vnc_startup_possible = False
+        # disable VNC question if text mode is requested and this is an automated kickstart
+        # installation
+        elif flags.automatedInstall:
+            error_messages.append("Not asking for VNC because of an automated install")
+            vnc_startup_possible = False
 
     # disable VNC question if we don't have network
     network_proxy = NETWORK.get_proxy()

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -36,7 +36,6 @@ from pyanaconda.core.i18n import _
 from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import USER_INTERFACE
 from pyanaconda.modules.common.constants.services import NETWORK, RUNTIME
-from pyanaconda.modules.common.structures.secret import SecretData
 from pyanaconda.modules.common.structures.vnc import VncData
 from pyanaconda.ui.tui.spokes.askvnc import AskVNCSpoke
 from pyanaconda.ui.tui import tui_quit_callback
@@ -134,7 +133,7 @@ def ask_vnc_question(anaconda, vnc_server, message):
             log.info("VNC requested via VNC question, switching Anaconda to GUI mode.")
         anaconda.display_mode = constants.DisplayModes.GUI
         flags.usevnc = True
-        vnc_server.password = vnc_data.password
+        vnc_server.password = vnc_data.password.value
 
 
 def check_vnc_can_be_started(anaconda):
@@ -305,8 +304,7 @@ def setup_display(anaconda, options):
         if not anaconda.gui_mode:
             log.info("VNC requested via boot/CLI option, switching Anaconda to GUI mode.")
             anaconda.display_mode = constants.DisplayModes.GUI
-        vnc_server.password = SecretData()
-        vnc_server.password.value = options.vncpassword
+        vnc_server.password = options.vncpassword
 
         # Only consider vncconnect when vnc is a param
         if options.vncconnect:
@@ -329,7 +327,7 @@ def setup_display(anaconda, options):
             anaconda.display_mode = constants.DisplayModes.GUI
 
         if vnc_server.password == "":
-            vnc_server.password = vnc_data.password
+            vnc_server.password = vnc_data.password.value
 
         if vnc_server.vncconnecthost == "":
             vnc_server.vncconnecthost = vnc_data.host

--- a/pyanaconda/modules/runtime/user_interface/ui.py
+++ b/pyanaconda/modules/runtime/user_interface/ui.py
@@ -29,6 +29,8 @@ from pyanaconda.modules.common.base import KickstartBaseModule
 from pyanaconda.modules.common.constants.objects import USER_INTERFACE
 from pyanaconda.modules.common.structures.policy import PasswordPolicy
 
+from pykickstart.commands.displaymode import DISPLAY_MODE_TEXT
+
 log = get_module_logger(__name__)
 
 __all__ = ["UIModule"]
@@ -48,6 +50,9 @@ class UIModule(KickstartBaseModule):
         self.display_mode_nonInteractive_changed = Signal()
         self._displayMode_nonInteractive = False
 
+        self.display_mode_text_kickstarted_changed = Signal()
+        self._display_mode_text_kickstarted = False
+
         self.vnc_changed = Signal()
         self._vnc = VncData()
 
@@ -59,6 +64,12 @@ class UIModule(KickstartBaseModule):
         """Process the kickstart data."""
         self.set_display_mode(data.displaymode.displayMode)
         self.set_display_mode_non_interactive(data.displaymode.nonInteractive)
+        # check if text mode was requested in kickstart
+        if data.displaymode.displayMode == DISPLAY_MODE_TEXT:
+            log.debug("Text mode requested by kickstart")
+            self._display_mode_text_kickstarted = True
+            self.display_mode_text_kickstarted_changed.emit()
+
         vnc = VncData()
         vnc.enabled = data.vnc.enabled
         vnc.host = data.vnc.host
@@ -112,6 +123,19 @@ class UIModule(KickstartBaseModule):
         self._displayMode_nonInteractive = non_interactive
         self.display_mode_nonInteractive_changed.emit()
         log.debug("Display mode non-interactive set to: %s", str(non_interactive))
+
+    @property
+    def display_mode_text_kickstarted(self):
+        """Report if text mode was explicitely requested via kickstart.
+
+
+        #NOTE: No setter as this is only set once when parsing the kickstasrt.
+
+        :return: if text mode was requested by kickstart
+        :rtype: bool
+        """
+
+        return self._display_mode_text_kickstarted
 
     @property
     def vnc(self):

--- a/pyanaconda/modules/runtime/user_interface/ui_interface.py
+++ b/pyanaconda/modules/runtime/user_interface/ui_interface.py
@@ -102,6 +102,11 @@ class UIInterface(KickstartModuleInterfaceTemplate):
         self.implementation.set_display_mode_non_interactive(non_interactive)
 
     @property
+    def DisplayModeTextKickstarted(self) -> Bool:
+        """Report if text mode was explicitly requested via kickstart."""
+        return self.implementation.display_mode_text_kickstarted
+
+    @property
     def Vnc(self) -> Structure:
         """Specification of the vnc configuration."""
         return VncData.to_structure(self.implementation.vnc)

--- a/pyanaconda/ui/tui/spokes/askvnc.py
+++ b/pyanaconda/ui/tui/spokes/askvnc.py
@@ -21,7 +21,6 @@ import sys
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.modules.common.constants.objects import USER_INTERFACE
 from pyanaconda.modules.common.constants.services import RUNTIME
-from pyanaconda.modules.common.structures.secret import SecretData
 from pyanaconda.modules.common.structures.vnc import VncData
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
 from pyanaconda.core.constants import USEVNC, USETEXT, QUIT_MESSAGE
@@ -91,7 +90,7 @@ class AskVNCSpoke(NormalTUISpoke):
 
     def _use_vnc_callback(self, data):
         self._usevnc = True
-        new_spoke = VNCPassSpoke(self.data, self.storage, self.payload, self.vnc_data)
+        new_spoke = VNCPassSpoke(self.data, self.storage, self.payload, vnc_data=self.vnc_data)
         ScreenHandler.push_screen_modal(new_spoke)
 
     def _use_text_callback(self, data):
@@ -119,7 +118,7 @@ class AskVNCSpoke(NormalTUISpoke):
         self.vnc_data.enabled = self._usevnc
         ui_proxy = RUNTIME.get_proxy(USER_INTERFACE)
         struct_vnc = VncData.to_structure(self.vnc_data)
-        ui_proxy.Vnc(struct_vnc)
+        ui_proxy.Vnc = struct_vnc
 
 
 class VNCPassSpoke(NormalTUISpoke):
@@ -132,7 +131,7 @@ class VNCPassSpoke(NormalTUISpoke):
         super().__init__(data, storage, payload)
         self.vnc_data = vnc_data
         self.title = N_("VNC Password")
-        self._password = SecretData()
+        self._password = ""
         if message:
             self._message = message
         else:
@@ -165,7 +164,7 @@ class VNCPassSpoke(NormalTUISpoke):
             self._print_error_and_redraw(_("The password cannot be more than "
                                            "eight characters long."))
         else:
-            self._password.value = p1
+            self._password = p1
             self.apply()
             self.close()
 
@@ -177,7 +176,7 @@ class VNCPassSpoke(NormalTUISpoke):
         self.redraw()
 
     def apply(self):
-        self.vnc_data.password = self._password
+        self.vnc_data.password.set_secret(self._password)
         ui_proxy = RUNTIME.get_proxy(USER_INTERFACE)
         struct_vnc = VncData.to_structure(self.vnc_data)
-        ui_proxy.Vnc(struct_vnc)
+        ui_proxy.Vnc = struct_vnc

--- a/pyanaconda/vnc.py
+++ b/pyanaconda/vnc.py
@@ -29,7 +29,6 @@ import subprocess
 from pyanaconda.core.i18n import _, P_
 from pyanaconda.modules.common.constants.objects import USER_INTERFACE
 from pyanaconda.modules.common.constants.services import RUNTIME
-from pyanaconda.modules.common.structures.secret import SecretData
 from pyanaconda.modules.common.structures.vnc import VncData
 from pyanaconda.ui.tui import tui_quit_callback
 from pyanaconda.ui.tui.spokes.askvnc import VNCPassSpoke
@@ -65,7 +64,7 @@ def shutdownServer():
 class VncServer(object):
 
     def __init__(self, root="/", ip=None, name=None,
-                 password=SecretData(), vncconnecthost="",
+                 password="", vncconnecthost="",
                  vncconnectport="", log_file="/tmp/vncserver.log",
                  pw_file="/tmp/vncpassword", timeout=constants.X_TIMEOUT):
         self.root = root
@@ -87,7 +86,7 @@ class VncServer(object):
 
     def setVNCPassword(self):
         """Set the vnc server password. Output to file. """
-        password_string = "%s\n" % self.password.value
+        password_string = "%s\n" % self.password
 
         # the -f option makes sure vncpasswd does not ask for the password again
         proc = util.startProgram(
@@ -232,10 +231,10 @@ class VncServer(object):
             util.ipmi_abort(scripts=self.anaconda.ksdata.scripts)
             sys.exit(1)
 
-        if self.password.value and (len(self.password.value) < 6 or len(self.password.value) > 8):
+        if self.password and (len(self.password) < 6 or len(self.password) > 8):
             self.changeVNCPasswdWindow()
 
-        if not self.password.value:
+        if not self.password:
             SecurityTypes = "None"
             rfbauth = "0"
         else:
@@ -266,11 +265,11 @@ class VncServer(object):
                                "This does not require a password to be set.  If you \n"
                                "set a password, it will be used in case the connection \n"
                                "to the vncviewer is unsuccessful\n\n"))
-        elif self.password.value == "":
+        elif self.password == "":
             self.log.warning(_("\n\nWARNING!!! VNC server running with NO PASSWORD!\n"
                                "You can use the inst.vncpassword=PASSWORD boot option\n"
                                "if you would like to secure the server.\n\n"))
-        elif self.password.value != "":
+        elif self.password != "":
             self.log.warning(_("\n\nYou chose to execute vnc with a password. \n\n"))
         else:
             self.log.warning(_("\n\nUnknown Error.  Aborting. \n\n"))


### PR DESCRIPTION
Provide information about text mode being requested via DBus property set at kickstart parsing time & check this property when deciding if the VNC question should be shown.

Also cleanup the code a bit and fix a typo affecting vnc command parsing.

Resolves: rhbz#2293672