### PR TITLE
webui: Move webui-desktop in libexec to our subdirectory

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -160,7 +160,7 @@ start_anaconda_web_ui() {
     fi
     # early execution of Firefox to reduce starting time
     mkdir -p /run/anaconda
-    /usr/libexec/webui-desktop -t live /cockpit/@localhost/anaconda-webui/index.html &
+    /usr/libexec/anaconda/webui-desktop -t live /cockpit/@localhost/anaconda-webui/index.html &
     echo -n "$!" > /run/anaconda/webui_script.pid
 }
 

--- a/pyanaconda/ui/webui/__init__.py
+++ b/pyanaconda/ui/webui/__init__.py
@@ -141,7 +141,7 @@ class CockpitUserInterface(ui.UserInterface):
         # FIXME: We probably want to move this to early execution similar to what we have on live
         profile_name = FIREFOX_THEME_DEFAULT
 
-        proc = startProgram(["/usr/libexec/webui-desktop",
+        proc = startProgram(["/usr/libexec/anaconda/webui-desktop",
                              "-t", profile_name, "-r", str(int(self.remote)),
                              "/cockpit/@localhost/anaconda-webui/index.html"],
                             reset_lang=False)

--- a/tests/unit_tests/pyanaconda_tests/ui/test_webui.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_webui.py
@@ -195,7 +195,7 @@ class SimpleWebUITestCase(unittest.TestCase):
             self._prepare_for_live_testing(pid_file, backend_file, remote=1)
             self.intf.run()
 
-            mocked_startProgram.assert_called_once_with(["/usr/libexec/webui-desktop",
+            mocked_startProgram.assert_called_once_with(["/usr/libexec/anaconda/webui-desktop",
                                                          "-t", FIREFOX_THEME_DEFAULT, "-r", "1",
                                                          "/cockpit/@localhost/anaconda-webui/index.html"],
                                                         reset_lang=False)
@@ -218,7 +218,7 @@ class SimpleWebUITestCase(unittest.TestCase):
             self._prepare_for_live_testing(pid_file, backend_file)
             self.intf.run()
 
-            mocked_startProgram.assert_called_once_with(["/usr/libexec/webui-desktop",
+            mocked_startProgram.assert_called_once_with(["/usr/libexec/anaconda/webui-desktop",
                                                          "-t", FIREFOX_THEME_DEFAULT, "-r", "0",
                                                          "/cockpit/@localhost/anaconda-webui/index.html"],
                                                         reset_lang=False)


### PR DESCRIPTION
Cherry-picked from master commit
bd870aae6c0c6ead569de4563ca241ee879e8588.

(I want to update Web UI in fedora-41 for fixing some bugs but and this is needed)