### PR TITLE
Update makefile clean file list with RPMs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,10 @@ MAINTAINERCLEANFILES =	Makefile.in config.guess config.h.in config.sub \
 						py-compile m4/* po/Makefile.in.in po/Rules-quot \
 						test-driver
 
-CLEANFILES = *~
+CLEANFILES = *~ 
+CLEANFILES += $(RPM_BUILD_DIR)/*.rpm
+CLEANFILES += $(SRPM_BUILD_DIR)/*.rpm
+CLEANFILES += *.tar.bz2
 
 dist_noinst_DATA      = $(PACKAGE_NAME).spec
 


### PR DESCRIPTION
`make rpms` target is producing *.rpm files in two directories:
- result/build/00-srpm-build
- result/build/01-rpm-build

This commit add those RPM files to list of the files which will be removed during `make clean`

