### PR TITLE
RHEL-10: Do not crash if RDP is selected after regular GUI startup failed

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -405,7 +405,9 @@ def setup_display(anaconda, options):
                     "an RDP session to connect to this computer from another computer and "
                     "perform a graphical installation or continue with a text mode "
                     "installation?")
-        rdp_creds = ask_rd_question(anaconda, message)
+        # we aren't really interested in the use_rd flag so at least mark it like this
+        # to avoid linters being grumpy
+        _use_rd, rdp_creds = ask_rd_question(anaconda, message)
 
     # if they want us to use RDP do that now
     if anaconda.gui_mode and flags.use_rd:


### PR DESCRIPTION
The `ask_rd_question()` function returns not only the credentials tuple, but also the "use remote desktop" flag.

We correctly handled that in the regular case where we ask for user password if user selected RDP instead of text mode.

But we missed that in the harder to test case where RDP is suggested as an option to the user after regular locally running GUI startup fails. Oops! :P

So handle the extra value and avoid the crash. :)

Backport of https://github.com/rhinstaller/anaconda/pull/5999
Resolves: [RHEL-69940](https://issues.redhat.com/browse/RHEL-69940)