### PR TITLE
logging: fix the length limit of packages info dbg message

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -241,7 +241,7 @@ if __name__ == "__main__":
 
     log.info("%s %s", sys.argv[0], util.get_anaconda_version_string(build_time_version=True))
     # Do not exceed default 8K limit on message length in rsyslog
-    for log_line in util.get_image_packages_info(max_string_chars=8096-100):
+    for log_line in util.get_image_packages_info(max_string_chars=8096-120):
         log.debug("Image packages: %s", log_line)
 
     if opts.updates_url:


### PR DESCRIPTION
Should fix

23:22:51,735 WARNING rsyslogd:message too long (8104) with configured size 8096, begin of message is: anaconda: main: Image packages: fuse3-libs-3.16.2-4.fc41.x86_64 gawk-5.3.0-4.fc4 [v8.2408.0-2.fc42 try https://www.rsyslog.com/e/2445 ]

Fixup of https://github.com/rhinstaller/anaconda/pull/5314