### PR TITLE
build: stop pulling systemd as build dependency

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -61,7 +61,7 @@ BuildRequires: libxklavier-devel >= %{libxklavierver}
 BuildRequires: make
 BuildRequires: pango-devel
 BuildRequires: python3-devel
-BuildRequires: systemd
+BuildRequires: systemd-rpm-macros
 # rpm and libarchive are needed for driver disk handling
 BuildRequires: rpm-devel >= %{rpmver}
 BuildRequires: libarchive-devel >= %{libarchivever}


### PR DESCRIPTION
systemd is correctly pulled as runtime dependency.

