### PR TITLE
infra: Fix rpmlint conffile-without-noreplace-flag warning

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -425,12 +425,15 @@ rm -rf \
 %exclude %{python3_sitearch}/pyanaconda/ui/gui/*
 %exclude %{python3_sitearch}/pyanaconda/ui/tui/*
 %{_bindir}/anaconda-cleanup
+# Installer configuration files aren’t updated post-installation,
+# so the noreplace flag doesn't offer a practical benefit in this context.
+# It is added to silence the rpmlint conffile-without-noreplace-flag warning.
 %dir %{_sysconfdir}/%{name}
-%config %{_sysconfdir}/%{name}/*
+%config(noreplace) %{_sysconfdir}/%{name}/*
 %dir %{_sysconfdir}/%{name}/conf.d
-%config %{_sysconfdir}/%{name}/conf.d/*
+%config(noreplace) %{_sysconfdir}/%{name}/conf.d/*
 %dir %{_sysconfdir}/%{name}/profile.d
-%config %{_sysconfdir}/%{name}/profile.d/*
+%config(noreplace) %{_sysconfdir}/%{name}/profile.d/*
 
 %if %{with live}
 # do not provide the live subpackage on RHEL


### PR DESCRIPTION
This commit addresses "conffile-without-noreplace-flag" rpmlit warnings reported in spec file.
Now all anaconda related configuration files are explicite marked to not overwrite user modified files.

