### PR TITLE
infra: Add pocketlint to rpm container

### DIFF
--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -34,6 +34,8 @@ RUN set -ex; \
   git \
   curl \
   python3-polib \
+  # Requirement for translation-canary which is started during RPM build
+  python3-pocketlint \
   /usr/bin/xargs \
   rsync \
   rpm-build; \


### PR DESCRIPTION
Add missing pocketlint to the `anaconda-rpm` container image. This PR solves:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 112, in _get_module_details
  File "/tmp/anaconda/translation-canary/translation_canary/translated/__init__.py", line 46, in <module>
    module = importlib.import_module(full_name)
  File "/usr/lib64/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/anaconda/translation-canary/translation_canary/translated/test_markup.py", line 30, in <module>
    from pocketlint.pangocheck import is_markup, markup_match
ModuleNotFoundError: No module named 'pocketlint'
```