### PR TITLE
network: do not crash on destroyed device object in GUI

### DIFF
--- a/pyanaconda/ui/gui/spokes/network.py
+++ b/pyanaconda/ui/gui/spokes/network.py
@@ -946,7 +946,9 @@ class NetworkControlBox(GObject.GObject):
             device = self.client.get_device_by_iface(dev_cfg.device_name)
             if device:
                 vlanid = device.get_vlan_id()
-                parent = device.get_parent().get_iface()
+                parent = device.get_parent() or ""
+                if parent:
+                    parent = parent.get_iface()
             else:
                 con = self.client.get_connection_by_uuid(dev_cfg.connection_uuid)
                 if con:


### PR DESCRIPTION
Resolves: RHEL-56141

This is port of https://github.com/rhinstaller/anaconda/pull/5482 to RHEL 10.