### PR TITLE
unit_tests: drop DASDDevice.opts like in related blivet change

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_dasd.py
@@ -83,8 +83,7 @@ class DASDInterfaceTestCase(unittest.TestCase):
                 "dev1",
                 fmt=get_format("ext4"),
                 size=Size("10 GiB"),
-                busid="0.0.0201",
-                opts={}
+                busid="0.0.0201"
             )
         )
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -221,8 +221,7 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             "dev1",
             fmt=get_format("ext4"),
             size=Size("10 GiB"),
-            busid="0.0.0201",
-            opts={}
+            busid="0.0.0201"
         ))
 
         data = self.interface.GetDeviceData("dev1")


### PR DESCRIPTION
https://github.com/storaged-project/blivet/pull/1162#issuecomment-1771443131 removes DASDDevice.opts. Anticipating that blivet change, update the anaconda unit tests making use of DASDDevice.

Cherry-picked from master commit: 9e3cb46a24b5e82c26ee2053a112cc158ad102ff

(This fixes the f41 broken daily run, needed because this https://bodhi.fedoraproject.org/updates/FEDORA-2024-315856b889 slipped in)