### PR TITLE
Handle invalid UTF-8 characters in efibootmgr output

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -111,7 +111,9 @@ class EFIBase:
                 self._add_single_efi_boot_target(parent)
 
     def remove_efi_boot_target(self):
-        buf = self.efibootmgr(capture=True)
+        # FIXME: Stop using replace_utf_decode_errors=True once
+        # https://github.com/rhboot/efibootmgr/pull/221/ is merged
+        buf = self.efibootmgr(capture=True, replace_utf_decode_errors=True)
         for line in buf.splitlines():
             try:
                 (slot, _product) = line.split(None, 1)


### PR DESCRIPTION
Modified the code to handle invalid UTF-8 characters in the output of the efibootmgr command by
using `errors="replace"`. This prevents decode exceptions when encountering non-UTF-8 sequences
in the EFI boot manager output [1].

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2292493#c21
Resolves: rhbz#2254801

