### PR TITLE
tests: autofix useless object inheritance pylint rule

### DIFF
--- a/dracut/driver_updates.py
+++ b/dracut/driver_updates.py
@@ -148,7 +148,7 @@ def find_isos(mnt):
     return [mnt+'/'+f for f in os.listdir(mnt) if f.lower().endswith('.iso')]
 
 
-class Driver(object):
+class Driver:
     """Represents a single driver (rpm), as listed by dd_list"""
     def __init__(self, source="", name="", flags="", description="", repo=""):
         self.source = source
@@ -590,7 +590,7 @@ def finish(user_request, topdir="/tmp"):
 # --- DEVICE LISTING HELPERS FOR THE MENU -----------------------------------
 
 
-class DeviceInfo(object):
+class DeviceInfo:
     def __init__(self, **kwargs):
         self.device = kwargs.get("DEVNAME", '')
         self.uuid = kwargs.get("UUID", '')
@@ -638,7 +638,7 @@ def get_deviceinfo():
 # --- INTERACTIVE MENU JUNK ------------------------------------------------
 
 
-class TextMenu(object):
+class TextMenu:
     def __init__(self, items, title=None, formatter=None, headeritem=None,
                  refresher=None, multi=False, page_height=20):
         self.items = items

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -38,7 +38,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class Anaconda(object):
+class Anaconda:
     def __init__(self):
         self._display_mode = None
         self._interactive_mode = True

--- a/pyanaconda/anaconda_logging.py
+++ b/pyanaconda/anaconda_logging.py
@@ -48,7 +48,7 @@ from threading import Lock
 program_log_lock = Lock()
 
 
-class _AnacondaLogFixer(object):
+class _AnacondaLogFixer:
     """ A mixin for logging.StreamHandler that does not lock during format.
 
         Add this mixin before the Handler type in the inheritance order.
@@ -74,7 +74,7 @@ class _AnacondaLogFixer(object):
         # Wrap the stream write in a lock acquisition
         # Use an object proxy in order to work with types that may not allow
         # the write property to be set.
-        class WriteProxy(object):
+        class WriteProxy:
 
             def write(self, *args, **kwargs):
                 handler.acquire()  # pylint: disable=no-member
@@ -149,7 +149,7 @@ class AnacondaPrefixFilter(logging.Filter):
         return True
 
 
-class AnacondaLog(object):
+class AnacondaLog:
     SYSLOG_CFGFILE = "/etc/rsyslog.conf"
 
     def __init__(self, write_to_journal=False):

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -314,7 +314,7 @@ def name_path_pairs(image_specs):
         yield name, path
 
 
-class HelpTextParser(object):
+class HelpTextParser:
     """Class to parse help text from file and make it available to option
        parser.
     """

--- a/pyanaconda/core/configuration/base.py
+++ b/pyanaconda/core/configuration/base.py
@@ -171,7 +171,7 @@ class Section(ABC):
         set_option(self._parser, self._section_name, option_name, value)
 
 
-class Configuration(object):
+class Configuration:
     """A base class for representation of a configuration handler."""
 
     def __init__(self):

--- a/pyanaconda/core/configuration/profile.py
+++ b/pyanaconda/core/configuration/profile.py
@@ -29,7 +29,7 @@ log = get_module_logger(__name__)
 __all__ = ["ProfileLoader"]
 
 
-class ProfileData(object):
+class ProfileData:
     """A class that represents a profile."""
 
     def __init__(self):
@@ -100,7 +100,7 @@ class ProfileData(object):
         self.variant_id = get_option(parser, section_name, "variant_id")
 
 
-class ProfileLoader(object):
+class ProfileLoader:
     """A class for loading information about profiles from configuration files."""
 
     def __init__(self):

--- a/pyanaconda/core/kickstart/specification.py
+++ b/pyanaconda/core/kickstart/specification.py
@@ -31,7 +31,7 @@ __all__ = [
 ]
 
 
-class KickstartSpecification(object):
+class KickstartSpecification:
     """Specification of kickstart data.
 
     This specification can be used to get the corresponding

--- a/pyanaconda/core/payload.py
+++ b/pyanaconda/core/payload.py
@@ -153,7 +153,7 @@ class ProxyStringError(Exception):
 
 
 # TODO: Add tests
-class ProxyString(object):
+class ProxyString:
     """ Handle a proxy url."""
     def __init__(self, url=None, protocol="http://", host=None, port="3128",
                  username=None, password=None):

