### PR TITLE
Remove deprecated `method` boot option

### DIFF
--- a/docs/boot-options.rst
+++ b/docs/boot-options.rst
@@ -822,13 +822,6 @@ Deprecated Options
 These options should still be accepted by the installer, but they are
 deprecated and may be removed soon.
 
-.. method:
-
-method
-^^^^^^
-
-This is an alias for `inst.repo`_.
-
 .. dns:
 
 dns
@@ -901,6 +894,11 @@ blacklist, nofirewire
 ``modprobe.blacklist=<mod1>,<mod2>...``
 
 You can add the firewire module to a denylist with ``modprobe.blacklist=firewire_ohci``.
+
+method:
+^^^^^^
+
+Use `inst.repo`_ instead.
 
 serial
 ^^^^^^

--- a/dracut/parse-anaconda-options.sh
+++ b/dracut/parse-anaconda-options.sh
@@ -72,7 +72,7 @@ check_removed_arg askmethod "Use an appropriate 'inst.repo=' argument instead."
 check_removed_arg asknetwork "Use an appropriate 'ip=' argument instead."
 
 # repo
-check_depr_arg "method=" "repo=%s"
+check_removed_arg "inst.method" "Use an appropriate 'inst.repo=' argument instead."
 
 # mpath
 check_removed_arg "inst.nompath"

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -460,9 +460,6 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help="This option is deprecated.")
     ap.add_argument("--multilib", dest="multiLib", action="store_true", default=False,
                     help=help_parser.help_text("multilib"))
-
-    ap.add_argument("-m", "--method", dest="method", default=None, metavar="METHOD",
-                    help=help_parser.help_text("method"))
     ap.add_argument("--repo", dest="method", default=None, metavar="REPO_URL",
                     help=help_parser.help_text("repo"))
     ap.add_argument("--stage2", dest="stage2", default=None, metavar="STAGE2_URL",

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -68,8 +68,8 @@ class DNFPayload(MigratedDBusPayload):
     def _set_default_source(self, opts):
         """Set the default source.
 
-        Set the source based on opts.method if it isn't already set
-        - opts.method is currently set by command line/boot options.
+        Set the source based on opts.repo if it isn't already set
+        - opts.repo is currently set by command line/boot options.
 
         Otherwise, use the source provided at a specific mount point
         by Dracut if there is any.
@@ -89,9 +89,9 @@ class DNFPayload(MigratedDBusPayload):
         if self.proxy.Sources:
             log.debug("The DNF source is already set.")
 
-        elif opts.method:
+        elif opts.repo:
             log.debug("Use the DNF source from opts.")
-            source_proxy = self._create_source_from_url(opts.method)
+            source_proxy = self._create_source_from_url(opts.repo)
             set_source(self.proxy, source_proxy)
 
         elif verify_valid_repository(DRACUT_REPO_DIR):


### PR DESCRIPTION
This is deprecated ~10 years already.

https://issues.redhat.com/browse/INSTALLER-1818