### PR TITLE
Backport support for Wayland-native Anaconda live installer from Fedora

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -20,11 +20,24 @@
 
 BACKEND_READY_FLAG=/run/anaconda/backend_ready
 
+WAYLAND_DISPLAY_SOCKET=/tmp/anaconda-wldisplay
+
+# Detect and save the wayland socket before re-exec
+if [ -n "$WAYLAND_DISPLAY" ]; then
+    if [ -e "$WAYLAND_DISPLAY_SOCKET" ]; then
+        rm -f "${WAYLAND_DISPLAY_SOCKET}"
+    fi
+    touch "${WAYLAND_DISPLAY_SOCKET}"
+    echo "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" > ${WAYLAND_DISPLAY_SOCKET}
+fi
+
 # The command needs to be run with root privileges, so if it was started
 # unprivileged, restart running as root.
 if [ "$(id -u)" -ne 0 ]; then
-    xhost +si:localuser:root
-    unset XAUTHORITY
+    if [ -z "$WAYLAND_DISPLAY" ]; then
+        xhost +si:localuser:root
+        unset XAUTHORITY
+    fi
     pkexec "$0" "$@"
 fi
 
@@ -32,6 +45,19 @@ fi
 if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
     export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${PKEXEC_UID}/bus
 fi
+
+# pkexec clears WAYLAND_DISPLAY from environment
+if [ -z "$WAYLAND_DISPLAY" ] && [ -e "$WAYLAND_DISPLAY_SOCKET" ]; then
+    WAYLAND_DISPLAY=$(cat "${WAYLAND_DISPLAY_SOCKET}")
+    export WAYLAND_DISPLAY
+fi
+
+# use the correct home and config directories for system settings
+PKEXEC_USER=$(id -un "${PKEXEC_UID}")
+HOME=$(bash -c "cd ~${PKEXEC_USER} && pwd")
+export HOME
+XDG_CONFIG_HOME="${HOME}/.config"
+export XDG_CONFIG_HOME
 
 # Allow running another command in the place of anaconda, but in this same
 # environment.  This allows storage testing to make use of all the module
@@ -170,8 +196,10 @@ start_anaconda() {
     $ANACONDA "$@"
 }
 
-# Force the X11 backend since sudo and wayland do not mix
-export GDK_BACKEND=x11
+# If no wayland socket is set, force x11 so that it loads correctly
+if [ -z "$WAYLAND_DISPLAY" ]; then
+    export GDK_BACKEND=x11
+fi
 
 if [ -x /usr/bin/udisks ]; then
     /usr/bin/udisks --inhibit -- start_anaconda "$@"

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -521,7 +521,8 @@ class GraphicalUserInterface(UserInterface):
 
         self.data = None
 
-        GLib.set_prgname("liveinst")    # matches liveinst.desktop filename
+        if conf.system.provides_liveuser:
+            GLib.set_prgname("liveinst")    # matches liveinst.desktop filename
         self.mainWindow = MainWindow(fullscreen=fullscreen, decorated=False)
 
         self._distributionText = distributionText

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -30,8 +30,9 @@ gi.require_version("Gtk", "3.0")
 gi.require_version("AnacondaWidgets", "3.4")
 gi.require_version("GdkPixbuf", "2.0")
 gi.require_version("GObject", "2.0")
+gi.require_version("GLib", "2.0")
 
-from gi.repository import Gdk, Gtk, AnacondaWidgets, GdkPixbuf, GObject
+from gi.repository import Gdk, Gtk, AnacondaWidgets, GdkPixbuf, GObject, GLib
 
 from pyanaconda.flags import flags
 from pyanaconda.core.i18n import _, C_
@@ -520,6 +521,7 @@ class GraphicalUserInterface(UserInterface):
 
         self.data = None
 
+        GLib.set_prgname("liveinst")    # matches liveinst.desktop filename
         self.mainWindow = MainWindow(fullscreen=fullscreen, decorated=False)
 
         self._distributionText = distributionText

--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -289,6 +289,7 @@ class MainWindow(Gtk.Window):
         # Remove the title bar, resize controls and other stuff if the window manager
         # allows it and decorated is set to False. Otherwise, it has no effect.
         self.set_decorated(decorated)
+        self.set_titlebar(Gtk.DrawingArea())
 
         # Hide the titlebar when maximized if the window manager allows it.
         # This makes anaconda look full-screenish but without covering parts

--- a/pyanaconda/ui/gui/main.glade
+++ b/pyanaconda/ui/gui/main.glade
@@ -10,6 +10,9 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="can_focus">False</property>
@@ -80,6 +83,9 @@
     <property name="can_focus">False</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="quitDialog-vbox1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/advanced_user.glade
