### PR TITLE
Fix RDP var contains string instead of bool

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -323,7 +323,10 @@ def setup_display(anaconda, options):
             anaconda.display_mode = constants.DisplayModes.GUI
         rdp_creds = rdp_credentials(options.rdp_username, options.rdp_password)
         # note if we have both set
-        rdp_credentials_sufficient = options.rdp_username and options.rdp_password
+        if options.rdp_username and options.rdp_password:
+            rdp_credentials_sufficient = True
+        else:
+            rdp_credentials_sufficient = False
 
     # check if GUI without WebUI
     startup_utils.fallback_to_tui_if_gtk_ui_is_not_available(anaconda)


### PR DESCRIPTION
The issue with the original code is in python behavior. Python on this code:

"a" or "b"

will give you

"b"

instead of probably expected 'True' value. This is fix to avoid break of the code in the future because this variable should keep boolean value.