### PR TITLE
payload: utilize disk usage for assuming the minimum required disk size in live OS

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_os.py
@@ -128,10 +128,10 @@ class LiveOSSourceTestCase(unittest.TestCase):
 
 class LiveOSSourceTasksTestCase(unittest.TestCase):
     """Test the tasks of the Live OS source."""
-    @patch("pyanaconda.modules.payloads.source.live_os.initialization.os.statvfs")
-    def test_live_os_image_size(self, statvfs):
+    @patch("pyanaconda.modules.payloads.source.live_os.initialization.execWithCapture")
+    def test_live_os_image_size(self, exec_mock):
         """Test Live OS image size calculation."""
-        statvfs.return_value = Mock(f_frsize=512, f_blocks=100, f_bfree=42)
+        exec_mock.return_value = "29696      /path/to/base/image/"
 
         task = SetUpLiveOSSourceTask(
                 "/path/to/base/image",


### PR DESCRIPTION
This approach replaces statvfs-based space calculation with 'shutil.disk_usage' which considers the apparent size of files instead of filesystem block usage.
    
Resolves: rhbz#2326532

On rawhide live image:

NOW:
--------
![Screen Shot 2024-11-19 at 08 18 16](https://github.com/user-attachments/assets/6591ef39-6418-4931-b1fe-ea26a572bca8)

BEFORE:
------------
![Screen Shot 2024-11-19 at 08 09 59](https://github.com/user-attachments/assets/6271d2b5-92f8-46da-a425-b228a3a63909)

I understand the difference is enormous but probably 8G is more realistic than 2.8G.

Let me know what you think. 