### PR TITLE
Support the not-satellite: prefix for server hostname

### DIFF
--- a/pyanaconda/modules/subscription/constants.py
+++ b/pyanaconda/modules/subscription/constants.py
@@ -20,3 +20,5 @@
 
 # name of the RHSM systemd unit
 RHSM_SERVICE_NAME = "rhsm.service"
+# server hostname prefix marking the URL as not Satellite
+SERVER_HOSTNAME_NOT_SATELLITE_PREFIX = "not-satellite:"

--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -33,6 +33,7 @@ from pyanaconda.modules.common.errors.subscription import RegistrationError, \
 from pyanaconda.modules.common.structures.subscription import AttachedSubscription, \
     SystemPurposeData
 from pyanaconda.modules.subscription import system_purpose
+from pyanaconda.modules.subscription.constants import SERVER_HOSTNAME_NOT_SATELLITE_PREFIX
 from pyanaconda.anaconda_loggers import get_module_logger
 
 import gi
@@ -176,8 +177,15 @@ class SetRHSMConfigurationTask(Task):
         # - all values need to be string variants
         # - proxy password is stored in SecretData instance and we need to retrieve
         #   its value
+        # - server host name might have a prefix indicating the given URL is not
+        #   a Satellite URL, drop that prefix before setting the value to RHSM
+
+        # drop the not-satellite prefix, if any
+        server_hostname = self._request.server_hostname.removeprefix(
+            SERVER_HOSTNAME_NOT_SATELLITE_PREFIX
+        )
         property_key_map = {
-            self.CONFIG_KEY_SERVER_HOSTNAME: self._request.server_hostname,
+            self.CONFIG_KEY_SERVER_HOSTNAME: server_hostname,
             self.CONFIG_KEY_SERVER_PROXY_HOSTNAME: self._request.server_proxy_hostname,
             self.CONFIG_KEY_SERVER_PROXY_PORT: str(self._request.server_proxy_port),
             self.CONFIG_KEY_SERVER_PROXY_USER: self._request.server_proxy_user,


### PR DESCRIPTION
Support the not-satellite: prefix for the server hostname RHSM value. This is cherry-picked from the upcoming Satellite support backport PR and makes it possible to run downstream integration tests without unnecessary changes (as RHEL 9 systems require this prefix for staging CDN testing).

Related: RHEL-49661