### PR TITLE
Fixes for unblocking RHEL-10 container builds

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -39,6 +39,10 @@ COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 RUN set -ex; \
   # Update the base container packages
   dnf update -y; \
+  # FIXME
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2295428
+  # https://issues.redhat.com/browse/RHEL-46558
+  # Remove selinux-policy targeted when the rhbz / RHEL issue above is fixed
   # Install rest of the dependencies
   dnf install -y \
   /usr/bin/xargs \
@@ -47,6 +51,7 @@ RUN set -ex; \
   bzip2 \
   rpm-ostree \
   python3-pip \
+  selinux-policy-targeted \
   rsync \
   # Need to have restorecon for the tests execution
   policycoreutils; \

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -59,7 +59,8 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         data = PackagesConfigurationData()
 
         macros = [
-            ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}')
+            ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts')
         ]
 
         task = self._run_task(data)
@@ -73,6 +74,7 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         macros = [
             ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
             ('_excludedocs', '1'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts')
         ]
 
         task = self._run_task(data)
@@ -86,6 +88,7 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         macros = [
             ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
             ('_install_langs', 'en:es'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts')
         ]
 
         task = self._run_task(data)
@@ -99,6 +102,7 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         macros = [
             ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
             ('_install_langs', '%{nil}'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts')
         ]
 
         task = self._run_task(data)

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -169,7 +169,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
     def test_get_supported_raid_levels(self):
         """Test GetSupportedRaidLevels."""
         assert self.interface.GetSupportedRaidLevels(DEVICE_TYPE_MD) == \
-            ['linear', 'raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6']
+            ['raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6']
 
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.get_format')
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.platform', new_callable=EFI)


### PR DESCRIPTION
This will unblock container refreshes.
This affects also RHEL.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2295428
Related: https://issues.redhat.com/browse/RHEL-46558

Cherry-picked from master branch commit: 56e02693154ff7c1d91ae914592e18cbd9bb3ab7.