--- a/pyanaconda/core/process_watchers.py
+++ b/pyanaconda/core/process_watchers.py
@@ -27,7 +27,7 @@ from pyanaconda.errors import ExitError
 __all__ = ["PidWatcher", "WatchProcesses"]
 
 
-class PidWatcher(object):
+class PidWatcher:
     """Watch for process and call callback when the process ends."""
 
     def __init__(self):
@@ -53,7 +53,7 @@ class PidWatcher(object):
         self._id = 0
 
 
-class WatchProcesses(object):
+class WatchProcesses:
     """Static class for watching external processes."""
 
     # Dictionary of processes to watch in the form {pid: [name, GLib event source id], ...}

--- a/pyanaconda/core/signal.py
+++ b/pyanaconda/core/signal.py
@@ -13,7 +13,7 @@ import inspect
 from weakref import WeakKeyDictionary
 
 
-class Signal(object):
+class Signal:
     def __init__(self):
         # The original implementation used WeakSet to store functions,
         # but that causes lambdas without any other reference to be

--- a/pyanaconda/core/startup/dbus_launcher.py
+++ b/pyanaconda/core/startup/dbus_launcher.py
@@ -44,7 +44,7 @@ log = get_anaconda_root_logger()
 __all__ = ["AnacondaDBusLauncher"]
 
 
-class AnacondaDBusLauncher(object):
+class AnacondaDBusLauncher:
     """Class for launching the Anaconda DBus modules."""
 
     DBUS_LAUNCH_BIN = "dbus-daemon"

--- a/pyanaconda/core/threads.py
+++ b/pyanaconda/core/threads.py
@@ -27,7 +27,7 @@ log = get_module_logger(__name__)
 _WORKER_THREAD_PREFIX = "AnaWorkerThread"
 
 
-class ThreadManager(object):
+class ThreadManager:
     """A singleton class for managing threads and processes.
 
        Notes:

--- a/pyanaconda/core/timer.py
+++ b/pyanaconda/core/timer.py
@@ -22,7 +22,7 @@
 from pyanaconda.core.glib import timeout_add, timeout_add_seconds, source_remove
 
 
-class Timer(object):
+class Timer:
     """Object to schedule functions and methods to the GLib event loop.
 
     Everything scheduled by Timer is ran on the main thread!

