### PR TITLE
workflows: Retry failed test by default in kickstart test GH workflow

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -280,6 +280,7 @@ jobs:
         run: |
           cat <<EOF > settings.ini
           [kickstart_test]
+          retry_on_failure=True
           kstest_local_repo=${{ github.workspace }}/kickstart-tests
           [library]
           directPath=${{ github.workspace }}/kickstart-tests/testlib

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -274,6 +274,7 @@ jobs:
         run: |
           cat <<EOF > settings.ini
           [kickstart_test]
+          retry_on_failure=True
           kstest_local_repo=${{ github.workspace }}/kickstart-tests
           [library]
           directPath=${{ github.workspace }}/kickstart-tests/testlib


### PR DESCRIPTION
More and more often we are running the whole kickstart test suite (or big set of tests) on a PR, for example:

/kickstart-test --testtype network

/kickstart-test --skip-testtypes none

There is quite a big chance of hitting a flake, so retry failing tests by default so there is no need to check if the failures are flakes or re-run the failed tests manually.