### PR TITLE
efi: Update __all__ dictionary

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -31,8 +31,16 @@ from pyanaconda.core.product import get_product_name
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
-__all__ = ["EFIGRUB", "Aarch64EFIGRUB", "Aarch64EFISystemdBoot",
-           "ArmEFIGRUB", "EFIBase", "X64EFISystemdBoot"]
+__all__ = [
+    "EFIGRUB",
+    "RISCV64EFIGRUB",
+    "Aarch64EFIGRUB",
+    "Aarch64EFISystemdBoot",
+    "ArmEFIGRUB",
+    "EFIBase",
+    "EFISystemdBoot",
+    "X64EFISystemdBoot"
+]
 
 
 class EFIBase(object):


### PR DESCRIPTION
Add two missing entries (`EFISystemdBoot`, `RISCV64EFIGRUB`) and sort the dictionary so that classes are listed in the same order as they appear in the file, which will hopefully make it easier to spot mistakes in the future.

I'm not actually sure whether or not this makes any difference, but since all other classes are listed I assume the dictionary is there for a reason...