### PR TITLE
Fix scheduling actions in reclaim space dialog (#2311936)

### DIFF
--- a/pyanaconda/ui/gui/spokes/lib/resize.py
+++ b/pyanaconda/ui/gui/spokes/lib/resize.py
@@ -552,10 +552,10 @@ class ResizeDialog(GUIObject):
             log.debug("Preserve %s.", obj.name)
         elif obj.action == _(SHRINK):
             log.debug("Shrink %s to %s.", obj.name, Size(obj.target))
-            self._device_tree.ShrinkDevice(obj.name, obj.target)
+            self._device_tree.ShrinkDevice(obj.device_id, obj.target)
         elif obj.action == _(DELETE):
             log.debug("Remove %s.", obj.name)
-            self._device_tree.RemoveDevice(obj.name)
+            self._device_tree.RemoveDevice(obj.device_id)
 
     def on_resize_clicked(self, *args):
         rows = []


### PR DESCRIPTION
We need to use the device ID here, not the name, so the backend can remove or resize the correct device.