### PR TITLE
doc: Add dropped kernel options to Wayland relnote

### DIFF
--- a/docs/release-notes/wayland-migration.rst
+++ b/docs/release-notes/wayland-migration.rst
@@ -8,6 +8,10 @@
     By implementing this update, we can eliminate dependencies on X11 and embrace newer, more
     secure technologies.
 
+    By this change some kernel boot options can't be used:
+    - inst.usefbx
+    - inst.xdriver
+
 :Links:
     - https://fedoraproject.org/wiki/Changes/Anaconda_As_Native_Wayland_Application
     - https://github.com/rhinstaller/anaconda/pull/5829


### PR DESCRIPTION
The migration of Anaconda to Wayland native application and Wayland environment also caused some kernel boot options to be dropped. We need to mention this in the release notes.