### PR TITLE
Fix `rebuild_iso` and `update_iso` scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ tests/*.trs
 tests/.coverage.*
 tests/pylint/.pylint.d
 tests/test-suite.log*
+updates/
 updates.img
 dracut/dd/dd_extract
 dracut/dd/dd_list

--- a/.structure-config
+++ b/.structure-config
@@ -8,6 +8,7 @@ INFRASTRUCTURE_FILES=(
 .coveragerc
 .shellcheckrc
 .github/
+.gitignore
 dockerfile/
 scripts/testing/
 scripts/jinja-render

--- a/scripts/testing/rebuild_iso
+++ b/scripts/testing/rebuild_iso
@@ -30,8 +30,7 @@ EOF
 
 BOOT_ISO="result/iso/boot.iso"
 PACKAGES_DIR="result/build/01-rpm-build/"
-UPDATED_BOOT_ISO="result/iso/iso.git_rev"
-BOOT_ISO_GIT_REVISION="result/iso/boot.iso.git_rev"
+BOOT_ISO_GIT_REVISION="result/iso/iso.git_rev"
 
 BUILD_TARGET="boot.iso"
 
@@ -55,12 +54,11 @@ sudo true
 # remove any previous package and relevant iso artifacts
 rm -rf result/build/
 rm -f ${BOOT_ISO}
-rm -f ${UPDATED_BOOT_ISO}
 rm -f ${BOOT_ISO_GIT_REVISION}
 # make sure the iso folder actually exists
 mkdir -p result/iso/
 # note the Git revision from which we build the boot.iso
-git rev-parse HEAD > result/iso/boot.iso.git_rev
+git rev-parse HEAD > ${BOOT_ISO_GIT_REVISION}
 
 # build the anaconda rpms
 make -f ./Makefile.am container-rpms-scratch

--- a/scripts/testing/update_iso
+++ b/scripts/testing/update_iso
@@ -88,7 +88,7 @@ def make_updates_image(git_id, rpm_paths):
     # Create the necessary folder structure
     os.makedirs(UPDATES_FOLDER, exist_ok=True)
     # Prepare updates image
-    cmd = f"./scripts/makeupdates -k -c -t {git_id}{rpm_args}"
+    cmd = f"./scripts/makeupdates -c -t {git_id}{rpm_args}"
     print("** Calling:", cmd)
     os.system(cmd)
     # Move it next to the ISOs


### PR DESCRIPTION
A few fixes in for the ISO handling helper scripts:
* variables around git_rev file creation were messy so let's clean that up and use that everywhere
* Add `updates` directory to the `.gitignore` this directory is used for updates image creation. It's directory holding files which are then packed into the updates image file.
* Remove `-k` parameter from the `makeupdates` call. This will avoid keeping the `updates` directory after updates image creation.