### PR TITLE
security: call /usr/libexec/fips-setup-helper

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -134,7 +134,7 @@ Requires: python3-pid
 
 # Required by the systemd service anaconda-fips.
 Requires: crypto-policies
-Requires: /usr/bin/update-crypto-policies
+Requires: crypto-policies-scripts
 
 # required because of the rescue mode and RDP question
 Requires: anaconda-tui = %{version}-%{release}

--- a/pyanaconda/modules/security/installation.py
+++ b/pyanaconda/modules/security/installation.py
@@ -159,13 +159,10 @@ class ConfigureFIPSTask(Task):
             log.debug("Don't set up FIPS on %s.", conf.target.type.value)
             return
 
-        # We use the --no-bootcfg option as we don't want fips-mode-setup
-        # to modify the bootloader configuration. Anaconda already does
-        # everything needed & it would require grubby to be available on
-        # the system.
+        # Bootloader is not modified. Anaconda already does everything needed.
         util.execWithRedirect(
-            "fips-mode-setup",
-            ["--enable", "--no-bootcfg"],
+            "/usr/libexec/fips-setup-helper",
+            ["anaconda"],
             root=self._sysroot
         )
 

--- a/pyanaconda/modules/security/security.py
+++ b/pyanaconda/modules/security/security.py
@@ -194,7 +194,7 @@ class SecurityService(KickstartService):
         # Add FIPS requirements.
         if self.fips_enabled:
             requirements.append(Requirement.for_package(
-                "/usr/bin/fips-mode-setup",
+                "crypto-policies-scripts",
                 reason="Required for FIPS compliance."
             ))
 

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -322,7 +322,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         assert self.security_interface.CollectRequirements() == [
             {
                 "type": get_variant(Str, "package"),
-                "name": get_variant(Str, "/usr/bin/fips-mode-setup"),
+                "name": get_variant(Str, "crypto-policies-scripts"),
                 "reason": get_variant(Str, "Required for FIPS compliance.")
             }
         ]
@@ -1014,7 +1014,7 @@ class SecurityTasksTestCase(unittest.TestCase):
         task.run()
 
         mock_util.execWithRedirect.assert_called_once_with(
-            "fips-mode-setup",
-            ["--enable", "--no-bootcfg"],
+            "/usr/libexec/fips-setup-helper",
+            ["anaconda"],
             root="/mnt/sysroot"
         )


### PR DESCRIPTION
crypto-policies now ships a helper for anaconda to call in order to just "do the right thing"
and make it not anaconda's responsibility.

Cherry-picked from master commit 123d8197707e4c773281f68ab7b9128d6c500342 Resolves: RHEL-57680

