### PR TITLE
infra: Fix live image generation if machine has multiple IPs

### DIFF
--- a/dockerfile/anaconda-live-iso-creator/lmc-build
+++ b/dockerfile/anaconda-live-iso-creator/lmc-build
@@ -38,7 +38,7 @@ start_http_server() {
     echo "$!" > $HTTP_PID
 
     # extract container IP
-    IP=$(ip -4 addr show scope global | grep -oP 'inet \K[\d.]+')
+    IP=$(ip -4 addr show scope global | grep -oP 'inet \K[\d.]+' | head -n1)
     echo "http://$IP:8000/"
 }
 

--- a/dockerfile/anaconda-live-iso-creator/lmc-build.j2
+++ b/dockerfile/anaconda-live-iso-creator/lmc-build.j2
@@ -36,7 +36,7 @@ start_http_server() {
     echo "$!" > $HTTP_PID
 
     # extract container IP
-    IP=$(ip -4 addr show scope global | grep -oP 'inet \K[\d.]+')
+    IP=$(ip -4 addr show scope global | grep -oP 'inet \K[\d.]+' | head -n1)
     echo "http://$IP:8000/"
 }
 


### PR DESCRIPTION
In some cases a machine running live image creation might have more than one valid IP address. As either of them should be usable for us, lets just pick the first one and use it.

Otherwise we would end up with corrupted kickstart where multiple lines of addresses would be added, failing validation later on in LMC.