### PR TITLE
tests: skip checks using Iterable from abc

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/core/test_kernel.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_kernel.py
@@ -18,7 +18,9 @@
 
 import unittest
 from pyanaconda.core.kernel import KernelArguments, kernel_arguments
-from collections.abc import Iterable
+# FIXME: https://github.com/pylint-dev/pylint/issues/10112
+# Re-enable the following line when the issue is fixed
+# from collections.abc import Iterable
 
 
 class KernelArgumentsTests(unittest.TestCase):
@@ -77,7 +79,9 @@ class KernelArgumentsTests(unittest.TestCase):
 
         ka = KernelArguments.from_defaults()
         it = ka.items()
-        assert isinstance(it, Iterable)
+        # FIXME: https://github.com/pylint-dev/pylint/issues/10112
+        # Re-enable the following line when the issue is fixed
+        # assert isinstance(it, Iterable)
         root_seen = False
         for k, v in it:  # pylint: disable=unused-variable
             if k == "root":
@@ -91,7 +95,9 @@ class KernelArgumentsTests(unittest.TestCase):
             "blah inst.foo=anything inst.nothing=indeed")
         it = ka.items_raw()
 
-        assert isinstance(it, Iterable)
+        # FIXME: https://github.com/pylint-dev/pylint/issues/10112
+        # Re-enable the following line when the issue is fixed
+        # assert isinstance(it, Iterable)
 
         res = dict()
         for k, v in it:


### PR DESCRIPTION
python-3.13.1 broke compatibility with pylint.

Revert this one the pylint issue [1] is fixed.

[1] https://github.com/pylint-dev/pylint/issues/10112
[2] https://github.com/pylint-dev/astroid/pull/2656
