### PR TITLE
infra: rename the 'master' branch to 'main'

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   # Use the yaml from a specific branch.
-  strict_yaml_branch: master
+  strict_yaml_branch: main
   # Don't wait for all other statuses to pass.
   require_ci_to_pass: false
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,7 +7,7 @@ template, not the rendered `.yml` file. To rebuild the workflow files from templ
 `.branch-variables.yml` file in the repo root.
 
 Most of the workflows are triggered by cron or comment events, so they belong only on the default
-branch which is `master`. These workflows are removed by templates on other branches. If the first
+branch which is `main`. These workflows are removed by templates on other branches. If the first
 line is `{% if distro_release == "rawhide" %}` then the workflow is of such kind.
 
 When editing a template, the following roughly describes what to expect:
@@ -42,12 +42,12 @@ Then, you should be fine to just create PR with changes to workflow and test on 
 For other triggers using a fork GitHub repository
 -------------------------------------------------
 
-However, if you have any other trigger than that you need a fork because workflow is always taken from the default branch of the repository (in case of Anaconda from master branch). To debug such a workflow follow these steps:
+However, if you have any other trigger than that you need a fork because workflow is always taken from the default branch of the repository (in case of Anaconda from main branch). To debug such a workflow follow these steps:
 
 1. Make your changes on the workflow.
-2. Push these changes to your fork master branch
+2. Push these changes to your fork main branch
     ```bash
-    git push -f <fork name> HEAD:master # force push current HEAD to master branch on your fork
+    git push -f <fork name> HEAD:main # force push current HEAD to main branch on your fork
     ```
 3. Go to your fork settings page **Actions → General** and make sure that **Allow all actions and reusable workflows** is selected.
 4. Run the specific workflow by executing the event trigger.

--- a/.github/workflows/container-autoupdate-eln.yml
+++ b/.github/workflows/container-autoupdate-eln.yml
@@ -25,5 +25,5 @@ jobs:
     secrets: inherit
     with:
       container-tag: eln
-      branch: master
+      branch: main
       base-container: 'quay.io/fedoraci/fedora:eln-x86_64'

--- a/.github/workflows/container-autoupdate-eln.yml.j2
+++ b/.github/workflows/container-autoupdate-eln.yml.j2
@@ -19,6 +19,6 @@ jobs:
     secrets: inherit
     with:
       container-tag: eln
-      branch: master
+      branch: main
       base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
 {% endif %}

--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master', 'rhel-9', 'rhel-10']
+        branch: ['main', 'rhel-9', 'rhel-10']
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
     uses: ./.github/workflows/container-rebuild-action.yml

