### PR TITLE
Ignore all storage errors when trying to activate swaps

### DIFF
--- a/pyanaconda/modules/storage/devicetree/fsset.py
+++ b/pyanaconda/modules/storage/devicetree/fsset.py
@@ -25,7 +25,8 @@ from gi.repository import BlockDev as blockdev
 
 from blivet.devices import NoDevice, DirectoryDevice, NFSDevice, FileDevice, MDRaidArrayDevice, \
     NetworkStorageDevice, OpticalDevice
-from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError
+from blivet.errors import UnrecognizedFSTabEntryError, FSTabTypeMismatchError, SwapSpaceError, \
+    StorageError
 from blivet.formats import get_format, get_device_format_class
 from blivet.storage_log import log_exception_info
 
@@ -530,8 +531,8 @@ class FSSet(object):
                 try:
                     device.setup()
                     device.format.setup()
-                except (blockdev.SwapOldError, blockdev.SwapSuspendError,
-                        blockdev.SwapUnknownError, blockdev.SwapPagesizeError) as e:
+                except (SwapSpaceError, blockdev.SwapError,
+                        StorageError, blockdev.BlockDevError) as e:
                     log.error("Failed to activate swap on '%s': %s", device.name, str(e))
                     break
                 else:


### PR DESCRIPTION
Anaconda tries to activate all swap devices during installation, currently we ignore errors related to the swap itself, but the activation can also fail because the device activation failed so we should ignore all storage errors in this situation.

Resolves: RHEL-55922

RHEL 9 port of #5858