### PR TITLE
bootloader: rely on unified GRUB configuration for UEFI and BIOS

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -143,6 +143,8 @@ Requires: python3-pid
 Requires: crypto-policies
 Requires: crypto-policies-scripts
 
+Requires: grub2-common
+
 # required because of the rescue mode and RDP question
 Requires: anaconda-tui = %{version}-%{release}
 

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -177,31 +177,6 @@ class EFIGRUB(EFIBase, GRUB2):
         """ Full path to EFI configuration file. """
         return "%s/%s" % (self.efi_config_dir, self._config_file)
 
-    def write_config(self):
-        config_path = "%s%s" % (conf.target.system_root, self.efi_config_file)
-
-        with open(config_path, "w") as fd:
-            grub_dir = self.config_dir
-            if self.stage2_device.format.type != "btrfs":
-                fs_uuid = self.stage2_device.format.uuid
-            else:
-                fs_uuid = self.stage2_device.format.vol_uuid
-
-            if fs_uuid is None:
-                raise BootLoaderError("Could not get stage2 filesystem UUID")
-
-            grub_dir = util.execWithCapture("grub2-mkrelpath", [grub_dir],
-                                            root=conf.target.system_root)
-            if not grub_dir:
-                raise BootLoaderError("Could not get GRUB directory path")
-
-            fd.write("search --no-floppy --fs-uuid --set=dev %s\n" % fs_uuid)
-            fd.write("set prefix=($dev)%s\n" % grub_dir)
-            fd.write("export $prefix\n")
-            fd.write("configfile $prefix/grub.cfg\n")
-
-        super().write_config()
-
 
 class EFISystemdBoot(EFIBase, SystemdBoot):
     """EFI Systemd-boot"""


### PR DESCRIPTION
This patch simplifies the EFI GRUB configuration generation by replacing the manual config file writing with a `grub2-mkconfig` command. By doing so, we avoid direct file handling and path resolution issues, leveraging `grub2-mkconfig` to set up the correct paths and UUIDs.

Additionally, this change enables OS Prober in `grub.cfg` generation by default, ensuring that other operating systems are detected and added to the boot menu automatically. This is particularly useful for multi-boot environments, as it allows the system to recognize existing OS installations without additional configuration.

Relevant to: https://issues.redhat.com/browse/INSTALLER-3977

- [x] : Blocked on https://bugzilla.redhat.com/show_bug.cgi?id=2326502
- [ ] : Consider blocking this on https://bugzilla.redhat.com/show_bug.cgi?id=2327644