### PR TITLE
Do not crash if RDP is selected after regular GUI startup failed (#2326410)

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -406,7 +406,9 @@ def setup_display(anaconda, options):
                     "an RDP session to connect to this computer from another computer and "
                     "perform a graphical installation or continue with a text mode "
                     "installation?")
-        rdp_creds = ask_rd_question(anaconda, message)
+        # we aren't really interested in the use_rd flag so at least mark it like this
+        # to avoid linters being grumpy
+        _use_rd, rdp_creds = ask_rd_question(anaconda, message)
 
     # if they want us to use RDP do that now
     if anaconda.gui_mode and flags.use_rd:

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -117,12 +117,6 @@ def ask_rd_question(anaconda, message):
     ScreenHandler.schedule_screen(spoke)
     App.run()
 
-    if spoke.use_remote_desktop:
-        if not anaconda.gui_mode:
-            log.info("RDP requested via RDP question, switching Anaconda to GUI mode.")
-        anaconda.display_mode = constants.DisplayModes.GUI
-        flags.use_rd = True
-
     return (spoke.use_remote_desktop, rdp_credentials(spoke.rdp_username, spoke.rdp_password))
 
 
@@ -133,7 +127,8 @@ def ask_for_rd_credentials(anaconda, username=None, password=None):
     :param str username: user set username (if any)
     :param str password: user set password (if any)
 
-    :return: namedtuple rdp_credentials(username, password)
+    :return: (use_rd, rdp_credentials(username, password))
+    :rtype: Tuple(bool, NameTuple(username, password))
     """
     App.initialize()
     loop = App.get_event_loop()
@@ -142,10 +137,7 @@ def ask_for_rd_credentials(anaconda, username=None, password=None):
     ScreenHandler.schedule_screen(spoke)
     App.run()
 
-    log.info("RDP credentials set")
-    anaconda.display_mode = constants.DisplayModes.GUI
-    flags.use_rd = True
-    return rdp_credentials(spoke._username, spoke._password)
+    return (True, rdp_credentials(spoke._username, spoke._password))
 
 
 def check_rd_can_be_started(anaconda):
@@ -339,9 +331,10 @@ def setup_display(anaconda, options):
         # or inst.rdp and insufficient credentials are provided
         # via boot options, ask interactively.
         if options.rdp_enabled and not rdp_credentials_sufficient:
-            rdp_creds = ask_for_rd_credentials(anaconda,
-                                               options.rdp_username,
-                                               options.rdp_password)
+            use_rd, rdp_creds = ask_for_rd_credentials(anaconda,
+                                                       options.rdp_username,
+                                                       options.rdp_password)
+            _set_gui_mode_on_rdp(anaconda, use_rd)
     else:
         # RDP can't be started - disable the RDP question and log
         # all the errors that prevented RDP from being started
@@ -356,6 +349,7 @@ def setup_display(anaconda, options):
                     "full control over the disk layout. Would you like "
                     "to use remote graphical access via the RDP protocol instead?")
         use_rd, credentials = ask_rd_question(anaconda, message)
+        _set_gui_mode_on_rdp(anaconda, use_rd)
         if not use_rd:
             # user has explicitly specified text mode
             flags.rd_question = False
@@ -408,7 +402,8 @@ def setup_display(anaconda, options):
                     "installation?")
         # we aren't really interested in the use_rd flag so at least mark it like this
         # to avoid linters being grumpy
-        _use_rd, rdp_creds = ask_rd_question(anaconda, message)
+        use_rd, rdp_creds = ask_rd_question(anaconda, message)
+        _set_gui_mode_on_rdp(anaconda, use_rd)
 
     # if they want us to use RDP do that now
     if anaconda.gui_mode and flags.use_rd:
@@ -426,3 +421,10 @@ def setup_display(anaconda, options):
         # as we might now be in text mode, which might not be able to display
         # the characters from our current locale
         startup_utils.reinitialize_locale(text_mode=anaconda.tui_mode)
+
+
+def _set_gui_mode_on_rdp(anaconda, use_rdp):
+    if not anaconda.gui_mode:
+        log.info("RDP requested via RDP question, switching Anaconda to GUI mode.")
+    anaconda.display_mode = constants.DisplayModes.GUI
+    flags.use_rd = use_rdp


### PR DESCRIPTION


The ask_rd_question() function returns not only the credentials tuple, but also the "use remote desktop" flag.

We correctly handled that in the regular case where we ask for user password if user selected RDP instead of text mode.

But we missed that in the harder to test case where RDP is suggested as an option to the user after regular locally running GUI startup fails. Oops! :P

So handle the extra value and avoid the crash. :)

Resolves: rhbz#2326410