### PR TITLE
Fix checking whether a disk can be cleared during autopart

### DIFF
--- a/pyanaconda/modules/storage/disk_initialization/configuration.py
+++ b/pyanaconda/modules/storage/disk_initialization/configuration.py
@@ -50,7 +50,7 @@ class DiskInitializationConfig(object):
         for disk in device.disks:
             # this will not include disks with hidden formats like multipath
             # and firmware raid member disks
-            if self.drives_to_clear and disk.name not in self.drives_to_clear:
+            if self.drives_to_clear and disk.device_id not in self.drives_to_clear:
                 return False
 
         if not self.clear_non_existent:
@@ -113,7 +113,7 @@ class DiskInitializationConfig(object):
             return False
 
         if self.initialization_mode == CLEAR_PARTITIONS_LIST and \
-           device.name not in self.devices_to_clear:
+           device.device_id not in self.devices_to_clear:
             return False
 
         return True


### PR DESCRIPTION
One more issue related to the device ID change. This does not happen with "normal" disks because we use name as device ID for them so this is triggered on a system with a BIOS RAID array.

Resolves: rhbz#2317287