### PR TITLE
Ignore all storage errors when trying to activate swaps

### DIFF
--- a/pyanaconda/modules/storage/devicetree/fsset.py
+++ b/pyanaconda/modules/storage/devicetree/fsset.py
@@ -22,7 +22,8 @@ import time
 from blivet import blockdev
 from blivet.devices import NoDevice, DirectoryDevice, NFSDevice, FileDevice, MDRaidArrayDevice, \
     NetworkStorageDevice, OpticalDevice
-from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError, SwapSpaceError
+from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError, SwapSpaceError, \
+    StorageError
 from blivet.formats import get_format, get_device_format_class
 from blivet.storage_log import log_exception_info
 
@@ -527,7 +528,8 @@ class FSSet(object):
                 try:
                     device.setup()
                     device.format.setup()
-                except (SwapSpaceError, blockdev.SwapActivateError) as e:
+                except (SwapSpaceError, blockdev.SwapActivateError,
+                        StorageError, blockdev.BlockDevError) as e:
                     log.error("Failed to activate swap on '%s': %s", device.name, str(e))
                     break
                 else:


### PR DESCRIPTION
Anaconda tries to activate all swap devices during installation, currently we ignore errors related to the swap itself, but the activation can also fail because the device activation failed so we should ignore all storage errors in this situation.

Resolves: RHEL-56591

RHEL 10 port of #5858