### PR TITLE
Use proxy server also for FTP .treeinfo download

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -274,7 +274,8 @@ class TreeInfoMetadata(object):
                 proxy = ProxyString(proxy_url)
                 proxies = {
                     "http": proxy.url,
-                    "https": proxy.url
+                    "https": proxy.url,
+                    "ftp": proxy.url
                 }
             except ProxyStringError as e:
                 log.debug("Failed to parse the proxy '%s': %s", proxy_url, e)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_tree_info.py
@@ -419,7 +419,8 @@ class TreeInfoMetadataTestCase(unittest.TestCase):
             headers={"user-agent": "anaconda (anaconda)/bluesky"},
             proxies={
                 'http': 'http://user:pass@example.com:3128',
-                'https': 'http://user:pass@example.com:3128'
+                'https': 'http://user:pass@example.com:3128',
+                'ftp': 'http://user:pass@example.com:3128'
             },
             verify=True,
             cert=None,


### PR DESCRIPTION
We missed ftp prefix in the list of schemes.

Resolves: RHEL-27938


Kickstart tests support: https://github.com/rhinstaller/kickstart-tests/pull/1281