### PR TITLE
Fix crash during shutdown by deferring DBus disconnection

### DIFF
--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -99,8 +99,8 @@ class Service(BaseModule):
 
     def stop(self):
         """Stop the loop."""
-        DBus.disconnect()
         Timer().timeout_sec(1, self.loop.quit)
+        DBus.disconnect()
 
     def set_locale(self, locale):
         """Set the locale for the module.


### PR DESCRIPTION
During the shutdown process in the stop method of the modules, the DBus.disconnect() call was executed too early, leading to a race condition:
The DBus connection was torn down while pending method invocations were still being processed. As a result, attempts to handle errors or finalize ongoing calls (e.g., Quit) could reference invalid or cleaned-up objects, leading to crashes.

This issue became apparent after changes in pygobject's DBus handling introduced stricter cleanup of invocation objects upon disconnection.
The updated behavior exposed the underlying problem in the shutdown sequence.

To fix this, the DBus.disconnect() call is deferred until after the event loop is scheduled to quit.

Resolves rhbz#2329587