--- a/.github/workflows/container-autoupdate.yml.j2
+++ b/.github/workflows/container-autoupdate.yml.j2
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
+        branch: ['main'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
     uses: ./.github/workflows/container-rebuild-action.yml

--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -7,7 +7,7 @@
 
 name: Rebuild container images
 # Rebuilds both ci and rpm container images for a given "target". Currently known targets:
-#  - master
+#  - main
 #  - eln
 #  - fedora-NN
 #
@@ -94,11 +94,11 @@ jobs:
       - name: Login to container registry
         run: podman login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
 
-        # we can hardcode the path to the image here because this will be executed only for master image
-      - name: Add latest tag for master container
-        if: ${{ inputs.container-tag == 'master' }}
+        # we can hardcode the path to the image here because this will be executed only for main image
+      - name: Add latest tag for main container
+        if: ${{ inputs.container-tag == 'main' }}
         run: |
-          podman tag quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:master quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:latest
+          podman tag quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:main quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:latest
           CI_TAG=latest make -f Makefile.am anaconda-${{ matrix.container-type }}-push
 
       - name: Push container to registry

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -2,7 +2,7 @@ name: Differential ShellCheck
 on:
   push:
   pull_request:
-    branches: [ master, rhel-*, fedora-* ]
+    branches: [ main, rhel-*, fedora-* ]
 
 permissions:
   contents: read

--- a/.github/workflows/l10n-po-update.yml
+++ b/.github/workflows/l10n-po-update.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        branch: ['master', 'rhel-9', 'rhel-10']
+        branch: ['main', 'rhel-9', 'rhel-10']
 
     steps:
       - name: Set up dependencies

--- a/.github/workflows/l10n-po-update.yml.j2
+++ b/.github/workflows/l10n-po-update.yml.j2
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        branch: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
+        branch: ['main'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
 
     steps:
       - name: Set up dependencies

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -9,7 +9,7 @@ name: Run tests on push
 on:
   push:
     branches:
-      - master
+      - main
       - fedora-[0-9]+
 
 permissions:

--- a/.github/workflows/push-tests.yml.j2
+++ b/.github/workflows/push-tests.yml.j2
@@ -3,7 +3,7 @@ name: Run tests on push
 on:
   push:
     branches:
-      - master
+      - main
       - fedora-[0-9]+
 
 permissions:

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -60,10 +60,10 @@ jobs:
             fi
           done
 
-  infra-template-master-match-check:
+  infra-template-main-match-check:
     runs-on: ubuntu-22.04
-    name: Compare templates files with master branch
-    if: github.event.pull_request.base.ref != 'master'
+    name: Compare templates files with main branch
+    if: github.event.pull_request.base.ref != 'main'
 
     steps:
       - name: Clone Anaconda repository
@@ -82,7 +82,7 @@ jobs:
           git log --oneline -1 origin/${{ github.event.pull_request.base.ref }}
           git rebase origin/${{ github.event.pull_request.base.ref }}
 
-      - name: Check if all changed template files are matching master branch
+      - name: Check if all changed template files are matching main branch
         run: |
           changed_template_files_in_pr=$(git diff --diff-filter=M --name-only origin/${{ github.event.pull_request.base.ref }} "*.j2")
           if [ -z "$changed_template_files_in_pr" ]; then
@@ -91,11 +91,11 @@ jobs:
             exit 0
           fi
 
-          changed_files=$(git diff --diff-filter=M --name-only origin/master "*.j2")
+          changed_files=$(git diff --diff-filter=M --name-only origin/main "*.j2")
 
           if [ -n "$changed_files" ]; then
             # print for debugging
-            echo "----- Template files differ with master branch -----"
+            echo "----- Template files differ with main branch -----"
             echo "$changed_files"
             echo "-------------------------"
 

--- a/.github/workflows/tests-daily.yml
+++ b/.github/workflows/tests-daily.yml
@@ -42,14 +42,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['master', 'rhel-9', 'rhel-10']
+        release: ['main', 'rhel-9', 'rhel-10']
         include:
-          - release: 'master'
-            target_branch: 'master'
-            ci_tag: 'master'
+          - release: 'main'
+            target_branch: 'main'
+            ci_tag: 'main'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: 'eln'
-          #  target_branch: 'master'
+          #  target_branch: 'main'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
           - release: 'rhel-9'
@@ -90,11 +90,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['master', 'rhel-9', 'rhel-10']
+        release: ['main', 'rhel-9', 'rhel-10']
         include:
-          - release: 'master'
-            target_branch: 'master'
-            ci_tag: 'master'
+          - release: 'main'
+            target_branch: 'main'
+            ci_tag: 'main'
           - release: 'rhel-9'
             target_branch: 'rhel-9'
             ci_tag: 'rhel-9'

--- a/.github/workflows/tests-daily.yml.j2
+++ b/.github/workflows/tests-daily.yml.j2
@@ -43,14 +43,14 @@ jobs:
         # * This is still a matrix because we might re-enable ELN one day and then we will need
         #   a matrix here.
         #}
-        release: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
+        release: ['main'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
         include:
-          - release: 'master'
-            target_branch: 'master'
-            ci_tag: 'master'
+          - release: 'main'
+            target_branch: 'main'
+            ci_tag: 'main'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: 'eln'
-          #  target_branch: 'master'
+          #  target_branch: 'main'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
         {% for branch in supported_branches %}
@@ -91,11 +91,11 @@ jobs:
       fail-fast: false
       matrix:
         {# For matrix details, see comments for the unit tests above. #}
-        release: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
+        release: ['main'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
         include:
-          - release: 'master'
-            target_branch: 'master'
-            ci_tag: 'master'
+          - release: 'main'
+            target_branch: 'main'
+            ci_tag: 'main'
         {% for branch in supported_branches %}
           - release: '{$ branch|first $}'
             target_branch: '{$ branch|first $}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,11 +26,11 @@ jobs:
         release: ['']
         include:
           - release: ''
-            target_branch: 'master'
-            ci_tag: 'master'
+            target_branch: 'main'
+            ci_tag: 'main'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
-          #  target_branch: 'master'
+          #  target_branch: 'main'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
 
@@ -96,11 +96,11 @@ jobs:
         release: ['']
         include:
           - release: ''
-            target_branch: 'master'
-            ci_tag: 'master'
+            target_branch: 'main'
+            ci_tag: 'main'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
-          #  target_branch: 'master'
+          #  target_branch: 'main'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
 

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -28,11 +28,11 @@ jobs:
         include:
         {% if distro_name == "fedora" and distro_release == "rawhide" %}
           - release: ''
-            target_branch: 'master'
-            ci_tag: 'master'
+            target_branch: 'main'
+            ci_tag: 'main'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
-          #  target_branch: 'master'
+          #  target_branch: 'main'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
         {% elif distro_name == "fedora" and distro_release is number %}
@@ -109,11 +109,11 @@ jobs:
         release: ['']
         include:
           - release: ''
-            target_branch: 'master'
-            ci_tag: 'master'
+            target_branch: 'main'
+            ci_tag: 'main'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
-          #  target_branch: 'master'
+          #  target_branch: 'main'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
         {% elif distro_name == "fedora" and distro_release is number %}

--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -26,7 +26,7 @@ on:
       - 'data/profile.d/**'
       - 'po/l10n-config.mk'
     branches:
-      - 'master'
+      - 'main'
 jobs:
   trigger:
     runs-on: ubuntu-22.04

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -20,7 +20,7 @@ on:
       - 'data/profile.d/**'
       - 'po/l10n-config.mk'
     branches:
-      - 'master'
+      - 'main'
 jobs:
   trigger:
     runs-on: ubuntu-22.04

--- a/.github/workflows/try-release-daily.yml
+++ b/.github/workflows/try-release-daily.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master', 'rhel-9', 'rhel-10']
+        branch: ['main', 'rhel-9', 'rhel-10']
 
     steps:
       - name: Check out repo

--- a/.github/workflows/try-release-daily.yml.j2
+++ b/.github/workflows/try-release-daily.yml.j2
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
+        branch: ['main'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
 
     steps:
       - name: Check out repo

--- a/.packit.yml
+++ b/.packit.yml
@@ -69,7 +69,7 @@ jobs:
     targets:
       - fedora-rawhide
       - fedora-eln
-    branch: master
+    branch: main
     owner: "@rhinstaller"
     project: Anaconda
     preserve_project: True

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -67,7 +67,7 @@ jobs:
     targets:
       - fedora-rawhide
       - fedora-eln
-    branch: master
+    branch: main
     owner: "@rhinstaller"
     project: Anaconda
     preserve_project: True

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -71,7 +71,7 @@ Which is my target git branch?
 Depending on where you want to make your contribution please choose your correct branch based on the table below.
 
 +--------------------------+--------------+
-| Fedora Rawhide           | master       |
+| Fedora Rawhide           | main         |
 +--------------------------+--------------+
 | Fedora XX                | fedora-XX    |
 +--------------------------+--------------+
@@ -205,16 +205,16 @@ Anaconda Installer Branching Policy (the long version)
 
 The basic premise is that there are the following branches:
 
-- master
+- main
 - fedora-<next fedora number>
 
-The ``master`` branch never waits for any release-related processes to take place and is used for Fedora Rawhide Anaconda builds.
+The ``main`` branch never waits for any release-related processes to take place and is used for Fedora Rawhide Anaconda builds.
 
 Concerning current RHEL branches, they are too divergent to integrate into this scheme. Thus, commits are merged onto, and builds are done on the RHEL branches.
 In this case, multiple pull requests will very likely be needed:
 
 - one for the ``rhel<number>-branch``
-- one for the ``master`` branch, if the change is not RHEL only
+- one for the ``main`` branch, if the change is not RHEL only
 - one for the ``fedora-<number>`` branch, if change should apply to branched Fedora too
 
 Releases
@@ -222,12 +222,12 @@ Releases
 
 The release process is as follows, for both Fedora Rawhide and branched Fedora versions:
 
-- a release commit is made (which bumps version in spec file) & tagged on the ``fedora-XX`` or ``master`` branch
+- a release commit is made (which bumps version in spec file) & tagged on the ``fedora-XX`` or ``main`` branch
 
 Concerning the ``<next Fedora number>`` branches (which could also be called ``next stable release`` if we wanted to decouple our versioning from Fedora in the future):
 
-- work which goes into the next Fedora goes to ``fedora-<next Fedora number>`` and must have another PR for ``master``, too
-- stuff we *don't* want to go to the next Fedora (too cutting edge, etc.) goes only to ``master`` branch
+- work which goes into the next Fedora goes to ``fedora-<next Fedora number>`` and must have another PR for ``main``, too
+- stuff we *don't* want to go to the next Fedora (too cutting edge, etc.) goes only to ``main`` branch
 - commits specific to a given Fedora release (temporary fixes, etc.) go only to the ``fedora-<next Fedora number>`` branch
 - this way we can easily see what was developed in which Fedora timeframe and possibly due to given Fedora testing phase feedback (bugfixes, etc.)
 
@@ -236,19 +236,19 @@ Example for the F38 and F39 cycle
 
 Once Fedora 38 is branched, we have these branches in the repository:
 
-- ``master``
+- ``main``
 - ``fedora-38``
 
 This would continue until f38 is released, after which we:
 
 - keep the ``fedora-38`` branch as an inactive record of the f38 cycle
-- work on the ``master`` branch only
+- work on the ``main`` branch only
 
-After a while, Fedora 39 is branched and we start the ``fedora-39`` branch off the ``master`` branch.
+After a while, Fedora 39 is branched and we start the ``fedora-39`` branch off the ``main`` branch.
 
 This will result in the following branches for the f39 cycle:
 
-- ``master``
+- ``main``
 - ``fedora-39``
 
 Guidelines for Commits
@@ -369,7 +369,7 @@ Then push the merge to the remote::
 
     git push origin <target branch>
 
-If the pull request has been opened for the ``fedora-38`` branch, then you also need to check if the same change should go to the ``master`` branch in another PR.
+If the pull request has been opened for the ``fedora-38`` branch, then you also need to check if the same change should go to the ``main`` branch in another PR.
 
 .. _pure-community-features:
 

--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,11 @@ Anaconda is the OS installer used by Fedora, RHEL, CentOS and other Linux distri
     :alt: Documentation Status
     :target: https://anaconda-installer.readthedocs.io/en/latest/?badge=latest
 
-.. image:: https://codecov.io/gh/rhinstaller/anaconda/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/rhinstaller/anaconda/branch/main/graph/badge.svg
     :alt: Coverage status
     :target: https://codecov.io/gh/rhinstaller/anaconda
 
-.. image:: https://translate.fedoraproject.org/widgets/anaconda/-/master/svg-badge.svg
+.. image:: https://translate.fedoraproject.org/widgets/anaconda/-/main/svg-badge.svg
     :alt: Translation status
     :target: https://translate.fedoraproject.org/engage/anaconda/?utm_source=widget
 

--- a/branch-config.mk
+++ b/branch-config.mk
@@ -27,16 +27,16 @@
 
 
 # Name of the expected current git branch.
-# This could be master, fedora-XX, rhel-X ...
-GIT_BRANCH ?= master
+# This could be main, fedora-XX, rhel-X ...
+GIT_BRANCH ?= main
 
-# Directory for this anaconda branch in anaconda-l10n repository. This could be master, fXX, rhel-8 etc.
-L10N_DIR ?= master
+# Directory for this anaconda branch in anaconda-l10n repository. This could be main, fXX, rhel-8 etc.
+L10N_DIR ?= main
 
 # Base container for our containers.
 BASE_CONTAINER ?= registry.fedoraproject.org/fedora:rawhide
 
 # COPR repo for use in container builds.
-# Can be @rhinstaller/Anaconda for master, or @rhinstaller/Anaconda-devel for branched Fedora.
+# Can be @rhinstaller/Anaconda for main, or @rhinstaller/Anaconda-devel for branched Fedora.
 COPR_REPO ?= \@rhinstaller/Anaconda
 

--- a/branch-config.mk.j2
+++ b/branch-config.mk.j2
@@ -21,17 +21,17 @@
 {% if distro_name == "fedora" and distro_release == "rawhide" %}
 
 # Name of the expected current git branch.
-# This could be master, fedora-XX, rhel-X ...
-GIT_BRANCH ?= master
+# This could be main, fedora-XX, rhel-X ...
+GIT_BRANCH ?= main
 
-# Directory for this anaconda branch in anaconda-l10n repository. This could be master, fXX, rhel-8 etc.
-L10N_DIR ?= master
+# Directory for this anaconda branch in anaconda-l10n repository. This could be main, fXX, rhel-8 etc.
+L10N_DIR ?= main
 
 # Base container for our containers.
 BASE_CONTAINER ?= registry.fedoraproject.org/fedora:rawhide
 
 # COPR repo for use in container builds.
-# Can be @rhinstaller/Anaconda for master, or @rhinstaller/Anaconda-devel for branched Fedora.
+# Can be @rhinstaller/Anaconda for main, or @rhinstaller/Anaconda-devel for branched Fedora.
 COPR_REPO ?= \@rhinstaller/Anaconda
 
 {% elif distro_name == "fedora" %}

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -15,7 +15,7 @@ FROM ${image}
 # The `git_branch` arg will set git branch of Anaconda from which we are downloding spec file to get
 # dependencies.
 # possible values:
-#   master
+#   main
 #   fedora-38
 ARG git_branch
 
@@ -41,7 +41,7 @@ RUN set -ex; \
   # Enable COPR repositories
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     BRANCH="${git_branch}"; \
-    if [ $BRANCH == "master" ]; then \
+    if [ $BRANCH == "main" ]; then \
       BRANCH="rawhide"; \
     fi; \
     BRANCH=${BRANCH#fedora-}; \

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -9,9 +9,9 @@
 # sudo make -f ./Makefile.am anaconda-iso-creator-build
 #
 # # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
+# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:main
 # or to build WebUI image:
-# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z --entrypoint /lorax-build-webui quay.io/rhinstaller/anaconda-iso-creator:master
+# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z --entrypoint /lorax-build-webui quay.io/rhinstaller/anaconda-iso-creator:main
 #
 # note:
 # - add `--network=slirp4netns` if you need to share network with host computer to reach

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -12,7 +12,7 @@
 # mount to /anaconda-rpms to the container (could be RO mount).
 #
 #   sudo make -f ./Makefile.am container-rpms-scratch
-#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
+#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:main
 #
 # Input directory:
 # /anaconda-rpms/ (Anaconda RPM files for the build)

--- a/dockerfile/anaconda-iso-creator/lorax-build-webui
+++ b/dockerfile/anaconda-iso-creator/lorax-build-webui
@@ -17,7 +17,7 @@
 # To run this please do:
 #
 #   sudo make -f ./Makefile.am container-rpms-scratch
-#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z --entrypoint /lorax-build-webui quay.io/rhinstaller/anaconda-iso-creator:master
+#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z --entrypoint /lorax-build-webui quay.io/rhinstaller/anaconda-iso-creator:main
 #
 #
 # Input directory:

--- a/dockerfile/anaconda-iso-creator/lorax-build-webui.j2
+++ b/dockerfile/anaconda-iso-creator/lorax-build-webui.j2
@@ -10,7 +10,7 @@
 # To run this please do:
 #
 #   sudo make -f ./Makefile.am container-rpms-scratch
-#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z --entrypoint /lorax-build-webui quay.io/rhinstaller/anaconda-iso-creator:master
+#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z --entrypoint /lorax-build-webui quay.io/rhinstaller/anaconda-iso-creator:main
 #
 #
 # Input directory:

--- a/dockerfile/anaconda-iso-creator/lorax-build.j2
+++ b/dockerfile/anaconda-iso-creator/lorax-build.j2
@@ -5,7 +5,7 @@
 # mount to /anaconda-rpms to the container (could be RO mount).
 #
 #   sudo make -f ./Makefile.am container-rpms-scratch
-#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:master
+#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-iso-creator:main
 #
 # Input directory:
 # /anaconda-rpms/ (Anaconda RPM files for the build)

--- a/dockerfile/anaconda-live-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-live-iso-creator/Dockerfile
@@ -16,7 +16,7 @@
 # sudo make -f ./Makefile.am anaconda-live-iso-creator-build
 #
 # # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-live-iso-creator:master
+# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-live-iso-creator:main
 #
 # note:
 # - add `--network=slirp4netns` if you need to share network with host computer to reach

--- a/dockerfile/anaconda-live-iso-creator/Dockerfile.j2
+++ b/dockerfile/anaconda-live-iso-creator/Dockerfile.j2
@@ -9,7 +9,7 @@
 # sudo make -f ./Makefile.am anaconda-live-iso-creator-build
 #
 # # /var/tmp tmpfs speeds up lorax and avoids https://bugzilla.redhat.com/show_bug.cgi?id=1906364
-# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-live-iso-creator:master
+# sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-live-iso-creator:main
 #
 # note:
 # - add `--network=slirp4netns` if you need to share network with host computer to reach

--- a/dockerfile/anaconda-live-iso-creator/lmc-build
+++ b/dockerfile/anaconda-live-iso-creator/lmc-build
@@ -12,7 +12,7 @@
 # mount to /anaconda-rpms to the container (could be RO mount).
 #
 #   sudo make -f ./Makefile.am container-rpms-scratch
-#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-live-iso-creator:master
+#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-live-iso-creator:main
 #
 # Input directory:
 # /anaconda-rpms/ (Anaconda RPM files for the build)

--- a/dockerfile/anaconda-live-iso-creator/lmc-build.j2
+++ b/dockerfile/anaconda-live-iso-creator/lmc-build.j2
@@ -5,7 +5,7 @@
 # mount to /anaconda-rpms to the container (could be RO mount).
 #
 #   sudo make -f ./Makefile.am container-rpms-scratch
-#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-live-iso-creator:master
+#   sudo podman run -i --rm --privileged --tmpfs /var/tmp:rw,mode=1777 -v `pwd`/result/build/01-rpm-build:/anaconda-rpms:ro -v `pwd`/output-dir:/images:z quay.io/rhinstaller/anaconda-live-iso-creator:main
 #
 # Input directory:
 # /anaconda-rpms/ (Anaconda RPM files for the build)

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -15,7 +15,7 @@ FROM ${image}
 # The `git_branch` arg will set git branch of Anaconda from which we are downloding spec file to get
 # dependencies.
 # possible values:
-#   master
+#   main
 #   fedora-38
 ARG git_branch
 ARG copr_repo=@rhinstaller/Anaconda
@@ -46,7 +46,7 @@ RUN set -ex; \
   rpmlint; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     BRANCH="${git_branch}"; \
-    if [ $BRANCH == "master" ]; then \
+    if [ $BRANCH == "main" ]; then \
       BRANCH="rawhide"; \
     fi; \
     BRANCH=${BRANCH#fedora-}; \

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,4 @@
-.. Anaconda documentation master file, created by
+.. Anaconda documentation main file, created by
    sphinx-quickstart on Wed Sep 18 14:37:01 2013.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -27,7 +27,7 @@ The overall workflow can be summarized to 3 steps:
 - Packit PR in Fedora distgit
 - start build in Fedora distgit
 
-0. have an up to date Anaconda repo clone and ``master`` branch checked out
+0. have an up to date Anaconda repo clone and ``main`` branch checked out
 
 1. tag an Anaconda release:
 
@@ -37,11 +37,11 @@ The overall workflow can be summarized to 3 steps:
 
 2. check the commit and tag are correct
 
-3. push the master branch to the remote
+3. push the main branch to the remote
 
 ::
 
-      git push master --tags
+      git push main --tags
 
 4. this should trigger a GitHub workflow that will create a new Anaconda release + release tarball, taking ~10 minutes
 
@@ -108,11 +108,11 @@ environment way see mock path below. It is also fully manual.
 
 3. check the commit and tag are correct
 
-4. push the master branch to the remote
+4. push the main branch to the remote
 
 ::
 
-    git push master --tags
+    git push main --tags
 
 5. configure anaconda
 
@@ -255,11 +255,11 @@ Start by cloning translation repository (ideally outside of Anaconda git) and en
    git clone git@github.com:rhinstaller/anaconda-l10n.git
    cd anaconda-l10n
 
-Create a new localization directory from ``master`` directory:
+Create a new localization directory from ``main`` directory:
 
 ::
 
-   cp -r master f<version>
+   cp -r main f<version>
 
 Add the new folder to git:
 
@@ -271,7 +271,7 @@ Commit these changes:
 
 ::
 
-   git commit -m "Branch new Fedora <version> from master"
+   git commit -m "Branch new Fedora <version> from main"
 
 Push new localization directory. This will be automatically discovered and added by
 `Weblate <https://translate.fedoraproject.org/projects/anaconda/>`_ service:
@@ -297,7 +297,7 @@ Update the matrix. For example, for f39 we had:
 ::
 
       matrix:
-        branch: [ master, f39, rhel-9 ]
+        branch: [ main, f39, rhel-9 ]
         include:
           (...)
           - branch: f39
@@ -334,7 +334,7 @@ Create the fedora-<version> upstream branch:
 
 ::
 
-    git checkout master
+    git checkout main
     git pull
     git checkout -b fedora-<version>
 
@@ -384,11 +384,11 @@ If everything works correctly you can push the branch to the origin (``-u`` make
     git checkout fedora-<version>
     git push -u origin fedora-<version>
 
-After the branching is done, you also need to update infrastructure on the ``master`` branch. Switch to that branch:
+After the branching is done, you also need to update infrastructure on the ``main`` branch. Switch to that branch:
 
 ::
 
-    git switch master
+    git switch main
 
 Edit branch specific settings:
 
@@ -404,11 +404,11 @@ Expect changes only in Github workflows that generate containers etc. for multip
     make -f Makefile.am reload-infra
     git commit -a -m "infra: Configure for the new fedora-NN branch"
 
-Then, finally, push the updated master branch:
+Then, finally, push the updated main branch:
 
 ::
 
-    git push origin master
+    git push origin main
 
 Container rebuilds after branching
 ----------------------------------
@@ -465,7 +465,7 @@ Make sure you are in the Rawhide branch:
 
 ::
 
-    git checkout master
+    git checkout main
 
 Do the major version bump and verify that the output looks correct:
 
@@ -477,7 +477,7 @@ If everything looks fine (changelog, new major version & the tag) push the chang
 
 ::
 
-    git push origin master --tags
+    git push origin main --tags
 
 Then continue with the normal Rawhide Anaconda build process.
 
@@ -512,7 +512,7 @@ How to collect release notes after branched GA release
 Release notes are collected in ``docs/release-notes/*.rst``. When a major Fedora version goes GA,
 these should be collected into the file ``docs/release-notes.rst``. To do so:
 
-0. Work on the master branch. Edit the file. New content is added on top.
+0. Work on the main branch. Edit the file. New content is added on top.
 1. Create a heading for new Fedora version and subheadings for the broader areas. The previous
    entry can provide some guidance.
 2. Copy the individual release notes contents into the document according to the headings, and edit
@@ -523,4 +523,4 @@ these should be collected into the file ``docs/release-notes.rst``. To do so:
 5. Commit and make a PR.
 
 The branch used for the release is not touched. This might be surprising, but docs are always used
-from the ``master`` branch.
+from the ``main`` branch.

--- a/po/l10n-config.mk
+++ b/po/l10n-config.mk
@@ -18,7 +18,7 @@
 # What to pull from the l10n repo when getting translations
 # This supports anything that git can use, but is intended to be a SHA of a commit that works.
 # This line must be always in the same format, because it is changed by automation.
-GIT_L10N_SHA ?= 3583aef73f878ed8aa601397b02138935f504ff4
+GIT_L10N_SHA ?= bf47f2c6d9962d28df055de8058000aa7c7e8324
 
 # Localization repository location
 L10N_REPOSITORY ?= https://github.com/rhinstaller/anaconda-l10n.git

--- a/po/l10n-config.mk
+++ b/po/l10n-config.mk
@@ -23,5 +23,5 @@ GIT_L10N_SHA ?= 3583aef73f878ed8aa601397b02138935f504ff4
 # Localization repository location
 L10N_REPOSITORY ?= https://github.com/rhinstaller/anaconda-l10n.git
 
-# Branch used in localization repository. This should be master all the time.
-GIT_L10N_BRANCH ?= master
+# Branch used in localization repository. This should be main all the time.
+GIT_L10N_BRANCH ?= main

--- a/scripts/testing/check-container-age.sh
+++ b/scripts/testing/check-container-age.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-# container image name, eg. "quay.io/rhinstaller/anaconda-ci:master"
+# container image name, eg. "quay.io/rhinstaller/anaconda-ci:main"
 container_name="$1"
 # when is an image too old - string for `date --date=`
 too_old_description="60 hours ago"

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -97,7 +97,7 @@ Note
 ----
 
 Please update your container from time to time to have newest dependencies.
-To do that, run `podman pull quay.io/rhinstaller/anaconda-ci:master` or build
+To do that, run `podman pull quay.io/rhinstaller/anaconda-ci:main` or build
 it locally again.
 
 Run rpm tests inside of container
@@ -117,11 +117,11 @@ Run unit tests with patched pykickstart or other libraries
 
 1. Pull the container::
 
-      podman pull quay.io/rhinstaller/anaconda-ci:master
+      podman pull quay.io/rhinstaller/anaconda-ci:main
 
 2. Run the container temporary with your required resources (pykickstart in this example)::
 
-      podman run --name=cnt-add --rm -it -v ./pykickstart:/pykickstart:z quay.io/rhinstaller/anaconda-ci:master sh
+      podman run --name=cnt-add --rm -it -v ./pykickstart:/pykickstart:z quay.io/rhinstaller/anaconda-ci:main sh
 
 3. Do your required changes in the container (install pykickstart in this example)::
 
@@ -129,9 +129,9 @@ Run unit tests with patched pykickstart or other libraries
 
 4. Commit the changed container as updated one. **DO NOT exit the running container, run this command in new terminal!**
 
-      podman commit cnt-add quay.io/rhinstaller/anaconda-ci:master
+      podman commit cnt-add quay.io/rhinstaller/anaconda-ci:main
 
-   You can change the ``master`` tag to something else if you don't want to replace the existing one.
+   You can change the ``main`` tag to something else if you don't want to replace the existing one.
    Feel free to exit the running container now.
 
 5. Run other commands for container ci as usual. Don't forget to append ``CI_TAG=<your-tag>`` to
@@ -145,7 +145,7 @@ All test and maintenance actions are run by `GitHub workflows`_.  These YAML
 files completely describe what steps are required to run some action, what are
 its triggers and so on.
 
-Pull request for master:
+Pull request for main:
 ________________________
 
 Unit and rpm tests are run by the `validate.yml workflow`_.  We use GitHub's
@@ -176,7 +176,7 @@ Running kickstart-tests:
 ________________________
 
 The `kickstart-tests.yml workflow`_ allows rhinstaller organization members to
-run kickstart-tests_ against an anaconda PR (only ``master`` for now). Send a
+run kickstart-tests_ against an anaconda PR (only ``main`` for now). Send a
 comment that starts with ``/kickstart-tests <options>`` to the pull request to
 trigger it. It is possible to use tests updated via a kickstart-tests
 repository PR. See the `kickstart-tests.yml workflow`_ for supported
@@ -194,7 +194,7 @@ Automatic container build
 _________________________
 
 Containers are updated daily by the `container-autoupdate.yml workflow`_
-from Anaconda ``master`` repository. Before pushing a new
+from Anaconda ``main`` repository. Before pushing a new
 container, tests are executed on this container to avoid regressions.
 
 Manual container build
@@ -202,7 +202,7 @@ ______________________
 
 Just go to the `actions tab`_ in the Anaconda repository to the
 “Refresh container images“ and press the ``Run workflow`` button on a button on
-a particular branch. Usually ``master``, but for testing a change to the
+a particular branch. Usually ``main``, but for testing a change to the
 container you can push your branch to the origin repo and run it from there.
 
 Security precautions for testing RHEL
@@ -229,12 +229,12 @@ dependent jobs. First will check user privileges, second will run the tests in
 case the first one succeeded.
 
 **PR created by external contributors** -- these have to be started by workflow
-file `validate-rhel-8.yml workflow`_ from the ``master`` branch
+file `validate-rhel-8.yml workflow`_ from the ``main`` branch
 checking all the comments. If comment starts with ``/test`` phrase it will check
 the owner of the comment. When everything succeed it will set progress on the pull
 request originating the comment and start the tests. This progress is updated
 based on the result of the tests. As explained above, the whole implementation
-of the workflow is in the ``master`` branch which could be pretty confusing.
+of the workflow is in the ``main`` branch which could be pretty confusing.
 
 Changing workflow file by attacker
 __________________________________


### PR DESCRIPTION
This affects:
* Anaconda repository branch
* Container tags in quay.io
