### PR TITLE
pyanaconda: remove code paths around module command parsing as this was deprecated

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -38,7 +38,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.52-1
+%define pykickstartver 3.58-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.9.0-1
 %define rpmver 4.15.0

--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -24,7 +24,7 @@
 
 # Supported kickstart commands.
 from pykickstart.commands.authselect import F28_Authselect as Authselect
-from pykickstart.commands.autopart import F38_AutoPart as AutoPart
+from pykickstart.commands.autopart import F41_AutoPart as AutoPart
 from pykickstart.commands.bootloader import F39_Bootloader as Bootloader
 from pykickstart.commands.btrfs import F23_BTRFS as BTRFS
 from pykickstart.commands.cdrom import FC3_Cdrom as Cdrom
@@ -54,7 +54,7 @@ from pykickstart.commands.nfs import FC6_NFS as NFS
 from pykickstart.commands.nvdimm import F40_Nvdimm as Nvdimm
 from pykickstart.commands.ostreecontainer import F38_OSTreeContainer as OSTreeContainer
 from pykickstart.commands.ostreesetup import F38_OSTreeSetup as OSTreeSetup
-from pykickstart.commands.partition import F34_Partition as Partition
+from pykickstart.commands.partition import F41_Partition as Partition
 from pykickstart.commands.raid import F29_Raid as Raid
 from pykickstart.commands.realm import F19_Realm as Realm
 from pykickstart.commands.reboot import F23_Reboot as Reboot
@@ -93,7 +93,7 @@ from pykickstart.commands.logvol import F29_LogVolData as LogVolData
 from pykickstart.commands.mount import F27_MountData as MountData
 from pykickstart.commands.network import F39_NetworkData as NetworkData
 from pykickstart.commands.nvdimm import F28_NvdimmData as NvdimmData
-from pykickstart.commands.partition import F29_PartData as PartData
+from pykickstart.commands.partition import F41_PartData as PartData
 from pykickstart.commands.raid import F29_RaidData as RaidData
 from pykickstart.commands.repo import F30_RepoData as RepoData
 from pykickstart.commands.snapshot import F26_SnapshotData as SnapshotData

--- a/pyanaconda/modules/payloads/kickstart.py
+++ b/pyanaconda/modules/payloads/kickstart.py
@@ -193,17 +193,6 @@ def convert_ks_data_to_packages_selection(ks_data):
     for group in ks_data.packages.excludedGroupList:
         selection.excluded_groups.append(group.name)
 
-    for module in ks_data.module.dataList():
-        name = module.name
-
-        if module.stream:
-            name += ":" + module.stream
-
-        if module.enable:
-            selection.modules.append(name)
-        else:
-            selection.disabled_modules.append(name)
-
     return selection
 
 
@@ -248,30 +237,6 @@ def convert_packages_selection_to_ksdata(selection, ks_data):
         )
         ks_data.packages.excludedGroupList.append(ks_group)
 
-    for name in selection.modules:
-        ks_module = create_ks_module(name)
-        ks_data.module.dataList().append(ks_module)
-
-    for name in selection.disabled_modules:
-        ks_module = create_ks_module(name, enabled=False)
-        ks_data.module.dataList().append(ks_module)
-
-
-def create_ks_module(name, enabled=True):
-    """Create a new instance of a kickstart module.
-
-    :param name: a name of the module
-    :param enabled: True if the module is enabled, otherwise False
-    :return: a kickstart module object
-    """
-    names = name.split(":", maxsplit=1) + [""]
-
-    return COMMANDS.ModuleData(
-        name=names[0],
-        stream=names[1],
-        enable=enabled,
-    )
-
 
 def create_ks_group(name, include=GROUP_DEFAULT):
     """Create a new instance of a kickstart group.
@@ -302,6 +267,7 @@ class PayloadKickstartSpecification(KickstartSpecification):
     commands_data = {
         "ModuleData": COMMANDS.ModuleData,
         "RepoData": COMMANDS.RepoData,
+
     }
 
     sections = {

--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -506,44 +506,6 @@ class DNFManager(object):
         packages = self._base.sack.query().available().filter(name__glob=pattern)
         return [p.name for p in packages]
 
-    def enable_modules(self, module_specs):
-        """Mark module streams for enabling.
-
-        Mark module streams matching the module_specs list and also
-        all required modular dependencies for enabling. For specs
-        that do not specify the stream, the default stream is used.
-
-        :param module_specs: a list of specs
-        :raise MissingSpecsError: if there are missing specs
-        :raise BrokenSpecsError: if there are broken specs
-        """
-        log.debug("Enabling modules: %s", module_specs)
-
-        try:
-            module_base = dnf.module.module_base.ModuleBase(self._base)
-            module_base.enable(module_specs)
-        except dnf.exceptions.MarkingErrors as e:
-            log.error("Failed to enable modules!\n%s", str(e))
-            self._handle_marking_errors(e)
-
-    def disable_modules(self, module_specs):
-        """Mark modules for disabling.
-
-        Mark modules matching the module_specs list for disabling.
-        Only the name part of the module specification is relevant.
-
-        :param module_specs: a list of specs to disable
-        :raise MissingSpecsError: if there are missing specs
-        :raise BrokenSpecsError: if there are broken specs
-        """
-        log.debug("Disabling modules: %s", module_specs)
-        try:
-            module_base = dnf.module.module_base.ModuleBase(self._base)
-            module_base.disable(module_specs)
-        except dnf.exceptions.MarkingErrors as e:
-            log.error("Failed to disable modules!\n%s", str(e))
-            self._handle_marking_errors(e)
-
     def apply_specs(self, include_list, exclude_list):
         """Mark packages, groups and modules for installation.
 

