### PR TITLE
network: improve logging of writing configuration

### DIFF
--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -84,6 +84,7 @@ def _write_config_file(root, path, content, error_msg, overwrite):
     """
     fpath = os.path.normpath(root + path)
     if os.path.isfile(fpath) and not overwrite:
+        log.debug("Not overwriting existing configuration file %s", fpath)
         return
     try:
         with open(fpath, "w") as fobj:


### PR DESCRIPTION
Especially with regard to image types of installation it is useful to know that the configuration was not written due to already existing file.