### PR TITLE
build: rpmlint fix: E: explicit-lib-dependency libselinux-python3

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -95,7 +95,7 @@ Requires: python3-meh >= %{mehver}
 %if 0%{?rhel} < 10 || 0%{?fedora}
 Requires: libreport-anaconda >= %{libreportanacondaver}
 %endif
-Requires: libselinux-python3
+Requires: python3-libselinux
 Requires: python3-rpm >= %{rpmver}
 Requires: python3-pyparted >= %{pypartedver}
 Requires: python3-requests


### PR DESCRIPTION
The correct python binding for libselinux is the updated. The reason it was working was a virtual provides [1].

[1] https://src.fedoraproject.org/rpms/libselinux/blob/rawhide/f/libselinux.spec#_63