### PR TITLE
Utils: Update testing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.lo
 *.o
 *.pyc
+*.qcow2
 *.so
 *.typelib
 *~

--- a/scripts/testing/update_iso
+++ b/scripts/testing/update_iso
@@ -22,6 +22,9 @@ PROJECT_DIR = os.path.dirname(
         )
     )
 
+# Virtual disk location
+VIRT_DISK = os.path.join(PROJECT_DIR, "tmp_virt_disk.qcow2")
+
 # Relative path to the ISO folder within the project
 ISO_FOLDER = os.path.join(PROJECT_DIR, "result", "iso")
 
@@ -212,6 +215,7 @@ def get_virt_install_command_line():
            "--name", "anaconda-updated-iso", "--os-variant=detect=on",
            "--memory", "4096", "--graphics", "vnc,listen=127.0.0.2",
            "--transient",
+           "--disk", VIRT_DISK + ",size=20",
            "--location", UPDATED_ISO]
     return cmd
 


### PR DESCRIPTION
Testing script 'update_iso' is using virt-install to test the built ISO. With every run virt-install will create new virtual drive in ~/.local/share/libvirt/images. With 20G size of each it may lead to filling up host HDD pretty fast.

This commit configures virt-install to reuse the same disk image located in the main project directory. This way it saves the space and makes it easy to remove if needed.


