### PR TITLE
Revert "payload: raise exception on non zero exit code from rsync"

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -433,12 +433,19 @@ class InstallFromImageTask(Task):
 
         try:
             self.report_progress(_("Installing software..."))
-            for line in execReadlines(cmd, args):
+            reader = execReadlines(cmd, args, raise_on_nozero=False)
+            for line in reader:
                 self._parse_rsync_update(line)
 
         except (OSError, RuntimeError) as e:
             msg = "Failed to install image: {}".format(e)
             raise PayloadInstallationError(msg) from None
+
+        if reader.rc == 11:
+            raise PayloadInstallationError(
+                "Failed to install image: "
+                "{} exited with code {}".format(cmd, reader.rc)
+            )
 
     def _parse_rsync_update(self, line):
         """Try to extract progress from rsync output.

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -120,7 +120,7 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
             "--exclude", "/etc/machine-info",
             mount_point + "/",
             "/mnt/root"
-        ])
+        ], raise_on_nozero=False)
 
     @patch("pyanaconda.modules.payloads.payload.live_image.installation.os.sync")
     @patch("pyanaconda.modules.payloads.payload.live_image.installation.execReadlines")
@@ -138,6 +138,24 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
                 task.run()
 
         msg = "Failed to install image: Fake!"
+        assert str(cm.value) == msg
+
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.os.sync")
+    @patch("pyanaconda.modules.payloads.payload.live_image.installation.execReadlines")
+    def test_install_image_task_failed_return_code(self, exec_readlines, os_sync):
+        """Test installation from an image task with bad return code."""
+        exec_readlines.return_value = self._make_reader(11)
+
+        with tempfile.TemporaryDirectory() as mount_point:
+            task = InstallFromImageTask(
+                sysroot="/mnt/root",
+                mount_point=mount_point
+            )
+
+            with pytest.raises(PayloadInstallationError) as cm:
+                task.run()
+
+        msg = "Failed to install image: rsync exited with code 11"
         assert str(cm.value) == msg
 
 


### PR DESCRIPTION
This reverts commit 44bde41afed8b19876a84df5fe4635a47707fcd4. It is causing KDE live installs to fail (as it seems rsync has been exiting non-zero on KDE live installs, but without causing any apparent problems in the installed system).

resolves: rhbz#2329379