### PR TITLE
docs: update release note about modularity deprecation

### DIFF
--- a/docs/release-notes/deprecate-modularity.rst
+++ b/docs/release-notes/deprecate-modularity.rst
@@ -2,9 +2,12 @@
 :Summary: Deprecate RPM modularity module
 
 :Description:
-    Based on the DNF team recommendation we decided to deprecate RPM modularity
-    feature in Anaconda. This is only a deprecation not removal but we will
-    reevaluate in future Fedora based on decisions from the DNF team.
+    Based on the discontinuation of RPM modularity in Fedora 39,
+    we have decided to remove the RPM modularity feature in Anaconda.
+    The 'module' kickstart command is no longer functional but can still
+    be included in the kickstart file. However, its presence will now generate a warning.
+    In a future release, this command will be completely removed,
+    and its usage will result in an error.
 
 :Links:
     - https://issues.redhat.com/browse/RHELBU-2699


### PR DESCRIPTION
This now reflects what the DeprecatedCommand in pykickstart is.

