### PR TITLE
Add support for creating LUKS HW-OPAL devices

### DIFF
--- a/pyanaconda/modules/common/structures/partitioning.py
+++ b/pyanaconda/modules/common/structures/partitioning.py
@@ -47,6 +47,8 @@ class PartitioningRequest(DBusData):
         self._escrow_certificate = ""
         self._backup_passphrase_enabled = False
 
+        self._opal_admin_passphrase = ""
+
     @property
     def partitioning_scheme(self) -> Int:
         """The partitioning scheme.
@@ -255,12 +257,25 @@ class PartitioningRequest(DBusData):
     def backup_passphrase_enabled(self, enabled: Bool):
         self._backup_passphrase_enabled = enabled
 
+    @property
+    def opal_admin_passphrase(self) -> Str:
+        """OPAL admin passphrase to be used when configuring hardware encryption
+
+        :return: a string with the OPAL admin passphrase
+        """
+        return self._opal_admin_passphrase
+
+    @opal_admin_passphrase.setter
+    def opal_admin_passphrase(self, value: Str):
+        self._opal_admin_passphrase = value
+
     def __repr__(self):
         """Generate a string representation."""
         return generate_string_from_data(
             self,
-            skip=["passphrase"],
-            add={"passphrase_set": bool(self.passphrase)}
+            skip=["passphrase", "opal_admin_passphrase"],
+            add={"passphrase_set": bool(self.passphrase),
+                 "opal_admin_passphrase_set": bool(self.opal_admin_passphrase)}
         )
 
 

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_module.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_module.py
@@ -92,6 +92,8 @@ class AutoPartitioningModule(PartitioningModule):
             request.escrow_certificate = data.autopart.escrowcert
             request.backup_passphrase_enabled = data.autopart.backuppassphrase
 
+            request.opal_admin_passphrase = data.autopart.hw_passphrase
+
         self.set_request(request)
 
     def setup_kickstart(self, data):
@@ -122,6 +124,9 @@ class AutoPartitioningModule(PartitioningModule):
 
         data.autopart.escrowcert = self.request.escrow_certificate
         data.autopart.backuppassphrase = self.request.backup_passphrase_enabled
+
+        # Don't generate sensitive information.
+        data.autopart.hw_passphrase = ""
 
     @property
     def request(self):

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -119,6 +119,7 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
             "pbkdf_args": pbkdf_args,
             "escrow_cert": escrow_cert,
             "add_backup_passphrase": request.backup_passphrase_enabled,
+            "opal_admin_passphrase": request.opal_admin_passphrase,
         }
 
     @staticmethod

--- a/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
@@ -410,7 +410,8 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                     escrow_cert=cert,
                     add_backup_passphrase=partition_data.backuppassphrase,
                     luks_version=partition_data.luks_version,
-                    pbkdf_args=pbkdf_args
+                    pbkdf_args=pbkdf_args,
+                    opal_admin_passphrase=partition_data.hw_passphrase,
                 )
                 luksdev = LUKSDevice(
                     "luks%d" % storage.next_id,
@@ -426,7 +427,8 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
                     escrow_cert=cert,
                     add_backup_passphrase=partition_data.backuppassphrase,
                     luks_version=partition_data.luks_version,
-                    pbkdf_args=pbkdf_args
+                    pbkdf_args=pbkdf_args,
+                    opal_admin_passphrase=partition_data.hw_passphrase,
                 )
                 luksdev = LUKSDevice("luks%d" % storage.next_id,
                                      fmt=luksformat,

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_automatic.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_automatic.py
@@ -102,6 +102,7 @@ class AutopartitioningInterfaceTestCase(unittest.TestCase):
             'pbkdf-iterations': get_variant(Int, 1000),
             'escrow-certificate': get_variant(Str, 'file:///tmp/escrow.crt'),
             'backup-passphrase-enabled': get_variant(Bool, True),
+            'opal-admin-passphrase': get_variant(Str, '123456'),
         }
         self._check_dbus_property(
             "Request",
@@ -200,6 +201,7 @@ class AutomaticPartitioningTaskTestCase(unittest.TestCase):
         request.cipher = "aes-xts-plain64"
         request.escrow_certificate = "file:///tmp/escrow.crt"
         request.backup_passphrase_enabled = True
+        request.opal_admin_passphrase = "passphrase"
 
         args = AutomaticPartitioningTask._get_luks_format_args(storage, request)
         assert args == {
@@ -209,6 +211,7 @@ class AutomaticPartitioningTaskTestCase(unittest.TestCase):
             "pbkdf_args": None,
             "escrow_cert": "CERTIFICATE",
             "add_backup_passphrase": True,
+            "opal_admin_passphrase": "passphrase",
         }
 
     def test_luks2_format_args(self):
@@ -231,6 +234,7 @@ class AutomaticPartitioningTaskTestCase(unittest.TestCase):
             "luks_version": "luks2",
             "escrow_cert": None,
             "add_backup_passphrase": False,
+            "opal_admin_passphrase": "",
         }
 
         assert isinstance(pbkdf_args, LUKS2PBKDFArgs)


### PR DESCRIPTION
This adds support for creating encrypted devices using the OPAL self-encrypting drives. Anaconda only needs to make sure to pass the OPAL administrator passphrase to Blivet when creating the LUKS device, everything else will be taken care by either Blivet or pykickstart -- whether a "normal" or OPAL LUKS device will be created is controlled by the "--luks-version" kickstart option specified by the user which is passed "as is" to Blivet.