### PR TITLE
RHEL-9: Use proxy server also for FTP .treeinfo download

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -1303,7 +1303,8 @@ class DNFPayload(Payload):
             try:
                 proxy = ProxyString(proxy_url)
                 proxies = {"http": proxy.url,
-                           "https": proxy.url}
+                           "https": proxy.url,
+                           "ftp": proxy.url}
             except ProxyStringError as e:
                 log.info("Failed to parse proxy for _getTreeInfo %s: %s",
                          proxy_url, e)


### PR DESCRIPTION
We missed ftp prefix in the list of schemes.

Resolves: RHEL-27938
(cherry picked from commit a203b7569bc5ac96b17e9ee9af58590cceaf332f)
Kickstart tests support: https://github.com/rhinstaller/kickstart-tests/pull/1281