--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -335,7 +335,7 @@ def execReadlines(command, argv, stdin=None, root='/', env_prune=None, filter_st
         This returns an iterator with the lines from the command until it has finished
     """
 
-    class ExecLineReader(object):
+    class ExecLineReader:
         """Iterator class for returning lines from a process and cleaning
            up the process when the output is no longer needed.
         """
@@ -799,7 +799,7 @@ def get_anaconda_version_string(build_time_version=False):
         return "unknown"
 
 
-class LazyObject(object):
+class LazyObject:
     """The lazy object."""
 
     def __init__(self, getter):

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -72,7 +72,7 @@ ERROR_RETRY = 2
 # TOP-LEVEL ERROR HANDLING OBJECT
 ###
 
-class ErrorHandler(object):
+class ErrorHandler:
     """This object makes up one part of anaconda's error handling system.  This
        part is the UI-agnostic error callback.  Throughout anaconda, various
        error conditions can occur in places that need to pop up a dialog, but

--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -23,7 +23,7 @@ log = get_module_logger(__name__)
 
 
 # A lot of effort, but it only allows a limited set of flags to be referenced
-class Flags(object):
+class Flags:
     def __setattr__(self, attr, val):
         # pylint: disable=no-member
         if attr not in self.__dict__ and not self._in_init:

--- a/pyanaconda/gnome_remote_desktop.py
+++ b/pyanaconda/gnome_remote_desktop.py
@@ -72,7 +72,7 @@ def shutdown_server():
             log.error("Shutdown of the GNOME Remote Desktop session failed with exception:\n%s", e)
 
 
-class GRDServer(object):
+class GRDServer:
 
     def __init__(self, anaconda, root="/", ip=None,
                  rdp_username="", rdp_password=""):

--- a/pyanaconda/input_checking.py
+++ b/pyanaconda/input_checking.py
@@ -48,7 +48,7 @@ def get_policy(policy_name) -> PasswordPolicy:
     return PasswordPolicy.from_defaults(policy_name)
 
 
-class PwqualitySettingsCache(object):
+class PwqualitySettingsCache:
     """Cache for libpwquality settings used for password validation.
 
     Libpwquality settings instantiation is probably not exactly cheap
@@ -75,7 +75,7 @@ class PwqualitySettingsCache(object):
 pwquality_settings_cache = PwqualitySettingsCache()
 
 
-class PasswordCheckRequest(object):
+class PasswordCheckRequest:
     """A wrapper for a password check request.
 
     This in general means the password to be checked as well as its validation criteria
@@ -200,7 +200,7 @@ class PasswordCheckRequest(object):
         self._secret_type = new_type
 
 
-class CheckResult(object):
+class CheckResult:
     """Result of an input check."""
 
     def __init__(self):
@@ -312,7 +312,7 @@ class PasswordValidityCheckResult(CheckResult):
         self.length_ok_changed.emit(value)
 
 
-class InputCheck(object):
+class InputCheck:
     """Input checking base class."""
 
     def __init__(self):
@@ -571,7 +571,7 @@ class FullnameCheck(InputCheck):
             self.result.success = False
 
 
-class InputField(object):
+class InputField:
     """An input field containing data to be checked.
 
     The input field can have an initial value that can be
@@ -602,7 +602,7 @@ class InputField(object):
                 self._initial_change_signal_fired = True
 
 
-class PasswordChecker(object):
+class PasswordChecker:
     """Run multiple password and input checks in a given order and report the results.
 
     All added checks (in insertion order) will be run and results returned as error message

--- a/pyanaconda/installation_tasks.py
+++ b/pyanaconda/installation_tasks.py
@@ -34,7 +34,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class BaseTask(object):
+class BaseTask:
     """A base class for Task and TaskQueue.
 
     It holds shared methods, properties and signals.

--- a/pyanaconda/lifecycle.py
+++ b/pyanaconda/lifecycle.py
@@ -80,7 +80,7 @@ def add_controller(controller_name, controller_categories):
     return controller
 
 
-class Controller(object):
+class Controller:
     """A singleton that track initialization of Anaconda modules."""
     def __init__(self):
         self._lock = RLock()

--- a/pyanaconda/modules/boss/install_manager/install_manager.py
+++ b/pyanaconda/modules/boss/install_manager/install_manager.py
@@ -23,7 +23,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class InstallManager(object):
+class InstallManager:
     """Manager of the system installation."""
 
     def __init__(self):

--- a/pyanaconda/modules/boss/kickstart_manager/element.py
+++ b/pyanaconda/modules/boss/kickstart_manager/element.py
@@ -18,7 +18,7 @@
 from enum import Enum
 
 
-class KickstartElement(object):
+class KickstartElement:
     """Stores element parsed from kickstart with reference to file.
 
     Element can be a command, a section or an addon. Addon is not considered
@@ -140,7 +140,7 @@ class KickstartElement(object):
         return content
 
 
-class KickstartElements(object):
+class KickstartElements:
     """Container for storing and filtering KickstartElement objects
 
     Preserves order of added elements.

--- a/pyanaconda/modules/boss/kickstart_manager/kickstart_manager.py
+++ b/pyanaconda/modules/boss/kickstart_manager/kickstart_manager.py
@@ -30,7 +30,7 @@ log = get_module_logger(__name__)
 __all__ = ['KickstartManager']
 
 
-class KickstartManager(object):
+class KickstartManager:
     """Distributes kickstart to modules and collects it back."""
 
     def __init__(self):

--- a/pyanaconda/modules/boss/module_manager/module_manager.py
+++ b/pyanaconda/modules/boss/module_manager/module_manager.py
@@ -25,7 +25,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class ModuleManager(object):
+class ModuleManager:
     """A class for managing kickstart modules."""
 
     def __init__(self):

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -26,7 +26,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class LocaledWrapper(object):
+class LocaledWrapper:
     """Class wrapping systemd-localed daemon functionality."""
 
     def __init__(self):

--- a/pyanaconda/modules/network/device_configuration.py
+++ b/pyanaconda/modules/network/device_configuration.py
@@ -61,7 +61,7 @@ virtual_device_types = [
 ]
 
 
-class DeviceConfigurations(object):
+class DeviceConfigurations:
     """Stores the state of persistent configuration of network devices.
 
     Contains only configuration of devices supported by Anaconda.

--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -88,7 +88,7 @@ class InvalidSelectionError(DNFManagerError):
     """The software selection couldn't be resolved."""
 
 
-class DNFManager(object):
+class DNFManager:
     """The abstraction of the DNF base."""
 
     def __init__(self):

--- a/pyanaconda/modules/payloads/payload/dnf/tree_info.py
+++ b/pyanaconda/modules/payloads/payload/dnf/tree_info.py
@@ -83,7 +83,7 @@ class InvalidTreeInfoError(TreeInfoMetadataError):
     pass
 
 
-class TreeInfoMetadata(object):
+class TreeInfoMetadata:
     """The representation of a .treeinfo file.
 
     The structure of the installation root can be similar to this:
@@ -382,7 +382,7 @@ class TreeInfoMetadata(object):
         return None
 
 
-class TreeInfoRepoMetadata(object):
+class TreeInfoRepoMetadata:
     """Metadata repo object contains metadata about repository."""
 
     def __init__(self, repo_name, tree_info, root_url):

--- a/pyanaconda/modules/payloads/payload/factory.py
+++ b/pyanaconda/modules/payloads/payload/factory.py
@@ -22,7 +22,7 @@ from pyanaconda.modules.payloads.constants import PayloadType
 __all__ = ["PayloadFactory"]
 
 
-class PayloadFactory(object):
+class PayloadFactory:
     """Factory to create payloads."""
 
     @staticmethod

--- a/pyanaconda/modules/payloads/payload/live_image/download_progress.py
+++ b/pyanaconda/modules/payloads/payload/live_image/download_progress.py
@@ -25,7 +25,7 @@ __all__ = ["DownloadProgress"]
 log = get_module_logger(__name__)
 
 
-class DownloadProgress(object):
+class DownloadProgress:
     """Provide methods for image download progress reporting."""
 
     def __init__(self, url, total_size, callback):

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_manager.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_manager.py
@@ -39,7 +39,7 @@ log = get_module_logger(__name__)
 __all__ = ["FlatpakManager"]
 
 
-class FlatpakManager(object):
+class FlatpakManager:
     """Main class to handle flatpak installation and management."""
 
     LOCAL_REMOTE_NAME = "Anaconda"

--- a/pyanaconda/modules/payloads/source/factory.py
+++ b/pyanaconda/modules/payloads/source/factory.py
@@ -23,7 +23,7 @@ from pyanaconda.modules.payloads.source.utils import is_tar
 __all__ = ["SourceFactory"]
 
 
-class SourceFactory(object):
+class SourceFactory:
     """Factory to create payload sources."""
 
     @staticmethod

--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -164,7 +164,7 @@ class BootLoaderArguments:
             self.add(key)
 
 
-class BootLoader(object):
+class BootLoader:
     """A base class for boot loaders."""
 
     name = "Generic Bootloader"

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -43,7 +43,7 @@ __all__ = [
 ]
 
 
-class EFIBase(object):
+class EFIBase:
     """A base class for EFI-based boot loaders."""
 
     @property

--- a/pyanaconda/modules/storage/bootloader/execution.py
+++ b/pyanaconda/modules/storage/bootloader/execution.py
@@ -44,7 +44,7 @@ def setup_bootloader(storage, dry_run=False):
     executor.execute(storage=storage, dry_run=dry_run)
 
 
-class BootloaderExecutor(object):
+class BootloaderExecutor:
     """The executor of the bootloader command."""
 
     def execute(self, storage, dry_run=False):

--- a/pyanaconda/modules/storage/bootloader/factory.py
+++ b/pyanaconda/modules/storage/bootloader/factory.py
@@ -23,7 +23,7 @@ log = get_module_logger(__name__)
 __all__ = ["BootLoaderFactory"]
 
 
-class BootLoaderFactory(object):
+class BootLoaderFactory:
     """The boot loader factory."""
 
     # The default boot loader class.

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -34,7 +34,7 @@ log = get_module_logger(__name__)
 __all__ = ["GRUB2", "IPSeriesGRUB2"]
 
 
-class SerialConsoleOptions(object):
+class SerialConsoleOptions:
     """The serial console options."""
 
     def __init__(self):

--- a/pyanaconda/modules/storage/bootloader/image.py
+++ b/pyanaconda/modules/storage/bootloader/image.py
@@ -19,7 +19,7 @@
 __all__ = ["BootLoaderImage", "LinuxBootLoaderImage"]
 
 
-class BootLoaderImage(object):
+class BootLoaderImage:
     """A base class for boot loader images.
 
     Suitable for non-linux OS images.

--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -537,7 +537,7 @@ def verify_lvm_destruction(storage, constraints, report_error, report_warning):
             ))
 
 
