### PR TITLE
infra: Allow webui tests for external contributors

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -70,4 +70,4 @@ jobs:
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
-          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
+          bots/tests-trigger --allow --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -64,5 +64,5 @@ jobs:
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
-          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
+          bots/tests-trigger --allow --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
 {% endif %}


### PR DESCRIPTION
Currently, we need to manually execute web UI tests for external contributors on each Anaconda PR. This is security precaution to avoid malicious code to be executed on Cockpit runners.

However, our project is configured that we need to manually allow all the workflows by pressing a button for every tests run for external contributors. The webui case is making the same requirement twice for this specific test.

To avoid unnecessary burden with not giving us much benefit, let's allow external contributors for every run automatically. Press of the GitHub button on PR should be good enough confirmation that there is no malicious code.