### PR TITLE
Revert "build: Install systemd-resolved in ELN aka RHEL-11"

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -134,7 +134,7 @@ Requires: NetworkManager-libnm >= %{nmver}
 Requires: kbd
 Requires: chrony
 Requires: systemd
-%if 0%{?rhel} > 10 || 0%{?fedora}
+%if ! 0%{?rhel}
 Requires: systemd-resolved
 %endif
 Requires: python3-pid


### PR DESCRIPTION
This reverts commit 5f870b9045afc91f7e99a4c29020cdc75f577c74.

systemd-resolved is not part of ELN (at this point).

Resolves: rhbz#2304080

Related kickstart test that should catch inconsistency in the future: https://github.com/rhinstaller/kickstart-tests/pull/1351