### PR TITLE
Revert "pyanaconda: storage: workaround for Virtio Block Device being displayed as 0x1af4"

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -143,11 +143,6 @@ class DeviceTreeViewer(ABC):
         # FIXME: We should generate the description from the device data.
         data.description = getattr(device, "description", "")
 
-        # Workaround for Virtio Block Device being displayed as 0x1af4
-        # https://github.com/storaged-project/blivet/pull/174
-        if data.description == "0x1af4":
-            data.description = _("Virtio Block Device")
-
         data.attrs["serial"] = self._get_attribute(device, "serial")
         data.attrs["vendor"] = self._get_attribute(device, "vendor")
         data.attrs["model"] = self._get_attribute(device, "model")


### PR DESCRIPTION
This reverts commit 4785219049066c7734d2a48815f857fd3f974938.

Can be reverted once https://github.com/storaged-project/blivet/pull/1313/commits/874f8f50ab870e0c0b1cd4d53839015a232c9332
    reaches Rawhide.
