### PR TITLE
Fix journal redirect on systems without journal

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -32,16 +32,6 @@ import pid
 
 from pyanaconda.modules.common.structures.rescue import RescueData
 
-# Redirect Anaconda main process stderr to Journal,
-# as otherwise this could end up writing all over
-# the TUI on TTY1.
-
-# create an appropriately named Journal writing stream
-from systemd import journal
-anaconda_stderr_stream = journal.stream("anaconda", priority=journal.LOG_ERR)
-# redirect stderr of this process to the stream
-os.dup2(anaconda_stderr_stream.fileno(), sys.stderr.fileno())
-
 
 def exitHandler(rebootData):
     # Clear the list of watched PIDs.


### PR DESCRIPTION
We redirect all the error messages from stderr to journal in the main Anaconda process. This is mainly covering errors and warnings from GTK UI.

However, this code returns FileNotFound on systems which don't have journal enabled.

To fix this move this code under our existing logic for logging to journal which is enabled only on HW installations.