### PR TITLE
Remove stray comma from widgets/configure.ac

### DIFF
--- a/widgets/configure.ac
+++ b/widgets/configure.ac
@@ -67,7 +67,7 @@ AC_ARG_ENABLE([glade],
 
 AS_IF([test "x$enable_glade" != "xno"],
       [ANACONDA_PKG_CHECK_MODULES([GLADEUI], [gladeui-2.0 >= 3.10])
-       AC_SUBST(GLADE_SUBDIR, "glade"),
+       AC_SUBST(GLADE_SUBDIR, "glade")
        AC_CONFIG_FILES([glade/Makefile])],
       [AC_SUBST(GLADE_SUBDIR, "")])
 


### PR DESCRIPTION
Fixes "./configure: line 14763: ,: command not found" error message from autoconf.