### PR TITLE
Fix permission errors from liveinst exit

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -26,6 +26,7 @@ if [ "$(id -u)" -ne 0 ]; then
     xhost +si:localuser:root
     unset XAUTHORITY
     pkexec "$0" "$@"
+    exit $?
 fi
 
 # pkexec clears DBUS_SESSION_BUS_ADDRESS from environment


### PR DESCRIPTION
We switched to policykit to run Anaconda on Live media where it is started by liveuser instead of root. However, the pkexec will run the same script as root and after anaconda ends, the original script will continue execution as liveuser which is expected to raise permission errors.

To fix this, stop the script execution after the pkexec call.

Resolves: rhbz#2314607

Reviewed-by: Ray Strode (halfline)