### PR TITLE
Fix source spoke being inaccessible if payload thread errors out

### DIFF
--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -45,6 +45,7 @@ class PayloadState(IntEnum):
     DOWNLOADING_PKG_METADATA = 4
     DOWNLOADING_GROUP_METADATA = 5
     FINISHED = 6
+    PAYLOAD_THREAD_TERMINATED = 7
 
     # Error
     ERROR = -1
@@ -155,6 +156,16 @@ class PayloadManager(object):
             target=self._run_thread,
             args=(payload, fallback, checkmount, onlyOnChange)
         ))
+
+        # Wait for the new thread to finish
+        threadMgr.wait(THREAD_PAYLOAD)
+
+        # Notify any listeners that payload thread has terminated
+        #
+        # This might be necessary to notify spokes waiting for
+        # the payload thread to terminate, by the notification
+        # not comming from the thread they are waiting for to terminate.
+        self._set_state(PayloadState.PAYLOAD_THREAD_TERMINATED)
 
     def _set_state(self, event_id):
         # Update the current state


### PR DESCRIPTION
Add a new event source spoke can listen to, which can be used to (re)check spoke access conditions.

This is necessary, as otherwise we would only get an error event from the payload thread itself while it is still running. This is problematic as the spoke ready check expects the payload thread to be gone. This results in the check still seeing the payload thread as running and incorrectly resolving as False, making the source spoke inaccessible.

With the new event being triggered once payload thread terminates, we can run the ready check once more, resolving correctly to True, making the source spoke accessible.

Resolves: RHEL-4721