### PR TITLE
Suppress tracebacks when SIGTERM signal processing

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -289,9 +289,18 @@ if __name__ == "__main__":
     from pyanaconda.anaconda import Anaconda
     anaconda = Anaconda()
 
+    def terminate(num, frame):
+        try:
+            # This will execute atexit function which might fail because of logging exception
+            # which shouldn't be used in signal handlers. However, it's during the shutdown
+            # process so let's suppress this to avoid issues.
+            sys.exit(1)
+        except Exception as ex:
+            print("Error raised when terminating Anaconda: \n %s", ex)
+
     # reset python's default SIGINT handler
     signal.signal(signal.SIGINT, signal.SIG_IGN)
-    signal.signal(signal.SIGTERM, lambda num, frame: sys.exit(1))
+    signal.signal(signal.SIGTERM, terminate)
 
     # synchronously-delivered signals such as SIGSEGV and SIGILL cannot be handled properly from
     # Python, so install signal handlers from the faulthandler stdlib module.

--- a/anaconda.py
+++ b/anaconda.py
@@ -108,6 +108,8 @@ def exitHandler(rebootData):
         else:  # reboot action is KS_REBOOT or None
             util.execWithRedirect("systemctl", ["--no-wall", "reboot"], do_preexec=False)
 
+    print("End of atexit!", file=sys.stderr)
+
 
 def parse_arguments(argv=None, boot_cmdline=None):
     """Parse command line/boot options and arguments.
@@ -296,7 +298,7 @@ if __name__ == "__main__":
             # process so let's suppress this to avoid issues.
             sys.exit(1)
         except Exception as ex:
-            print("Error raised when terminating Anaconda: \n %s", ex)
+            print("Error raised when terminating Anaconda: \n %s", ex, file=sys.stderr)
 
     # reset python's default SIGINT handler
     signal.signal(signal.SIGINT, signal.SIG_IGN)


### PR DESCRIPTION
This is a workaround for
https://github.com/rhinstaller/kickstart-tests/issues/1296

where we are most likely hitting issue that logging is not safe to use in the signal handlers because logging is not reentrant safe. To avoid failures in KS tests and also test if this is the correct issue, let's use this workaround.

The ideal fix should be to not use logging in atexit call which might be tricky to resolve and also we will use a lot of log outputs.