### PR TITLE
build: rpmlint fix: disable the generation of the debuginfo  for core package

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -81,6 +81,9 @@ Requires: anaconda-tui = %{version}-%{release}
 The anaconda package is a metapackage for the Anaconda installer.
 
 %package core
+# Since the binaries in anaconda-core are shell or Python scripts,
+# there's no need to generate a debuginfo package
+%define debug_package %{nil}
 Summary: Core of the Anaconda installer
 # core/signal.py is under MIT
 License: GPL-2.0-or-later AND MIT


### PR DESCRIPTION
The error E: no-binary from rpmlint arises because the anaconda-core-debuginfo package expects to contain debug symbols for compiled binaries, but the package contains only scripts (Python, shell).
To fix the issue, disable the generation of the debuginfo package.

