### PR TITLE
Log stderr to journal only on supported platforms

### DIFF
--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -241,6 +241,9 @@ class AnacondaLog(object):
         Redirect Anaconda main process stderr to Journal, as otherwise this could end up writing
         all over the TUI on TTY1.
         """
+        if not self.write_to_journal:
+            return
+
         # create an appropriately named Journal writing stream
         anaconda_stderr_stream = journal.stream("anaconda", priority=journal.LOG_ERR)
         # redirect stderr of this process to the stream


### PR DESCRIPTION
On my previous commit c9f931f773dadf9e46cfd7d5c56e66b56c08b844 I forgot this part :(

Without it, the stderr is still redirected to journal all the time.