### PR TITLE
Use Github gating (approve button) for webui-trigger workflow

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -14,7 +14,7 @@
 
 name: Anaconda Web UI
 on:
-  pull_request_target:
+  pull_request:
     # All file changes that might affect the Web UI
     paths:
       - 'pyanaconda/**'
@@ -75,5 +75,5 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
-          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
-          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
+          echo '${{ secrets.INSTALLKER_TOKEN }}' > ~/.config/cockpit-dev/github-token
+          bots/tests-trigger --allow --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui

--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -27,6 +27,12 @@ on:
       - 'po/l10n-config.mk'
     branches:
       - 'master'
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   trigger:
     runs-on: ubuntu-22.04

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -8,7 +8,7 @@
 
 name: Anaconda Web UI
 on:
-  pull_request_target:
+  pull_request:
     # All file changes that might affect the Web UI
     paths:
       - 'pyanaconda/**'
@@ -69,6 +69,6 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
-          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
-          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
+          echo '${{ secrets.INSTALLKER_TOKEN }}' > ~/.config/cockpit-dev/github-token
+          bots/tests-trigger --allow --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
 {% endif %}

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -21,6 +21,12 @@ on:
       - 'po/l10n-config.mk'
     branches:
       - 'master'
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
 jobs:
   trigger:
     runs-on: ubuntu-22.04

--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -1,6 +1,7 @@
 # Anaconda configuration file.
 # Version: unstable
 
+# TEST
 
 [Anaconda]
 # Run Anaconda in the debugging mode.


### PR DESCRIPTION
Currently, the webui trigger is gated for external contributors by failing the trigger workflow which demands developer to run a command on their machine to start tests on Anaconda PR.

This PR change allows external contributors execution all the time. Which raises an additional issue.

Anaconda project have workflows configured that they are required to be enabled each time manually by pressing button on the PR page. This works fine but only for `pull_request` trigger and webui-trigger workflow is using `pull_request_target` which is not covered by this gating. The `pull_request_target` trigger is used because we need a Github token of the workflow from the target repository so that webui tests are able to set the status on PR.

To resolve the issue above, let's use our own token instead of the workflow generated one and switch the trigger to `pull_request` which as side effect will also make the whole workflow more secure.