-class StorageCheckerReport(object):
+class StorageCheckerReport:
     """Class for results of the storage checking."""
 
     def __init__(self):
@@ -599,7 +599,7 @@ class StorageCheckerReport(object):
                 logger.warning(msg)
 
 
-class StorageChecker(object):
+class StorageChecker:
     """Class for advanced storage checking."""
 
     def __init__(self):

--- a/pyanaconda/modules/storage/devicetree/fsset.py
+++ b/pyanaconda/modules/storage/devicetree/fsset.py
@@ -172,7 +172,7 @@ def get_system_filesystems(devicetree):
     return devices
 
 
-class BlkidTab(object):
+class BlkidTab:
     """ Dictionary-like interface to blkid.tab with device path keys """
 
     def __init__(self, chroot=""):
@@ -214,7 +214,7 @@ class BlkidTab(object):
         return self.devices.get(key, default)
 
 
-class CryptTab(object):
+class CryptTab:
     """ Dictionary-like interface to crypttab entries with map name keys """
 
     def __init__(self, devicetree, blkid_tab=None, chroot=""):
@@ -300,7 +300,7 @@ class CryptTab(object):
         return self.mappings.get(key, default)
 
 
-class FSSet(object):
+class FSSet:
     """A class to represent a set of filesystems."""
 
     def __init__(self, devicetree):