+++ b/pyanaconda/ui/gui/spokes/advanced_user.glade
@@ -21,6 +21,9 @@
     <property name="border_width">6</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/advstorage/dasd.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/dasd.glade
@@ -8,6 +8,9 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/advstorage/fcoe.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/fcoe.glade
@@ -9,6 +9,9 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/advstorage/iscsi.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/iscsi.glade
@@ -26,6 +26,9 @@
     <property name="default_width">600</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
+++ b/pyanaconda/ui/gui/spokes/advstorage/zfcp.glade
@@ -23,6 +23,9 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <property name="default-width">600</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">

--- a/pyanaconda/ui/gui/spokes/keyboard.glade
+++ b/pyanaconda/ui/gui/spokes/keyboard.glade
@@ -406,6 +406,9 @@
     <property name="default_height">450</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>
@@ -593,6 +596,9 @@
     <property name="default_height">450</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/beta_warning_dialog.glade
+++ b/pyanaconda/ui/gui/spokes/lib/beta_warning_dialog.glade
@@ -8,6 +8,9 @@
     <property name="default-width">550</property>
     <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can-focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/cart.glade
+++ b/pyanaconda/ui/gui/spokes/lib/cart.glade
@@ -27,6 +27,9 @@
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child>
       <placeholder/>
     </child>

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -7,6 +7,9 @@
     <property name="border-width">6</property>
     <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="can-focus">False</property>
@@ -113,6 +116,9 @@
     <property name="border-width">6</property>
     <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox4">
         <property name="can-focus">False</property>
@@ -308,6 +314,9 @@
     <property name="border-width">6</property>
     <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can-focus">False</property>
@@ -591,6 +600,9 @@ use.  Try something else?</property>
     <property name="border-width">6</property>
     <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox5">
         <property name="can-focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
+++ b/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
@@ -9,6 +9,9 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/detailederror.glade
+++ b/pyanaconda/ui/gui/spokes/lib/detailederror.glade
@@ -11,6 +11,9 @@
     <property name="window_position">center</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox2">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/installation_source_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/installation_source_helpers.glade
@@ -12,6 +12,9 @@
     <property name="border-width">6</property>
     <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <property name="create-folders">False</property>
     <property name="filter">isoFilter</property>
     <child internal-child="vbox">
@@ -79,6 +82,9 @@
     <property name="window-position">center-on-parent</property>
     <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <signal name="close" handler="on_close" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
@@ -232,6 +238,9 @@
     <property name="window-position">center-on-parent</property>
     <property name="type-hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox4">
         <property name="can-focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/network_secret_agent.glade
+++ b/pyanaconda/ui/gui/spokes/lib/network_secret_agent.glade
@@ -8,6 +8,9 @@
     <property name="title" translatable="yes">Authentication</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child>
       <placeholder/>
     </child>

--- a/pyanaconda/ui/gui/spokes/lib/ntp_dialog.glade
+++ b/pyanaconda/ui/gui/spokes/lib/ntp_dialog.glade
@@ -23,6 +23,9 @@
     <property name="border_width">6</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/passphrase.glade
+++ b/pyanaconda/ui/gui/spokes/lib/passphrase.glade
@@ -9,6 +9,9 @@
     <property name="default_width">600</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/refresh.glade
+++ b/pyanaconda/ui/gui/spokes/lib/refresh.glade
@@ -11,6 +11,9 @@
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="can_focus">False</property>

--- a/pyanaconda/ui/gui/spokes/lib/resize.glade
+++ b/pyanaconda/ui/gui/spokes/lib/resize.glade
@@ -38,6 +38,9 @@
     <property name="modal">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <signal name="key-release-event" handler="on_key_pressed" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">

--- a/pyanaconda/ui/gui/spokes/lib/storage_dialogs.glade
+++ b/pyanaconda/ui/gui/spokes/lib/storage_dialogs.glade
@@ -12,6 +12,9 @@
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child>
       <placeholder/>
     </child>
@@ -230,6 +233,9 @@
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
     <property name="decorated">False</property>
+    <child type="titlebar">
+      <object class="GtkDrawingArea"/>
+    </child>
     <child>
       <placeholder/>
     </child>


### PR DESCRIPTION
This pull request backports relevant commits to support the Wayland-native live installer setup for CentOS Stream images.

This is needed for CentOS Hyperscale and CentOS Alternative Images.

Resolves: [RHEL-67390](https://issues.redhat.com/browse/RHEL-67390)