### PR TITLE
Fix check for biosboot partition in GRUB2.check

### DIFF
--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -475,13 +475,12 @@ class GRUB2(BootLoader):
         # If the first partition starts too low and there is no biosboot partition show an error.
         error_msg = None
         biosboot = False
-        parts = self.stage1_disk.format.parted_disk.partitions
-        for p in parts:
-            if p.getFlag(PARTITION_BIOS_GRUB):
+        for p in self.stage1_disk.children:
+            if p.format.type == "biosboot" or p.parted_partition.getFlag(PARTITION_BIOS_GRUB):
                 biosboot = True
                 break
 
-            start = p.geometry.start * p.disk.device.sectorSize
+            start = p.parted_partition.geometry.start * p.parted_partition.disk.device.sectorSize
             if start < min_start:
                 error_msg = _("%(deviceName)s may not have enough space for grub2 to embed "
                               "core.img when using the %(fsType)s file system on %(deviceType)s") \


### PR DESCRIPTION
For partitions scheduled to be created the PARTITION_BIOS_GRUB flag is not yet set so we can't use it to check for the biosboot partition presence.

Resolves: RHEL-55922

RHEL 9 backport of #5874