--- a/pyanaconda/modules/payloads/payload/dnf/validation.py
+++ b/pyanaconda/modules/payloads/payload/dnf/validation.py
@@ -131,12 +131,6 @@ class CheckPackagesSelectionTask(ValidationTask):
         report = ValidationReport()
 
         with self._reported_errors(report):
-            self._dnf_manager.disable_modules(self._selection.disabled_modules)
-
-        with self._reported_errors(report):
-            self._dnf_manager.enable_modules(self._selection.modules)
-
-        with self._reported_errors(report):
             self._dnf_manager.apply_specs(self._include_list, self._exclude_list)
 
         with self._reported_errors(report):

--- a/pyanaconda/modules/payloads/payload/factory.py
+++ b/pyanaconda/modules/payloads/payload/factory.py
@@ -67,7 +67,6 @@ class PayloadFactory(object):
         if data.cdrom.seen or \
            data.harddrive.seen or \
            data.hmc.seen or \
-           data.module.seen or \
            data.nfs.seen or \
            data.url.seen or \
            data.repo.seen or \

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_validation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_validation.py
@@ -21,7 +21,7 @@ from unittest.mock import Mock, patch
 
 from pyanaconda.modules.common.structures.packages import PackagesSelectionData
 from pyanaconda.modules.payloads.payload.dnf.dnf_manager import InvalidSelectionError, \
-    MissingSpecsError, BrokenSpecsError, DNFManager
+    MissingSpecsError, DNFManager
 from pyanaconda.modules.payloads.payload.dnf.validation import CheckPackagesSelectionTask, \
     VerifyRepomdHashesTask
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_validation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_dnf_validation.py
@@ -44,8 +44,6 @@ class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
         report = task.run()
 
         dnf_manager.clear_selection.assert_called_once_with()
-        dnf_manager.disable_modules.assert_called_once_with([])
-        dnf_manager.enable_modules.assert_called_once_with([])
         dnf_manager.apply_specs.assert_called_once_with([], ["@core"])
         dnf_manager.resolve_selection.assert_called_once_with()
         assert report.get_messages() == []
@@ -65,8 +63,6 @@ class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
         report = task.run()
 
         dnf_manager.clear_selection.assert_called_once_with()
-        dnf_manager.disable_modules.assert_called_once_with([])
-        dnf_manager.enable_modules.assert_called_once_with([])
         dnf_manager.apply_specs.assert_called_once_with(
             ["@environment", "@core", "kernel"], []
         )
@@ -95,12 +91,6 @@ class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
         report = task.run()
 
         dnf_manager.clear_selection.assert_called_once_with()
