### PR TITLE
Don't log a bogus warning when kickstart specifies a disk label

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic/noninteractive_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/noninteractive_partitioning.py
@@ -62,10 +62,8 @@ class NonInteractivePartitioningTask(PartitioningTask, metaclass=ABCMeta):
         # Update the disk label.
         disk_label = disk_init_proxy.DefaultDiskLabel
 
-        if disk_label and not DiskLabel.set_default_label_type(disk_label):
-            log.warning("%s is not a supported disklabel type on this platform. "
-                        "Using default disklabel %s instead.", disk_label,
-                        DiskLabel.get_platform_label_types()[0])
+        if disk_label:
+            DiskLabel.set_default_label_type(disk_label)
 
         return config
 


### PR DESCRIPTION
When this code was introduced back in c0c04cc7 , it used blivet 1.0 platform.setDefaultDiskLabelType, which checked whether the requested label was in the platform's supported labels, and returned False immediately if it wasn't.

However, in mid-2017, blivet 2.0 made a big API change, and the equivalent method - `DiskLabel.set_default_label_type` - does not check the requested label in any way, and never returns anything. It just assumes whatever you passed is OK, sets it, and (implicitly) returns None.

anaconda was updated to use the new method, but the "log a warning if it doesn't return" logic was left in place. So now we always log this warning. We do actually always set the label type, but the message is confusing.