### PR TITLE
network: enable NM autoconnections only if inst.ks and ip= is not used

### DIFF
--- a/data/systemd/anaconda-nm-disable-autocons.service
+++ b/data/systemd/anaconda-nm-disable-autocons.service
@@ -1,5 +1,7 @@
 [Unit]
-ConditionKernelCommandLine=inst.net.noautodefault
+ConditionKernelCommandLine=|ip
+ConditionKernelCommandLine=|inst.ks
+ConditionKernelCommandLine=|inst.net.noautodefault
 Description=NetworkManager autoconnections configuration for Anaconda installation environment
 Before=NetworkManager.service
 


### PR DESCRIPTION
Applies rhel-specific patch https://github.com/rhinstaller/anaconda/commit/49d345bdb2aa311e22d70e2b9f636a37e07f79ae to rhel-10

TODO:
- [x] Add a test (kickstart test?)
- [x] Try to figure out generic upstream solution / patch - would require detection of rhel (on systemd units level)