### PR TITLE
infra: tests: add rpmlint to existing rpm tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -336,7 +336,9 @@ container-rpm-test:
 	$(RPM_NAME):$(CI_TAG) \
 	sh -exc ' \
 	    /run-build-and-arg make run-rpm-tests-only; \
-	    dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm'
+	    dnf install -y /tmp/anaconda/result/build/01-rpm-build/*.rpm; \
+	    cd /tmp/anaconda; \
+	    rpmlint *.spec.in result/build/01-rpm-build/*.rpm --config rpmlint.toml'
 
 container-rpms:
 	@./scripts/testing/check-container-age.sh "$(RPM_NAME):$(CI_TAG)"

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -42,7 +42,8 @@ RUN set -ex; \
   python3-pocketlint \
   /usr/bin/xargs \
   rsync \
-  rpm-build; \
+  rpm-build \
+  rpmlint; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     BRANCH="${git_branch}"; \
     if [ $BRANCH == "master" ]; then \


### PR DESCRIPTION
rpmlint is used in Fedora dist git in the release process. Having it included in the upstream CI will allow us early detection of the potential linter issues in spec / rpms.

- [x] Blocked on fixing the remaining RPM lint issues

