### PR TITLE
Redirect only GLib loggers to Journal

### DIFF
--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -252,6 +252,12 @@ class AnacondaLog(object):
         # create functions that convert the messages coming
         # from GLib into something that fits to the anaconda logging format
         def log_adapter(domain, level, message, user_data):
+            if level in (LogLevelFlags.LEVEL_ERROR,
+                         LogLevelFlags.LEVEL_CRITICAL):
+                self.anaconda_logger.error("GLib: %s", message)
+            elif level is LogLevelFlags.LEVEL_WARNING:
+                self.anaconda_logger.warning("GLib: %s", message)
+
             self.anaconda_logger.debug("GLib: %s", message)
 
         def structured_log_adapter(level, fields, field_count, user_data):

--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -1,7 +1,7 @@
 #
 # anaconda_logging.py: Support for logging to multiple destinations with log
 #                      levels - basically an extension to the Python logging
-#                      module with Anaconda specififc enhancements.
+#                      module with Anaconda specific enhancements.
 #
 # Copyright (C) 2000, 2001, 2002, 2005, 2017  Red Hat, Inc.  All rights reserved.
 #
@@ -28,10 +28,8 @@ import warnings
 
 from pyanaconda.core import constants
 from pyanaconda.core.path import set_mode
-
-import gi
-gi.require_version("GLib", "2.0")
-from gi.repository import GLib
+from pyanaconda.core.glib import log_set_handler, log_set_writer_func, log_writer_format_fields, \
+      LogLevelFlags, LogWriterOutput
 
 ENTRY_FORMAT = "%(asctime)s,%(msecs)03d %(levelname)s %(name)s: %(message)s"
 STDOUT_FORMAT = "%(asctime)s %(message)s"
@@ -261,13 +259,13 @@ class AnacondaLog(object):
             self.anaconda_logger.debug("GLib: %s", message)
 
         def structured_log_adapter(level, fields, field_count, user_data):
-            message = GLib.log_writer_format_fields(level, fields, True)
+            message = log_writer_format_fields(level, fields, True)
             self.anaconda_logger.debug("GLib: %s", message)
-            return GLib.LogWriterOutput.HANDLED
+            return LogWriterOutput.HANDLED
 
         # redirect GLib log output via the functions
-        GLib.log_set_handler(None, GLib.LogLevelFlags.LEVEL_MASK, log_adapter, None)
-        GLib.log_set_writer_func(structured_log_adapter, None)
+        log_set_handler(None, LogLevelFlags.LEVEL_MASK, log_adapter, None)
+        log_set_writer_func(structured_log_adapter, None)
 
     # pylint: disable=redefined-builtin
     def showwarning(self, message, category, filename, lineno,

--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -249,10 +249,6 @@ class AnacondaLog(object):
 
         :param log: anaconda log handler
         """
-
-        if not self.write_to_journal:
-            return
-
         # create functions that convert the messages coming
         # from GLib into something that fits to the anaconda logging format
         def log_adapter(domain, level, message, user_data):

--- a/pyanaconda/core/glib.py
+++ b/pyanaconda/core/glib.py
@@ -31,9 +31,11 @@ from gi.repository.GLib import markup_escape_text, format_size_full, \
                                io_add_watch, child_watch_add, \
                                source_remove, timeout_source_new, \
                                spawn_close_pid, spawn_async_with_pipes, \
+                               log_writer_format_fields, log_set_handler, log_set_writer_func, \
                                MainLoop, MainContext, \
                                GError, Variant, VariantType, Bytes, \
                                IOCondition, IOChannel, SpawnFlags, \
+                               LogWriterOutput, LogLevelFlags, \
                                MAXUINT
 from gi.repository.Gio import Cancellable
 
@@ -47,8 +49,10 @@ __all__ = ["create_main_loop", "create_new_context",
            "io_add_watch", "child_watch_add",
            "source_remove", "timeout_source_new",
            "spawn_close_pid", "spawn_async_with_pipes",
+           "log_writer_format_fields", "log_set_handler", "log_set_writer_func",
            "GError", "Variant", "VariantType", "Bytes",
            "IOCondition", "IOChannel", "SpawnFlags",
+           "LogWriterOutput", "LogLevelFlags",
            "MAXUINT", "Cancellable"]
 
 


### PR DESCRIPTION
Previously we redirected all output from the main Anaconda process to Journal to avoid GTK log messages (as GTK runs in the main process) from spamming TTY. Turns out this broke a couple things, such as the shell prompt in rescue mode.

So drop the wholesale process output redirection and instead just redirect (hopefully) all GLib based loggers (used by GTK) to Journal.

Related: RHEL-58834