### PR TITLE
Revert "infra: Allow webui tests for external contributors"

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -70,4 +70,4 @@ jobs:
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
-          bots/tests-trigger --allow --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
+          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -64,5 +64,5 @@ jobs:
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
-          bots/tests-trigger --allow --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
+          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
 {% endif %}


### PR DESCRIPTION
Reverts rhinstaller/anaconda#6025

Unfortunately, we found out that `pull_request_target` is not covered by the GitHub approval :(