### PR TITLE
Remove support for i686 builds

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -2,6 +2,7 @@ Summary: Graphical system installer
 Name:    anaconda
 Version: @PACKAGE_VERSION@
 Release: @PACKAGE_RELEASE@%{?dist}
+ExcludeArch: %{ix86}
 License: GPL-2.0-or-later
 URL:     http://fedoraproject.org/wiki/Anaconda
 
@@ -194,11 +195,11 @@ Requires: libblockdev-lvm-dbus
 # active directory/freeipa join support
 Requires: realmd
 Requires: isomd5sum >= %{isomd5sumver}
-%ifarch %{ix86} x86_64
+%ifarch x86_64
 Recommends: fcoe-utils >= %{fcoeutilsver}
 %endif
 # likely HFS+ resize support
-%ifarch %{ix86} x86_64
+%ifarch x86_64
 %if ! 0%{?rhel}
 Requires: hfsplus-tools
 %endif
@@ -240,7 +241,7 @@ Summary: Installation image specific dependencies
 # Pull in most stuff with the -env- metapackage
 Requires: anaconda-install-env-deps = %{version}-%{release}
 # Require storage things that are only recommended in -env-
-%ifarch %{ix86} x86_64
+%ifarch x86_64
 Requires: fcoe-utils >= %{fcoeutilsver}
 %endif
 # only WeakRequires elsewhere and not guaranteed to be present

--- a/docs/release-notes/drop-i686-builds.rst
+++ b/docs/release-notes/drop-i686-builds.rst
@@ -1,0 +1,13 @@
+:Type: Packaging
+:Summary: Remove i686 builds
+
+:Description:
+    Anaconda is still (not explicitly) supporting i686 builds even thought
+    that Fedora dropped the support a long time ago.
+
+    Anaconda now excludes the i686 builds explicitly in Anaconda to allow
+    our dependent packages drop of the i686 build.
+
+:Links:
+    - https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
+    - https://github.com/coreos/fedora-coreos-tracker/issues/1716


### PR DESCRIPTION
Fedora does not support this anymore and we are currently blocking other packages to drop this dependency because we require them.

See:
https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval https://github.com/coreos/fedora-coreos-tracker/issues/1716

Suggested-by: Aashish Radhakrishnan