### PR TITLE
Fix using kickstart mount command with device ID

### DIFF
--- a/pyanaconda/modules/common/structures/partitioning.py
+++ b/pyanaconda/modules/common/structures/partitioning.py
@@ -269,6 +269,7 @@ class MountPointRequest(DBusData):
 
     def __init__(self):
         self._device_spec = ""
+        self._ks_spec = ""
         self._mount_point = ""
         self._mount_options = ""
         self._reformat = False
@@ -287,6 +288,19 @@ class MountPointRequest(DBusData):
     def device_spec(self, spec: Str):
         """Set the block device to mount."""
         self._device_spec = spec
+
+    @property
+    def ks_spec(self) -> Str:
+        """Kickstart specification of the block device to mount.
+
+        :return: a device specification
+        """
+        return self._ks_spec
+
+    @ks_spec.setter
+    def ks_spec(self, spec: Str):
+        """Set the kickstart specification of the device to mount."""
+        self._ks_spec = spec
 
     @property
     def mount_point(self) -> Str:

--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -58,8 +58,8 @@ class ManualPartitioningModule(PartitioningModule):
             request = MountPointRequest()
             request.mount_point = mount_data.mount_point
 
-            device = self.storage.devicetree.resolve_device(mount_data.device)
-            request.device_spec = device.device_id
+            request.device_spec = None
+            request.ks_spec = mount_data.device
 
             request.reformat = mount_data.reformat
             request.format_type = mount_data.format
@@ -77,8 +77,12 @@ class ManualPartitioningModule(PartitioningModule):
             mount_data = data.MountData()
             mount_data.mount_point = request.mount_point
 
-            device = self.storage.devicetree.get_device_by_device_id(request.device_spec)
-            mount_data.device = device.path
+            if request.device_spec:
+                device = self.storage.devicetree.get_device_by_device_id(request.device_spec)
+                mount_data.device = device.path
+            else:
+                mount_data.device = request.ks_spec
+
             mount_data.reformat = request.reformat
 
             mount_data.format = request.format_type
@@ -163,7 +167,13 @@ class ManualPartitioningModule(PartitioningModule):
         :return: an instance of MountPointRequest or None
         """
         for request in requests:
-            if device is self.storage.devicetree.get_device_by_device_id(request.device_spec):
+            if request.device_spec:
+                rdevice = self.storage.devicetree.get_device_by_device_id(request.device_spec)
+            else:
+                rdevice = self.storage.devicetree.resolve_device(request.ks_spec)
+            if device is rdevice:
+                if not request.device_spec:
+                    request.device_spec = device.device_id
                 return request
 
         return None

--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -64,7 +64,13 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
             # XXX empty request, ignore
             return
 
-        device = storage.devicetree.get_device_by_device_id(device_spec)
+        if device_spec:
+            device = storage.devicetree.get_device_by_device_id(device_spec)
+        else:
+            device = storage.devicetree.resolve_device(mount_data.ks_spec)
+            if device:
+                device_spec = device.device_id
+
         if device is None:
             raise StorageError(
                 _("Unknown or invalid device '{}' specified").format(device_spec)

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
@@ -71,6 +71,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             "reformat": get_variant(Bool, False),
             "format-type": get_variant(Str, ""),
             "format-options": get_variant(Str, ""),
+            "ks-spec": get_variant(Str, ""),
             "mount-options": get_variant(Str, "")
         }
         self._check_dbus_property(
@@ -84,6 +85,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             "reformat": get_variant(Bool, True),
             "format-type": get_variant(Str, "xfs"),
             "format-options": get_variant(Str, "-L BOOT"),
+            "ks-spec": get_variant(Str, ""),
             "mount-options": get_variant(Str, "user")
         }
         self._check_dbus_property(
@@ -97,6 +99,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             "reformat": get_variant(Bool, False),
             "format-type": get_variant(Str, ""),
             "format-options": get_variant(Str, ""),
+            "ks-spec": get_variant(Str, ""),
             "mount-options": get_variant(Str, "")
         }
         request_2 = {
@@ -105,6 +108,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
             "reformat": get_variant(Bool, True),
             "format-type": get_variant(Str, ""),
             "format-options": get_variant(Str, ""),
+            "ks-spec": get_variant(Str, ""),
             "mount-options": get_variant(Str, "")
         }
         self._check_dbus_property(
@@ -174,6 +178,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
                 'format-options': get_variant(Str, ''),
                 'format-type': get_variant(Str, 'ext4'),
                 'mount-options': get_variant(Str, ''),
+                'ks-spec': get_variant(Str, ''),
                 'mount-point': get_variant(Str, '/'),
                 'reformat': get_variant(Bool, False)
             },
@@ -182,6 +187,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
                 'format-options': get_variant(Str, ''),
                 'format-type': get_variant(Str, 'swap'),
                 'mount-options': get_variant(Str, ''),
+                'ks-spec': get_variant(Str, ''),
                 'mount-point': get_variant(Str, ''),
                 'reformat': get_variant(Bool, False)
             }
@@ -225,6 +231,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
                 'device-spec': get_variant(Str, 'dev1'),
                 'format-options': get_variant(Str, '-L BOOT'),
                 'format-type': get_variant(Str, 'xfs'),
+                'ks-spec': get_variant(Str, ''),
                 'mount-options': get_variant(Str, 'user'),
                 'mount-point': get_variant(Str, '/home'),
                 'reformat': get_variant(Bool, True)
@@ -233,6 +240,7 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
                 'device-spec': get_variant(Str, 'dev2'),
                 'format-options': get_variant(Str, ''),
                 'format-type': get_variant(Str, 'swap'),
+                'ks-spec': get_variant(Str, ''),
                 'mount-options': get_variant(Str, ''),
                 'mount-point': get_variant(Str, ''),
                 'reformat': get_variant(Bool, False)


### PR DESCRIPTION
We unfortunately don't have populated devicetree when parsing the kickstart so we cannot get the device ID we need later when working with the manual partitioning requests so we need a new attribute for requests gathered from kickstart so we can use resolve_device later to actually get the device and the device ID from it.

Resolves: https://github.com/rhinstaller/kickstart-tests/issues/1273