### PR TITLE
network: handle autoconnections policy for rhel upstream

### DIFF
--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -28,6 +28,7 @@ dist_systemd_DATA = anaconda.service \
                     anaconda-sshd.service \
                     anaconda-nm-config.service \
                     anaconda-nm-disable-autocons.service \
+                    anaconda-nm-disable-autocons-rhel.service \
                     anaconda-pre.service \
                     anaconda-s390-device-config-import.service \
                     anaconda-fips.service

--- a/data/systemd/anaconda-generator
+++ b/data/systemd/anaconda-generator
@@ -43,4 +43,5 @@ done
 
 ln -sf "$systemd_dir/anaconda-nm-config.service" "$target_dir/anaconda-nm-config.service"
 ln -sf "$systemd_dir/anaconda-nm-disable-autocons.service" "$target_dir/anaconda-nm-disable-autocons.service"
+ln -sf "$systemd_dir/anaconda-nm-disable-autocons-rhel.service" "$target_dir/anaconda-nm-disable-autocons-rhel.service"
 ln -sf "$systemd_dir/anaconda-pre.service" "$target_dir/anaconda-pre.service"

--- a/data/systemd/anaconda-nm-disable-autocons-rhel.service
+++ b/data/systemd/anaconda-nm-disable-autocons-rhel.service
@@ -1,0 +1,10 @@
+[Unit]
+ConditionKernelCommandLine=|ip
+ConditionKernelCommandLine=|inst.ks
+ConditionOSRelease=ID=rhel
+Description=NetworkManager autoconnections configuration for Anaconda installation environment for RHEL
+Before=NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/anaconda-nm-disable-autocons


### PR DESCRIPTION
The added shared service will be run only on rhel systems.

Resolves: RHEL-53196