### PR TITLE
infra: update cppcheck for version 2.16

### DIFF
--- a/tests/cppcheck/suppression-list.txt
+++ b/tests/cppcheck/suppression-list.txt
@@ -7,6 +7,25 @@ unusedFunction:widgets/glade/*
 // stop whining about G_DEFINE macros
 constStatement:*/widgets/src/*
 constStatement:widgets/src/*
+// The constStatement is replaced with syntaxError in cppcheck 2.16
+// Let's ignore it but be more location specific
+// Asking for hints at https://sourceforge.net/p/cppcheck/discussion/development/thread/09e165a455/#0be6
+syntaxError:*/widgets/src/BaseWindow.c:166
+syntaxError:*/widgets/src/DiskOverview.c:120
+syntaxError:*/widgets/src/HubWindow.c:96
+syntaxError:*/widgets/src/LayoutIndicator.c:86
+syntaxError:*/widgets/src/MountpointSelector.c:102
+syntaxError:*/widgets/src/SpokeSelector.c:94
+syntaxError:*/widgets/src/SpokeWindow.c:68
+syntaxError:*/widgets/src/StandaloneWindow.c:67
+syntaxError:widgets/src/BaseWindow.c:166
+syntaxError:widgets/src/DiskOverview.c:120
+syntaxError:widgets/src/HubWindow.c:96
+syntaxError:widgets/src/LayoutIndicator.c:86
+syntaxError:widgets/src/MountpointSelector.c:102
+syntaxError:widgets/src/SpokeSelector.c:94
+syntaxError:widgets/src/SpokeWindow.c:68
+syntaxError:widgets/src/StandaloneWindow.c:67
 
 //
 returnDanglingLifetime:*widgets/src/gettext.h


### PR DESCRIPTION
I was also considering removing the -DG_DEFINE_TYPE options and similar and suppress the undefinedMacro instead of syntaxError but commit 8282570816e48117f3b61c43eae37db6884e1181
suggests there must be a reason we are defining the G_DEFINE_ with -D option.

So make the syntaxError suppressions at least more specific.

Also I am asking for hints and explanation at https://sourceforge.net/p/cppcheck/discussion/development/thread/09e165a455/

Failed check example: https://github.com/rhinstaller/anaconda/actions/runs/11656717413
