### PR TITLE
Fixes for unblocking RHEL-9 container builds

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -16,6 +16,11 @@ RUN set -ex; \
 # Prepare environment and install build dependencies
 RUN set -e; \
   dnf update -y; \
+  # FIXME
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2295428
+  # https://issues.redhat.com/browse/RHEL-46558
+  # Remove selinux-policy targeted when the rhbz / RHEL issue above is fixed
+  # Install rest of the dependencies
   dnf install -y \
   curl-minimal \
   /usr/bin/xargs \
@@ -32,7 +37,8 @@ RUN set -e; \
   python3-lxml \
   policycoreutils \
   python3-gobject-base \
-  python3-pip; \
+  python3-pip \
+  selinux-policy-targeted; \
   curl -L https://raw.githubusercontent.com/rhinstaller/anaconda/${git_branch}/anaconda.spec.in | sed 's/@PACKAGE_VERSION@/0/; s/@PACKAGE_RELEASE@/0/; s/%{__python3}/python3/' > /tmp/anaconda.spec; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   rpmspec -q --requires /tmp/anaconda.spec | grep -v anaconda | xargs -d '\n' dnf install -y; \

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -49,7 +49,8 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         data = PackagesConfigurationData()
 
         macros = [
-            ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}')
+            ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts')
         ]
 
         task = self._run_task(data)
@@ -63,6 +64,7 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         macros = [
             ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
             ('_excludedocs', '1'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts')
         ]
 
         task = self._run_task(data)
@@ -76,6 +78,7 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         macros = [
             ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
             ('_install_langs', 'en,es'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts')
         ]
 
         task = self._run_task(data)
@@ -89,6 +92,7 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         macros = [
             ('__dbi_htconfig', 'hash nofsync %{__dbi_other} %{__dbi_perms}'),
             ('_install_langs', '%{nil}'),
+            ('__file_context_path', '/etc/selinux/targeted/contexts/files/file_contexts')
         ]
 
         task = self._run_task(data)


### PR DESCRIPTION
This will unblock container refreshes.
This affects also RHEL.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2295428
Related: https://issues.redhat.com/browse/RHEL-46558

Cherry-picked from master branch commit: 56e02693154ff7c1d91ae914592e18cbd9bb3ab7.

