### PR TITLE
infra: Remove unnecessary deps from install deps

### DIFF
--- a/scripts/testing/install_dependencies.sh
+++ b/scripts/testing/install_dependencies.sh
@@ -36,16 +36,20 @@ TEMP=$(mktemp /tmp/anaconda.spec.XXXXXXX)
 # remove all problematic pieces from anaconda spec to be able to get dependencies
 sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' ./anaconda.spec.in > $TEMP
 
+# Ignore everything else than our dependencies from the spec files
+INSTALL_ONLY_DEPS="\
+python3- \
+-devel"
 # get all build requires dependencies from the spec file and strip out version
 # version could be problematic because of fedora version you are running and
 # they are mostly not important for automake
 build_deps=$(rpmspec -q --buildrequires $TEMP | sed 's/>=.*$//')
 # add also runtime dependencies for the local development
 # remove anaconda packages and also '(glibc-langpack-en or glibc-all-langpacks)' which will fail otherwise
-requires_deps=$(rpmspec -q --requires $TEMP | grep -v -E "(anaconda-|-widgets| or )" | sed 's/>=.*$//')
+requires_deps=$(rpmspec -q --requires $TEMP | grep -E "(${INSTALL_ONLY_DEPS// /|})" | sed 's/>=.*$//')
 
 # shellcheck disable=SC2068
-dnf install $@ $build_deps $requires_deps  # do NOT quote the list or it falls apart
+dnf install --setopt=install_weak_deps=False $@ $build_deps $requires_deps  # do NOT quote the list or it falls apart
 
 # clean up the temp file
 rm $TEMP

--- a/scripts/testing/install_dependencies.sh
+++ b/scripts/testing/install_dependencies.sh
@@ -29,7 +29,7 @@
 set -eu
 
 # shellcheck disable=SC2068
-dnf install $@ make rpm-build python3-polib
+dnf install $@ make rpm-build python3-polib git
 
 TEMP=$(mktemp /tmp/anaconda.spec.XXXXXXX)
 


### PR DESCRIPTION
One of the biggest use cases for the install_dependencies.sh script is to get dependencies to the container for development easily. However, container management services are not usable from the container directly and are not helpful for development (just development dependency).

Having these in the container could block easy way to call binaries from inside of the container in similar cases like `distrobox-host-exec` which enables you to call container commands (allows our make commands) from inside of the distrobox container.
Others are just wrong to be installed on developer machine for example gnome-kiosk.

Replacement of https://github.com/rhinstaller/anaconda/pull/5844 .