--- a/pyanaconda/modules/storage/devicetree/root.py
+++ b/pyanaconda/modules/storage/devicetree/root.py
@@ -315,7 +315,7 @@ def _parse_fstab(devicetree, chroot):
     return mounts, devices, mountopts
 
 
-class Root(object):
+class Root:
     """A root represents an existing OS installation."""
 
     def __init__(self, name=None, product=None, version=None, arch=None, devices=None,

--- a/pyanaconda/modules/storage/disk_initialization/configuration.py
+++ b/pyanaconda/modules/storage/disk_initialization/configuration.py
@@ -29,7 +29,7 @@ log = get_module_logger(__name__)
 _all__ = ["DiskInitializationConfig"]
 
 
-class DiskInitializationConfig(object):
+class DiskInitializationConfig:
     """Configuration of the disk initialization."""
 
     def __init__(self):

--- a/pyanaconda/modules/storage/partitioning/factory.py
+++ b/pyanaconda/modules/storage/partitioning/factory.py
@@ -22,7 +22,7 @@ from pyanaconda.modules.storage.partitioning.constants import PartitioningMethod
 __all__ = ["PartitioningFactory"]
 
 
-class PartitioningFactory(object):
+class PartitioningFactory:
     """The partitioning factory."""
 
     @staticmethod

--- a/pyanaconda/modules/storage/partitioning/specification.py
+++ b/pyanaconda/modules/storage/partitioning/specification.py
@@ -22,7 +22,7 @@ from pykickstart.constants import AUTOPART_TYPE_PLAIN, AUTOPART_TYPE_BTRFS, AUTO
     AUTOPART_TYPE_LVM_THINP
 
 
-class PartSpec(object):
+class PartSpec:
 
     def __init__(self, mountpoint=None, fstype=None, size=None, max_size=None,
                  grow=False, btr=False, lv=False, thin=False, weight=0,

--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -48,7 +48,7 @@ DASD_DESCRIPTION = N_("DASD")
 ZFCP_DESCRIPTION = N_("zFCP")
 
 
-class Platform(object):
+class Platform:
     """A base class for a platform.
 
     A class containing platform-specific information and methods for use

--- a/pyanaconda/mutter_display.py
+++ b/pyanaconda/mutter_display.py
@@ -30,7 +30,7 @@ class MutterConfigError(Exception):
     pass
 
 
-class MonitorId(object):
+class MonitorId:
     """Collection of properties that identify a unique monitor."""
 
     def __init__(self, props):
@@ -46,7 +46,7 @@ class MonitorId(object):
                self.serial == other.serial
 
 
-class MonitorMode(object):
+class MonitorMode:
     """Available modes for a monitor."""
 
     def __init__(self, props):
@@ -59,7 +59,7 @@ class MonitorMode(object):
         self.properties = props[6]
 
 
-class Monitor(object):
+class Monitor:
     """Represent a connected physical monitor."""
 
     def __init__(self, props):
@@ -68,7 +68,7 @@ class Monitor(object):
         self.properties = props[2]
 
 
-class LogicalMonitor(object):
+class LogicalMonitor:
     """Represent the current logical monitor configuration"""
 
     def __init__(self, props):
@@ -81,7 +81,7 @@ class LogicalMonitor(object):
         self.properties = props[6]
 
 
-class LogicalMonitorConfig(object):
+class LogicalMonitorConfig:
     """Logical monitor configuration object"""
 
     def __init__(self, logical_monitor, monitors, x, y, width, height):
@@ -120,7 +120,7 @@ class LogicalMonitorConfig(object):
         )
 
 
-class MutterDisplay(object):
+class MutterDisplay:
     """Class wrapping Mutter's display configuration API."""
 
     def __init__(self):

--- a/pyanaconda/ntp.py
+++ b/pyanaconda/ntp.py
@@ -228,7 +228,7 @@ def save_servers_to_config(servers, conf_file_path=NTP_CONFIG_FILE, out_file_pat
             raise NTPconfigError(msg.format(oserr.strerror)) from oserr
 
 
-class NTPServerStatusCache(object):
+class NTPServerStatusCache:
     """The cache of NTP server states."""
 
     def __init__(self):

--- a/pyanaconda/queuefactory.py
+++ b/pyanaconda/queuefactory.py
@@ -20,7 +20,7 @@ import queue
 from pyanaconda.core.string import upper_ascii, lower_ascii
 
 
-class QueueFactory(object):
+class QueueFactory:
     """Constructs a new object wrapping a Queue.Queue, complete with constants
        and sending functions for each type of message that can be put into the
        queue.

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -127,7 +127,7 @@ class RescueModeStatus(Enum):
     ROOT_NOT_FOUND = "root not found"
 
 
-class Rescue(object):
+class Rescue:
     """Rescue mode module.
 
         Provides interface to:

--- a/pyanaconda/ui/__init__.py
+++ b/pyanaconda/ui/__init__.py
@@ -36,7 +36,7 @@ class PathDict(dict):
         return new_dict
 
 
-class UserInterface(object):
+class UserInterface:
     """This is the base class for all kinds of install UIs.  It primarily
        defines what kinds of dialogs and entry widgets every interface must
        provide that the rest of anaconda may rely upon.

--- a/pyanaconda/ui/common.py
+++ b/pyanaconda/ui/common.py
@@ -30,7 +30,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class UIObject(object):
+class UIObject:
     """This is the base class from which all other UI classes are derived.  It
        thus contains only attributes and methods that are common to everything
        else.  It should not be directly instantiated.
@@ -101,7 +101,7 @@ class UIObject(object):
         return self._data
 
 
-class FirstbootSpokeMixIn(object):
+class FirstbootSpokeMixIn:
     """This MixIn class marks Spokes as usable for Firstboot
        and Anaconda.
     """
@@ -134,7 +134,7 @@ class FirstbootSpokeMixIn(object):
         return False
 
 
-class FirstbootOnlySpokeMixIn(object):
+class FirstbootOnlySpokeMixIn:
     """This MixIn class marks Spokes as usable for Firstboot."""
     @classmethod
     def should_run(cls, environment, data):

--- a/pyanaconda/ui/context.py
+++ b/pyanaconda/ui/context.py
@@ -19,7 +19,7 @@
 __all__ = ["context"]
 
 
-class UserInterfaceContext(object):
+class UserInterfaceContext:
     """The context of the user interface.
 
     The context provides access to persistent objects

--- a/pyanaconda/ui/gui/spokes/advanced_storage.py
+++ b/pyanaconda/ui/gui/spokes/advanced_storage.py
@@ -111,7 +111,7 @@ def create_row(device_data, selected, mutable):
     )
 
 
-class FilterPage(object):
+class FilterPage:
     """A FilterPage is the logic behind one of the notebook tabs on the filter
        UI spoke.  Each page has its own specific filtered model overlaid on top
        of a common model that holds all non-advanced disks.

--- a/pyanaconda/ui/gui/spokes/lib/additional_repositories.py
+++ b/pyanaconda/ui/gui/spokes/lib/additional_repositories.py
@@ -29,7 +29,7 @@ log = get_module_logger(__name__)
 __all__ = ["AdditionalRepositoriesSection"]
 
 
-class AdditionalRepositoriesSection(object):
+class AdditionalRepositoriesSection:
     """Representation of the additional repositories section.
 
     NOTE: This class is just a data holder now. The widget was removed.

--- a/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
+++ b/pyanaconda/ui/gui/spokes/lib/lang_locale_handler.py
@@ -35,7 +35,7 @@ gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import Gtk, Pango, GdkPixbuf
 
 
-class LangLocaleHandler(object, metaclass=ABCMeta):
+class LangLocaleHandler(metaclass=ABCMeta):
     """
     Class that could be used as a mixin for screens handling languages or
     locales configuration.

--- a/pyanaconda/ui/gui/spokes/lib/network_secret_agent.py
+++ b/pyanaconda/ui/gui/spokes/lib/network_secret_agent.py
@@ -124,7 +124,7 @@ class SecretAgentDialog(GUIObject):
 
 
 @dbus_interface(SECRET_AGENT.interface_name)
-class SecretAgent(object):
+class SecretAgent:
     def __init__(self, ui_callback):
         """Create a SecretAgent instance.
 

--- a/pyanaconda/ui/gui/utils.py
+++ b/pyanaconda/ui/gui/utils.py
@@ -180,7 +180,7 @@ def timed_action(delay=300, threshold=750, busy_cursor=True):
 
     """
 
-    class TimedAction(object):
+    class TimedAction:
         """Class making the timing work."""
 
         def __init__(self, func):

--- a/pyanaconda/ui/gui/xkl_wrapper.py
+++ b/pyanaconda/ui/gui/xkl_wrapper.py
@@ -34,7 +34,7 @@ iso_ = lambda x: gettext.translation("iso_639", fallback=True).gettext(x)
 # namedtuple for information about a keyboard layout (its language and description)
 LayoutInfo = namedtuple("LayoutInfo", ["langs", "desc"])
 
-class XklWrapper(object):
+class XklWrapper:
     """
     Class that used to wrap libxklavier functionality.
 

--- a/pyanaconda/ui/helpers.py
+++ b/pyanaconda/ui/helpers.py
@@ -73,12 +73,12 @@ def get_distribution_text():
     }
 
 
-class StorageCheckHandler(object, metaclass=ABCMeta):
+class StorageCheckHandler(metaclass=ABCMeta):
     errors = []
     warnings = []
 
 
-class SourceSwitchHandler(object, metaclass=ABCMeta):
+class SourceSwitchHandler(metaclass=ABCMeta):
     """ A class that can be used as a mixin handling
     installation source switching.
     It will correctly switch to the new method
@@ -158,7 +158,7 @@ class SourceSwitchHandler(object, metaclass=ABCMeta):
         self._set_source(source_proxy)
 
 
-class InputCheck(object):
+class InputCheck:
     """Handle an input validation check.
 
        This class is used by classes that implement InputCheckHandler to
@@ -229,7 +229,7 @@ class InputCheck(object):
         self._enabled = value
 
 
-class InputCheckHandler(object, metaclass=ABCMeta):
+class InputCheckHandler(metaclass=ABCMeta):
     """Provide a framework for adding input validation checks to a screen.
 
        This helper class provides a mean of defining and associating input

--- a/pyanaconda/ui/lib/format_dasd.py
+++ b/pyanaconda/ui/lib/format_dasd.py
@@ -32,7 +32,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class DasdFormatting(object):
+class DasdFormatting:
     """Class for formatting DASDs."""
 
     def __init__(self):

--- a/pyanaconda/ui/lib/software.py
+++ b/pyanaconda/ui/lib/software.py
@@ -136,7 +136,7 @@ def get_kernel_from_properties(features):
     return kernel_package
 
 
-class SoftwareSelectionCache(object):
+class SoftwareSelectionCache:
     """The cache of the user software selection.
 
     Use the software selection cache to select environments

--- a/pyanaconda/ui/lib/space.py
+++ b/pyanaconda/ui/lib/space.py
@@ -28,7 +28,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class FileSystemSpaceChecker(object):
+class FileSystemSpaceChecker:
     """This object provides for a way to verify that enough space is available
        on configured file systems to support the current software selections.
        It is run as part of completeness checking every time a spoke changes,

--- a/pyanaconda/ui/tui/tuiobject.py
+++ b/pyanaconda/ui/tui/tuiobject.py
@@ -115,7 +115,7 @@ class TUIObject(UIScreen, common.UIObject):
         UIScreen.refresh(self, args)
 
 
-class Dialog(object):
+class Dialog:
 
     def __init__(self, title, conditions=None, report_func=reporting_callback):
         """Get all required information and ask user for input.

--- a/tests/rpm_tests/test_create_rpm.py
+++ b/tests/rpm_tests/test_create_rpm.py
@@ -292,7 +292,7 @@ class InstalledFilesTestCase(RPMTestCase):
         return in_iter
 
 
-class FileFilters(object):
+class FileFilters:
 
     @staticmethod
     def makefiles_exclude(path):
@@ -382,7 +382,7 @@ class FileFilters(object):
     def src_ignore_exclude(path):
         return path not in IGNORED_SOURCE_FILES
 
-class RPMFilters(object):
+class RPMFilters:
 
     @staticmethod
     def debug_exclude(rpm):
@@ -398,7 +398,7 @@ class RPMFilters(object):
         return "anaconda-core" in rpm
 
 
-class ModifyingFilters(object):
+class ModifyingFilters:
 
     @staticmethod
     def rename_dot_in_files(path):

--- a/tests/unit_tests/pyanaconda_tests/__init__.py
+++ b/tests/unit_tests/pyanaconda_tests/__init__.py
@@ -34,7 +34,7 @@ from pyanaconda.modules.common.task import TaskInterface
 from dasbus.typing import get_native
 
 
-class run_in_glib(object):
+class run_in_glib:
     """Run the test methods in GLib.
 
     :param timeout: Timeout in seconds when the loop will be killed.

--- a/tests/unit_tests/pyanaconda_tests/core/test_signal.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_signal.py
@@ -24,7 +24,7 @@ import unittest
 
 from pyanaconda.core.signal import Signal
 
-class FooClass(object):
+class FooClass:
     def __init__(self):
         self._var = None
 

--- a/tests/unit_tests/pyanaconda_tests/core/test_util.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_util.py
@@ -641,7 +641,7 @@ class MiscTests(unittest.TestCase):
 
         # The @synchronized decorator work on methods of classes
         # that provide self._lock with Lock or RLock instance.
-        class LockableClass(object):
+        class LockableClass:
             def __init__(self):
                 self._lock = Lock()
 
@@ -659,7 +659,7 @@ class MiscTests(unittest.TestCase):
         assert lockable.sync_test_method()
 
         # The @synchronized decorator does not work on classes without self._lock.
-        class NotLockableClass(object):
+        class NotLockableClass:
             @synchronized
             def sync_test_method(self):
                 return "Hello world!"
@@ -863,7 +863,7 @@ class MiscTests(unittest.TestCase):
 
 class LazyObjectTestCase(unittest.TestCase):
 
-    class Object(object):
+    class Object:
 
         def __init__(self):
             self._x = 0

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_kickstart.py
@@ -471,7 +471,7 @@ class TestRunScriptsTask(unittest.TestCase):
         script.run.assert_called_once_with('/')
 
 
-class TestModule(object):
+class TestModule:
 
     def __init__(self, commands=None, sections=None, addons=None):
         self.kickstart_commands = commands or []

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/module_payload_shared.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/module_payload_shared.py
@@ -28,7 +28,7 @@ from pyanaconda.modules.payloads.source.factory import SourceFactory
 from pyanaconda.modules.payloads.constants import SourceState
 
 
-class PayloadKickstartSharedTest(object):
+class PayloadKickstartSharedTest:
 
     def __init__(self, payload_service, payload_service_intf):
         """Setup shared payload testing object for testing kickstart.
@@ -66,7 +66,7 @@ class PayloadKickstartSharedTest(object):
         return self.payload_service.active_payload
 
 
-class PayloadSharedTest(object):
+class PayloadSharedTest:
 
     def __init__(self, payload, payload_intf):
         """Setup shared payload test object for common payload testing.

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py
@@ -357,7 +357,7 @@ class FlatpakTest(unittest.TestCase):
         ], any_order=True)
 
 
-class OperationMock(object):
+class OperationMock:
     """Mock of the Flatpak.TransactionOperation class."""
 
     def __init__(self, ref="app/org.test/x86_64", op=TransactionOperationType.INSTALL):
@@ -371,7 +371,7 @@ class OperationMock(object):
         return self._op
 
 
-class RefMock(object):
+class RefMock:
     """Mock of the Flatpak.InstalledRef class."""
 
     def __init__(self, ref="app/org.test/x86_64", installed_size=0):

--- a/tests/unit_tests/pyanaconda_tests/test_controller.py
+++ b/tests/unit_tests/pyanaconda_tests/test_controller.py
@@ -22,7 +22,7 @@ import unittest
 
 from pyanaconda.lifecycle import Controller
 
-class TestModule(object):
+class TestModule:
     def __init__(self):
         self._test = 1
 


### PR DESCRIPTION
Since Python 3, all classes inherit from object by default, so object can be omitted from the list of base classes.

Auto-fixed with: ruff check --fix --select UP004 .

