### PR TITLE
storage: make _get_windows_data more robust

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -527,12 +527,13 @@ class DeviceTreeViewer(ABC):
                 continue
 
             device = self._get_device(blivet_device.name)
-            if str(device.part_type_uuid) == EFI_PARTITION_TYPE:
-                efi_partition = device
-                continue
+            if device and device.parted_partition:
+                if str(device.part_type_uuid) == EFI_PARTITION_TYPE:
+                    efi_partition = device
+                    continue
 
-            if str(device.part_type_uuid) in WINDOWS_PARTITION_TYPES:
-                windows_data.devices.append(device.name)
+                if str(device.part_type_uuid) in WINDOWS_PARTITION_TYPES:
+                    windows_data.devices.append(device.name)
 
         if len(windows_data.devices) > 0:
             if efi_partition is not None:


### PR DESCRIPTION
It is possible that the device is not found or does not have the parted_partition attrubute. I hit the issue with non-destructive webui tests which reuse storage after cleanups (see the journal of https://cockpit-logs.us-east-1.linodeobjects.com/pull-424-3ec2be5b-20240903-133345-fedora-rawhide-boot-anaconda-pr-5814-rhinstaller-anaconda-webui/log.html) so in general this could be an issue in environments with more involved storage configuration history. Let's be safer here.

```
  File "/usr/lib/python3.13/site-packages/dasbus/server/handler.py", line 265, in _handle_call
    return handler(*parameters, **additional_args)
  File "/usr/lib64/python3.13/site-packages/pyanaconda/modules/storage/devicetree/viewer_interface.py", line 194, in GetExistingSystems
    return OSData.to_structure_list(self.implementation.get_existing_systems())
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.13/site-packages/pyanaconda/modules/storage/devicetree/viewer.py", line 493, in get_existing_systems
    windows_data = self._get_windows_data()
  File "/usr/lib64/python3.13/site-packages/pyanaconda/modules/storage/devicetree/viewer.py", line 530, in _get_windows_data
    if str(device.part_type_uuid) == EFI_PARTITION_TYPE:
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/blivet/threads.py", line 49, in run_with_lock
    return m(*args, **kwargs)
  File "/usr/lib/python3.13/site-packages/blivet/devices/partition.py", line 380, in part_type_uuid
    if hasattr(parted.Partition, "type_uuid") and self.parted_partition.type_uuid:
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'type_uuid'

```