### PR TITLE
infra: Remove centos specific condition form spec

### DIFF
--- a/dockerfile/anaconda-ci/run-build-and-arg
+++ b/dockerfile/anaconda-ci/run-build-and-arg
@@ -6,6 +6,10 @@ rsync -a /anaconda /tmp/
 cd /tmp/anaconda
 rm -rf test-logs
 
+# For testing purpose let's pretend that CentOS container is RHEL
+# Without this fix we won't see subscription manager on ISO
+sed -i 's/ .. %{undefined centos}//' ./anaconda.spec.in
+
 ./autogen.sh
 # Enable us to change autotools configuration by ENV var.
 ./configure ${CONFIGURE_ARGS:-}


### PR DESCRIPTION
Currently we are building CentOS Stream package and using it to build RHEL ISO images. That works fine expect specific CentOS conditions. Let's fix that by modifying spec file before build.