### PR TITLE
network: add warning for kickstart network configuration when running…

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -39,7 +39,7 @@ from requests_ftp import FTPAdapter
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.path import make_directories, open_with_perm, join_paths
 from pyanaconda.core.constants import DRACUT_SHUTDOWN_EJECT, \
-    IPMI_ABORTED, PACKAGES_LIST_FILE
+    IPMI_ABORTED, PACKAGES_LIST_FILE, DRACUT_REPO_DIR
 from pyanaconda.core.live_user import get_live_user
 from pyanaconda.errors import RemovedModuleError
 
@@ -911,3 +911,13 @@ def get_image_packages_info(max_string_chars=0):
                     break
                 info_lines.append(' '.join(line.strip() for line in lines))
     return info_lines
+
+
+def is_stage2_on_nfs():
+    """Is the installation running from image mounted via NFS?"""
+    for line in open("/proc/mounts").readlines():
+        values = line.split()
+        if len(values) > 2:
+            if values[1] == DRACUT_REPO_DIR and values[2] in ("nfs", "nfs4"):
+                return True
+    return False

--- a/pyanaconda/network.py
+++ b/pyanaconda/network.py
@@ -258,6 +258,12 @@ def initialize_network():
     log.debug("Devices found: %s",
               [dev.device_name for dev in get_supported_devices()])
 
+    if util.is_stage2_on_nfs() and network_proxy.Kickstarted:
+        msg = "Using kickstart network configuration with installer image (stage2) provided " \
+            "via nfs server can freeze the installation."
+        log.warning(msg)
+        print("WARNING:", msg)
+
     run_network_initialization_task(network_proxy.ApplyKickstartWithTask())
     run_network_initialization_task(network_proxy.DumpMissingConfigFilesWithTask())
 


### PR DESCRIPTION
… from nfs

Resolves: RHEL-35250

Adds warning to tty1 and a log message.
![Screenshot from 2024-10-22 16-06-16](https://github.com/user-attachments/assets/7e045a54-6fa2-42b4-b14d-2573b6512de0)