-        dnf_manager.disable_modules.assert_called_once_with(
-            ["m3", "m4"]
-        )
-        dnf_manager.enable_modules.assert_called_once_with(
-            ["m1", "m2"]
-        )
         dnf_manager.apply_specs.assert_called_once_with(
             ["@e1", "@g1", "@g2", "p1", "p2"],
             ["@core", "@g3", "@g4", "p3", "p4"]
@@ -114,16 +104,14 @@ class CheckPackagesSelectionTaskTestCase(unittest.TestCase):
         selection = PackagesSelectionData()
 
         dnf_manager = Mock()
-        dnf_manager.disable_modules.side_effect = MissingSpecsError("e1")
-        dnf_manager.enable_modules.side_effect = BrokenSpecsError("e2")
         dnf_manager.apply_specs.side_effect = MissingSpecsError("e3")
         dnf_manager.resolve_selection.side_effect = InvalidSelectionError("e4")
 
         task = CheckPackagesSelectionTask(dnf_manager, selection)
         report = task.run()
 
-        assert report.error_messages == ["e2", "e4"]
-        assert report.warning_messages == ["e1", "e3"]
+        assert report.error_messages == ["e4"]
+        assert report.warning_messages == ["e3"]
 
 
 class VerifyRepomdHashesTaskTestCase(unittest.TestCase):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -466,25 +466,6 @@ class DNFKickstartTestCase(unittest.TestCase):
         payload.repositories[1].enabled = False
         self._test_kickstart(None, ks_out, expected_publish_calls=0)
 
-    def test_module_kickstart(self):
-        ks_in = """
-        module --name=nodejs
-        module --name=django --stream=1.6
-        module --name=postgresql --disable
-        module --name=mysql --stream=8.0 --disable
-        """
-        ks_out = """
-        module --name=nodejs
-        module --name=django --stream=1.6
-        module --name=postgresql --disable
-        module --name=mysql --stream=8.0 --disable
-
-        %packages
-
-        %end
-        """
-        self._test_kickstart(ks_in, ks_out)
-
     def test_packages_section_empty_kickstart(self):
         """Test the empty packages section."""
         ks_in = """

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -380,8 +380,6 @@ class ResolvePackagesTaskTestCase(unittest.TestCase):
         task.run()
 
         dnf_manager.clear_selection.assert_called_once_with()
-        dnf_manager.disable_modules.assert_called_once_with([])
-        dnf_manager.enable_modules.assert_called_once_with([])
         dnf_manager.apply_specs.assert_called_once_with(
             ["@core", "@r1", "@r2", "r4", "r5"], ["@r3", "r6"]
         )
@@ -405,7 +403,6 @@ class ResolvePackagesTaskTestCase(unittest.TestCase):
         dnf_manager = Mock()
         dnf_manager.default_environment = None
 
-        dnf_manager.disable_modules.side_effect = MissingSpecsError("e1")
         dnf_manager.apply_specs.side_effect = MissingSpecsError("e2")
 
         with pytest.raises(NonCriticalInstallationError) as cm:
@@ -413,10 +410,9 @@ class ResolvePackagesTaskTestCase(unittest.TestCase):
             task = ResolvePackagesTask(dnf_manager, selection, data)
             task.run()
 
-        expected = "e1\n\ne2"
+        expected = "e2"
         assert str(cm.value) == expected
 
-        dnf_manager.enable_modules.side_effect = BrokenSpecsError("e3")
         dnf_manager.resolve_selection.side_effect = InvalidSelectionError("e4")
 
         with pytest.raises(PayloadInstallationError) as cm:
@@ -424,7 +420,7 @@ class ResolvePackagesTaskTestCase(unittest.TestCase):
             task = ResolvePackagesTask(dnf_manager, selection, data)
             task.run()
 
-        expected = "e3\n\ne4"
+        expected = "e4"
         assert str(cm.value) == expected
 
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -31,7 +31,7 @@ from pyanaconda.modules.common.structures.packages import PackagesConfigurationD
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.common.structures.requirement import Requirement
 from pyanaconda.modules.payloads.payload.dnf.dnf_manager import DNFManager, MissingSpecsError, \
-    BrokenSpecsError, InvalidSelectionError
+    InvalidSelectionError
 from pyanaconda.modules.payloads.payload.dnf.installation import ImportRPMKeysTask, \
     SetRPMMacrosTask, DownloadPackagesTask, InstallPackagesTask, PrepareDownloadLocationTask, \
     CleanUpDownloadLocationTask, ResolvePackagesTask, UpdateDNFConfigurationTask, \

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -235,50 +235,6 @@ class DNFManagerTestCase(unittest.TestCase):
 
         assert size == Size("450 MiB")
 
-    @patch("dnf.module.module_base.ModuleBase.enable")
-    def test_enable_modules(self, module_base_enable):
-        """Test the enable_modules method."""
-        self.dnf_manager.enable_modules(
-            module_specs=["m1", "m2:latest"]
-        )
-        module_base_enable.assert_called_once_with(
-            ["m1", "m2:latest"]
-        )
-
-    @patch("dnf.module.module_base.ModuleBase.enable")
-    def test_enable_modules_error(self, module_base_enable):
-        """Test the failed enable_modules method."""
-        module_base_enable.side_effect = MarkingErrors(
-            module_depsolv_errors=["e1", "e2"]
-        )
-
-        with pytest.raises(BrokenSpecsError):
-            self.dnf_manager.enable_modules(
-                module_specs=["m1", "m2:latest"]
-            )
-
-    @patch("dnf.module.module_base.ModuleBase.disable")
-    def test_disable_modules(self, module_base_disable):
-        """Test the enable_modules method."""
-        self.dnf_manager.disable_modules(
-            module_specs=["m1", "m2:latest"]
-        )
-        module_base_disable.assert_called_once_with(
-            ["m1", "m2:latest"]
-        )
-
-    @patch("dnf.module.module_base.ModuleBase.disable")
-    def test_disable_modules_error(self, module_base_disable):
-        """Test the failed enable_modules method."""
-        module_base_disable.side_effect = MarkingErrors(
-            module_depsolv_errors=["e1", "e2"]
-        )
-
-        with pytest.raises(BrokenSpecsError):
-            self.dnf_manager.disable_modules(
-                module_specs=["m1", "m2:latest"]
-            )
-
     @patch("dnf.base.Base.install_specs")
     def test_apply_specs(self, install_specs):
         """Test the apply_specs method."""


### PR DESCRIPTION
Remove also the related tests as these are no longer relevant.

