### PR TITLE
Edns certs stage2 w initramfs r9

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,7 +35,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libxklavierver 5.4
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.32.11-1
+%define pykickstartver 3.32.13-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.6.0-13
 %define rpmver 4.10.0

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,7 @@ AC_CONFIG_FILES([Makefile
                  pyanaconda/modules/boss/module_manager/Makefile
                  pyanaconda/modules/boss/user_interface/Makefile
                  pyanaconda/modules/security/Makefile
+                 pyanaconda/modules/security/certificates/Makefile
                  pyanaconda/modules/timezone/Makefile
                  pyanaconda/modules/network/Makefile
                  pyanaconda/modules/network/firewall/Makefile

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -28,6 +28,7 @@ dist_systemd_DATA = anaconda.service \
                     anaconda-sshd.service \
                     anaconda-nm-config.service \
                     anaconda-nm-disable-autocons.service \
+                    anaconda-import-initramfs-certs.service \
                     anaconda-pre.service \
                     anaconda-fips.service
 

--- a/data/systemd/anaconda-generator
+++ b/data/systemd/anaconda-generator
@@ -43,3 +43,4 @@ done
 ln -sf $systemd_dir/anaconda-nm-config.service $target_dir/anaconda-nm-config.service
 ln -sf $systemd_dir/anaconda-nm-disable-autocons.service $target_dir/anaconda-nm-disable-autocons.service
 ln -sf $systemd_dir/anaconda-pre.service $target_dir/anaconda-pre.service
+ln -sf "$systemd_dir/anaconda-import-initramfs-certs.service" "$target_dir/anaconda-import-initramfs-certs.service"

--- a/data/systemd/anaconda-import-initramfs-certs.service
+++ b/data/systemd/anaconda-import-initramfs-certs.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Import of certificates added in initramfs stage of Anaconda via kickstart
+Before=NetworkManager.service
+Before=anaconda.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/anaconda/anaconda-import-initramfs-certs

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -430,7 +430,11 @@ def process_certificates(handler):
             log.error("Missing certificate file name, skipping.")
             continue
 
-        _dump_certificate(cert)
+        try:
+            _dump_certificate(cert)
+        except OSError as e:
+            log.error("Dump of certificate %s failed: %s", cert.filename, e)
+            continue
         # Dump for transport to switchroot
         _dump_certificate(cert, root=CERT_TRANSPORT_DIR+"/path/")
 

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -66,6 +66,8 @@ TMPDIR = "/tmp"
 ARPHRD_ETHER = "1"
 ARPHRD_INFINIBAND = "32"
 
+CERT_TRANSPORT_DIR = "/run/install/certificates"
+
 # Helper function for reading simple files in /sys
 def readsysfile(f):
     '''Return the contents of f, or "" if missing.'''
@@ -395,6 +397,44 @@ def ksnet_to_dracut(args, lineno, net, bootdev=False):
 
     return " ".join(line)
 
+
+def _dump_certificate(cert, root="/", dump_dir=None):
+    """Dump the certificate into specified file."""
+    dump_dir = dump_dir or cert.dir
+    if not dump_dir:
+        log.error("Certificate destination is missing for %s", cert.filename)
+        return
+
+    dst_dir = os.path.join(root, dump_dir.lstrip('/'))
+    log.debug("Dumping certificate %s into %s.", cert.filename, dst_dir)
+    if not os.path.exists(dst_dir):
+        log.debug("Path %s for certificate does not exist, creating.", dst_dir)
+        os.makedirs(dst_dir)
+
+    dst = os.path.join(dst_dir, cert.filename)
+
+    if os.path.exists(dst):
+        log.warning("Certificate file %s already exists, replacing.", dst)
+
+    with open(dst, 'w') as f:
+        f.write(cert.cert)
+        f.write('\n')
+
+
+def process_certificates(handler):
+    """Import certificates defined in %certificate sections."""
+    for cert in handler.certificates:
+        log.info("Processing kickstart certificate %s", cert.filename)
+
+        if not cert.filename:
+            log.error("Missing certificate file name, skipping.")
+            continue
+
+        _dump_certificate(cert)
+        # Dump for transport to switchroot
+        _dump_certificate(cert, root=CERT_TRANSPORT_DIR+"/path/")
+
+
 def process_kickstart(ksfile):
     handler = DracutHandler()
     try:
@@ -415,6 +455,7 @@ def process_kickstart(ksfile):
     with open(TMPDIR+"/ks.info", "a") as f:
         f.write('parsed_kickstart="%s"\n' % processed_file)
     log.info("finished parsing kickstart")
+    process_certificates(handler)
     return processed_file, handler.output
 
 if __name__ == '__main__':

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -541,3 +541,6 @@ TIMEZONE_PRIORITY_USER = 90
 
 # A flag file indicated the installation is running in rescue mode
 RESCUE_MODE_PATH = "/run/install/RESCUE_MODE"
+
+# Installation phases
+INSTALLATION_PHASE_PREINSTALL = "pre-install"

--- a/pyanaconda/core/kickstart/specification.py
+++ b/pyanaconda/core/kickstart/specification.py
@@ -83,7 +83,10 @@ class KickstartSpecificationHandler(KickstartHandler):
             self.registerData(name, data)
 
         for name, data in specification.sections_data.items():
-            self.registerSectionData(name, data)
+            if name is "certificate":
+                self.certificates.append(data())
+            else:
+                self.registerSectionData(name, data)
 
         if specification.addons:
             self.addons = AddonRegistry()

--- a/pyanaconda/core/kickstart/specification.py
+++ b/pyanaconda/core/kickstart/specification.py
@@ -49,8 +49,14 @@ class KickstartSpecification(object):
                     classes that represent them
     sections      - mapping of kickstart sections names to
                     classes that represent them
+                    value is a class or a tuple (class, section_data_class)
+                    where section_data_class is a value to be passed to dataObj
+                    class argument (typically the corresponding sections_data class)
     sections_data - mapping of kickstart sections data names to
                     classes that represent them
+                    value is a class or a tuple (class, data_list_name)
+                    where data_list_name is the name of the attribute holding
+                    list of the section data objects of the class
     addons        - mapping of kickstart addons names to
                     classes that represent them
 
@@ -69,6 +75,25 @@ class NoKickstartSpecification(KickstartSpecification):
     pass
 
 
+class SectionDataListStrWrapper():
+    """A wrapper for generating string from a list of kickstart data."""
+    def __init__(self, data_list, data):
+        """Initializer.
+
+        :param data_list: list of section data objects
+        :param data: class required for the object to be included in the string
+        """
+        self._data_list = data_list
+        self._data = data
+
+    def __str__(self):
+        retval = []
+        for data_obj in self._data_list:
+            if isinstance(data_obj, self._data):
+                retval.append(data_obj.__str__())
+        return "".join(retval)
+
+
 class KickstartSpecificationHandler(KickstartHandler):
     """Handler defined by a kickstart specification."""
 
@@ -83,10 +108,7 @@ class KickstartSpecificationHandler(KickstartHandler):
             self.registerData(name, data)
 
         for name, data in specification.sections_data.items():
-            if name is "certificate":
-                self.certificates.append(data())
-            else:
-                self.registerSectionData(name, data)
+            self.registerSectionData(name, data)
 
         if specification.addons:
             self.addons = AddonRegistry()
@@ -96,8 +118,16 @@ class KickstartSpecificationHandler(KickstartHandler):
 
     def registerSectionData(self, name, data):
         """Register data used by a section."""
-        obj = data()
-        setattr(self, name, obj)
+        if isinstance(data, tuple):
+            # Multiple data objects (section instances) stored in a list
+            data, data_list_name = data
+            data_list = []
+            setattr(self, data_list_name, data_list)
+            obj = SectionDataListStrWrapper(data_list, data)
+        else:
+            # Single data object for all section instances
+            obj = data()
+            setattr(self, name, obj)
         self._registerWriteOrder(obj)
 
     def registerAddonData(self, name, data):
@@ -123,7 +153,11 @@ class KickstartSpecificationParser(KickstartParser):
         super().__init__(handler)
 
         for section in specification.sections.values():
-            self.registerSection(section(handler))
+            if isinstance(section, tuple):
+                section_cls, data_obj = section
+                self.registerSection(section_cls(handler, dataObj=data_obj))
+            else:
+                self.registerSection(section(handler))
 
         if specification.addons:
             self.registerSection(AddonSection(handler))

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -316,6 +316,11 @@ def _prepare_installation(payload, ksdata):
         fips_task = security_proxy.PreconfigureFIPSWithTask(payload.type)
         pre_install.append_dbus_tasks(SECURITY, [fips_task])
 
+        # Import certificates so they are available for rpm scripts
+        certificates_proxy = SECURITY.get_proxy(CERTIFICATES)
+        certificates_task = certificates_proxy.PreInstallWithTask()
+        pre_install.append_dbus_tasks(SECURITY, [certificates_task])
+
     # Install the payload.
     pre_install.append(Task("Find additional packages & run pre_install()", payload.pre_install))
     installation_queue.append(pre_install)

--- a/pyanaconda/installation.py
+++ b/pyanaconda/installation.py
@@ -318,7 +318,7 @@ def _prepare_installation(payload, ksdata):
 
         # Import certificates so they are available for rpm scripts
         certificates_proxy = SECURITY.get_proxy(CERTIFICATES)
-        certificates_task = certificates_proxy.PreInstallWithTask()
+        certificates_task = certificates_proxy.PreInstallWithTask(payload.type)
         pre_install.append_dbus_tasks(SECURITY, [certificates_task])
 
     # Install the payload.

--- a/pyanaconda/kickstart.py
+++ b/pyanaconda/kickstart.py
@@ -428,6 +428,7 @@ class AnacondaPreParser(KickstartParser):
         self.registerSection(NullSection(self.handler, sectionOpen="%traceback"))
         self.registerSection(NullSection(self.handler, sectionOpen="%packages"))
         self.registerSection(NullSection(self.handler, sectionOpen="%addon"))
+        self.registerSection(NullSection(self.handler, sectionOpen="%certificate"))
         self.registerSection(NullSection(self.handler.anaconda, sectionOpen="%anaconda"))
 
 
@@ -451,6 +452,7 @@ class AnacondaKSParser(KickstartParser):
         self.registerSection(OnErrorScriptSection(self.handler, dataObj=self.scriptClass))
         self.registerSection(UselessSection(self.handler, sectionOpen="%packages"))
         self.registerSection(UselessSection(self.handler, sectionOpen="%addon"))
+        self.registerSection(UselessSection(self.handler, sectionOpen="%certificate"))
         self.registerSection(AnacondaSection(self.handler.anaconda))
 
 

--- a/pyanaconda/modules/boss/kickstart_manager/parser.py
+++ b/pyanaconda/modules/boss/kickstart_manager/parser.py
@@ -25,7 +25,7 @@ from pyanaconda.modules.boss.kickstart_manager.element import KickstartElement,\
     TrackedKickstartElements
 
 VALID_SECTIONS_ANACONDA = ["%pre", "%pre-install", "%post", "%onerror", "%traceback",
-                           "%packages", "%addon", "%anaconda"]
+                           "%packages", "%addon", "%anaconda", "%certificate"]
 
 
 class StoreSection(Section):

--- a/pyanaconda/modules/common/constants/objects.py
+++ b/pyanaconda/modules/common/constants/objects.py
@@ -19,7 +19,7 @@
 from dasbus.identifier import DBusObjectIdentifier
 from pyanaconda.modules.common.constants.namespaces import STORAGE_NAMESPACE, NETWORK_NAMESPACE, \
     PARTITIONING_NAMESPACE, DEVICE_TREE_NAMESPACE, \
-    RHSM_NAMESPACE, BOSS_NAMESPACE
+    RHSM_NAMESPACE, BOSS_NAMESPACE, SECURITY_NAMESPACE
 
 # Boss objects.
 
@@ -153,4 +153,10 @@ RHSM_ENTITLEMENT = DBusObjectIdentifier(
 RHSM_SYSPURPOSE = DBusObjectIdentifier(
     namespace=RHSM_NAMESPACE,
     basename="Syspurpose"
+)
+
+# Security objects
+CERTIFICATES = DBusObjectIdentifier(
+    namespace=SECURITY_NAMESPACE,
+    basename="Certificates"
 )

--- a/pyanaconda/modules/common/structures/security.py
+++ b/pyanaconda/modules/common/structures/security.py
@@ -1,0 +1,58 @@
+#
+# DBus structures for the storage data.
+#
+# Copyright (C) 2025  Red Hat, Inc.  All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from dasbus.structure import DBusData
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
+__all__ = ["CertificateData"]
+
+
+class CertificateData(DBusData):
+    """Structure for the certificate data."""
+
+    def __init__(self):
+        self._filename = ""
+        self._cert = ""
+        self._dir = ""
+
+    @property
+    def filename(self) -> Str:
+        """The certificate file name."""
+        return self._filename
+
+    @filename.setter
+    def filename(self, value: Str) -> None:
+        self._filename = value
+
+    @property
+    def cert(self) -> Str:
+        """The certificate content."""
+        return self._cert
+
+    @cert.setter
+    def cert(self, value: Str) -> None:
+        self._cert = value
+
+    @property
+    def dir(self) -> Str:
+        """The certificate directory."""
+        return self._dir
+
+    @dir.setter
+    def dir(self, value: Str) -> None:
+        self._dir = value

--- a/pyanaconda/modules/security/certificates/Makefile.am
+++ b/pyanaconda/modules/security/certificates/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2018  Red Hat, Inc.
+# Copyright (C) 2025  Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as published
@@ -14,10 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-SUBDIRS = certificates
-
 pkgpyexecdir = $(pyexecdir)/py$(PACKAGE_NAME)
-securitydir = $(pkgpyexecdir)/modules/security
-security_PYTHON = $(srcdir)/*.py
+certificatesdir = $(pkgpyexecdir)/modules/security/certificates
+dist_certificates_DATA = $(wildcard $(srcdir)/*.py)
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/pyanaconda/modules/security/certificates/__init__.py
+++ b/pyanaconda/modules/security/certificates/__init__.py
@@ -1,7 +1,5 @@
 #
-# Kickstart handler for date and time settings.
-#
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -17,25 +15,6 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pykickstart.parser import Certificate
-from pykickstart.sections import CertificateSection
-from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
+from pyanaconda.modules.security.certificates.certificates import CertificatesModule
 
-
-class SecurityKickstartSpecification(KickstartSpecification):
-
-    commands = {
-        "auth": COMMANDS.Authconfig,
-        "authconfig": COMMANDS.Authconfig,
-        "authselect": COMMANDS.Authselect,
-        "selinux": COMMANDS.SELinux,
-        "realm": COMMANDS.Realm
-    }
-
-    sections = {
-        "certificate": CertificateSection
-    }
-
-    sections_data = {
-        "certificate": Certificate
-    }
+__all__ = ["CertificatesModule"]

--- a/pyanaconda/modules/security/certificates/certificates.py
+++ b/pyanaconda/modules/security/certificates/certificates.py
@@ -95,3 +95,15 @@ class CertificatesModule(KickstartBaseModule):
             sysroot=conf.target.system_root,
             certificates=self.certificates,
         )
+
+    def pre_install_with_task(self):
+        """Import certificates into the system before the payload installation
+
+        NOTE: the reason is potential use by rpm scriptlets
+
+        :return: a DBus path of the import task
+        """
+        return ImportCertificatesTask(
+            sysroot=conf.target.system_root,
+            certificates=self.certificates,
+        )

--- a/pyanaconda/modules/security/certificates/certificates.py
+++ b/pyanaconda/modules/security/certificates/certificates.py
@@ -1,0 +1,57 @@
+#
+# Certificate  module
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.core.dbus import DBus
+from pykickstart.parser import Certificate
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.base import KickstartBaseModule
+from pyanaconda.modules.common.constants.objects import CERTIFICATES
+from pyanaconda.modules.common.structures.security import CertificateData
+from pyanaconda.modules.security.certificates.certificates_interface import CertificatesInterface
+
+log = get_module_logger(__name__)
+
+
+class CertificatesModule(KickstartBaseModule):
+    """The certificates installation module."""
+
+    def __init__(self):
+        super().__init__()
+
+        self._certificates = []
+
+    def publish(self):
+        """Publish the module."""
+        DBus.publish_object(CERTIFICATES.object_path, CertificatesInterface(self))
+
+    def process_kickstart(self, data):
+        """Process the kickstart data."""
+        for cert in data.certificates:
+            cert_data = CertificateData()
+            cert_data.filename = cert.filename
+            cert_data.cert = cert.cert
+            if cert.dir:
+                cert_data.dir = cert.dir
+            self._certificates.append(cert_data)
+
+    def setup_kickstart(self, data):
+        """Setup the kickstart data."""
+        for cert in self._certificates:
+            cert_ksdata = Certificate(cert=cert.cert, filename=cert.filename, dir=cert.dir)
+            data.certificates.append(cert_ksdata)

--- a/pyanaconda/modules/security/certificates/certificates.py
+++ b/pyanaconda/modules/security/certificates/certificates.py
@@ -19,6 +19,7 @@
 #
 from pyanaconda.core.dbus import DBus
 from pyanaconda.core.signal import Signal
+from pyanaconda.core.configuration.anaconda import conf
 from pykickstart.parser import Certificate
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.base import KickstartBaseModule
@@ -82,5 +83,15 @@ class CertificatesModule(KickstartBaseModule):
         """
         return ImportCertificatesTask(
             sysroot="/",
+            certificates=self.certificates,
+        )
+
+    def install_with_task(self):
+        """Import certificates into the installed system
+
+        :return: a DBus path of the import task
+        """
+        return ImportCertificatesTask(
+            sysroot=conf.target.system_root,
             certificates=self.certificates,
         )

--- a/pyanaconda/modules/security/certificates/certificates.py
+++ b/pyanaconda/modules/security/certificates/certificates.py
@@ -25,6 +25,7 @@ from pyanaconda.modules.common.base import KickstartBaseModule
 from pyanaconda.modules.common.constants.objects import CERTIFICATES
 from pyanaconda.modules.common.structures.security import CertificateData
 from pyanaconda.modules.security.certificates.certificates_interface import CertificatesInterface
+from pyanaconda.modules.security.certificates.installation import ImportCertificatesTask
 
 log = get_module_logger(__name__)
 
@@ -73,3 +74,13 @@ class CertificatesModule(KickstartBaseModule):
         # the properties changed signal here manually
         self.module_properties_changed.emit()
         log.debug("Certificates is set to %s.", certificates)
+
+    def import_with_task(self):
+        """Import certificates into the installer environment
+
+        :return: an installation task
+        """
+        return ImportCertificatesTask(
+            sysroot="/",
+            certificates=self.certificates,
+        )

--- a/pyanaconda/modules/security/certificates/certificates.py
+++ b/pyanaconda/modules/security/certificates/certificates.py
@@ -19,6 +19,7 @@
 #
 from pyanaconda.core.dbus import DBus
 from pyanaconda.core.signal import Signal
+from pyanaconda.core.constants import INSTALLATION_PHASE_PREINSTALL
 from pyanaconda.core.configuration.anaconda import conf
 from pykickstart.parser import Certificate
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -96,14 +97,17 @@ class CertificatesModule(KickstartBaseModule):
             certificates=self.certificates,
         )
 
-    def pre_install_with_task(self):
+    def pre_install_with_task(self, payload_type):
         """Import certificates into the system before the payload installation
 
         NOTE: the reason is potential use by rpm scriptlets
 
+        :param payload_type: a string with the payload type
         :return: a DBus path of the import task
         """
         return ImportCertificatesTask(
             sysroot=conf.target.system_root,
             certificates=self.certificates,
+            payload_type=payload_type,
+            phase=INSTALLATION_PHASE_PREINSTALL,
         )

--- a/pyanaconda/modules/security/certificates/certificates_interface.py
+++ b/pyanaconda/modules/security/certificates/certificates_interface.py
@@ -28,9 +28,14 @@ from pyanaconda.modules.common.structures.security import CertificateData
 class CertificatesInterface(KickstartModuleInterfaceTemplate):
     """DBus interface for the certificate installation module."""
 
-    def GetCertificates(self) -> List[Str]:
-        """Get all certificates to be installed the system.
+    def connect_signals(self):
+        super().connect_signals()
+        self.watch_property("Certificates", self.implementation.certificates_changed)
 
-        :return: a list of certificates names with their content
+    @property
+    def Certificates(self) -> List[Structure]:
+        """All certificates.
+
+        :return: a list of certificate DBus Structures
         """
-        return [CertificateData.to_structure(cert) for cert in self.implementation.get_certificates()]
+        return CertificateData.to_structure_list(self.implementation.certificates)

--- a/pyanaconda/modules/security/certificates/certificates_interface.py
+++ b/pyanaconda/modules/security/certificates/certificates_interface.py
@@ -58,3 +58,14 @@ class CertificatesInterface(KickstartModuleInterfaceTemplate):
         return TaskContainer.to_object_path(
             self.implementation.install_with_task()
         )
+
+    def PreInstallWithTask(self) -> ObjPath:
+        """Import certificates into the system before the payload installation
+
+        NOTE: the reason is potential use by rpm scriptlets
+
+        :return: a DBus path of the import task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.pre_install_with_task()
+        )

--- a/pyanaconda/modules/security/certificates/certificates_interface.py
+++ b/pyanaconda/modules/security/certificates/certificates_interface.py
@@ -1,7 +1,7 @@
 #
-# Kickstart handler for date and time settings.
+# DBus interface for the certificate module.
 #
-# Copyright (C) 2018 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of
@@ -17,25 +17,20 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-from pykickstart.parser import Certificate
-from pykickstart.sections import CertificateSection
-from pyanaconda.core.kickstart import KickstartSpecification, commands as COMMANDS
+from dasbus.server.interface import dbus_interface
+from dasbus.typing import *  # pylint: disable=wildcard-import
+from pyanaconda.modules.common.base import KickstartModuleInterfaceTemplate
+from pyanaconda.modules.common.constants.objects import CERTIFICATES
+from pyanaconda.modules.common.structures.security import CertificateData
 
 
-class SecurityKickstartSpecification(KickstartSpecification):
+@dbus_interface(CERTIFICATES.interface_name)
+class CertificatesInterface(KickstartModuleInterfaceTemplate):
+    """DBus interface for the certificate installation module."""
 
-    commands = {
-        "auth": COMMANDS.Authconfig,
-        "authconfig": COMMANDS.Authconfig,
-        "authselect": COMMANDS.Authselect,
-        "selinux": COMMANDS.SELinux,
-        "realm": COMMANDS.Realm
-    }
+    def GetCertificates(self) -> List[Str]:
+        """Get all certificates to be installed the system.
 
-    sections = {
-        "certificate": CertificateSection
-    }
-
-    sections_data = {
-        "certificate": Certificate
-    }
+        :return: a list of certificates names with their content
+        """
+        return [CertificateData.to_structure(cert) for cert in self.implementation.get_certificates()]

--- a/pyanaconda/modules/security/certificates/certificates_interface.py
+++ b/pyanaconda/modules/security/certificates/certificates_interface.py
@@ -22,6 +22,7 @@ from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.modules.common.base import KickstartModuleInterfaceTemplate
 from pyanaconda.modules.common.constants.objects import CERTIFICATES
 from pyanaconda.modules.common.structures.security import CertificateData
+from pyanaconda.modules.common.containers import TaskContainer
 
 
 @dbus_interface(CERTIFICATES.interface_name)
@@ -39,3 +40,12 @@ class CertificatesInterface(KickstartModuleInterfaceTemplate):
         :return: a list of certificate DBus Structures
         """
         return CertificateData.to_structure_list(self.implementation.certificates)
+
+    def ImportWithTask(self) -> ObjPath:
+        """Import certificates in the installer environment
+
+        :return: a DBus path of the import task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.import_with_task()
+        )

--- a/pyanaconda/modules/security/certificates/certificates_interface.py
+++ b/pyanaconda/modules/security/certificates/certificates_interface.py
@@ -49,3 +49,12 @@ class CertificatesInterface(KickstartModuleInterfaceTemplate):
         return TaskContainer.to_object_path(
             self.implementation.import_with_task()
         )
+
+    def InstallWithTask(self) -> ObjPath:
+        """Import certificates into the installed system
+
+        :return: a DBus path of the import task
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.install_with_task()
+        )

--- a/pyanaconda/modules/security/certificates/certificates_interface.py
+++ b/pyanaconda/modules/security/certificates/certificates_interface.py
@@ -59,13 +59,14 @@ class CertificatesInterface(KickstartModuleInterfaceTemplate):
             self.implementation.install_with_task()
         )
 
-    def PreInstallWithTask(self) -> ObjPath:
+    def PreInstallWithTask(self, payload_type: Str) -> ObjPath:
         """Import certificates into the system before the payload installation
 
         NOTE: the reason is potential use by rpm scriptlets
 
+        :param payload_type: a string with the payload type
         :return: a DBus path of the import task
         """
         return TaskContainer.to_object_path(
-            self.implementation.pre_install_with_task()
+            self.implementation.pre_install_with_task(payload_type)
         )

--- a/pyanaconda/modules/security/certificates/installation.py
+++ b/pyanaconda/modules/security/certificates/installation.py
@@ -50,6 +50,10 @@ class ImportCertificatesTask(Task):
             mkdirChain(dst_dir)
 
         dst = join_paths(dst_dir, cert.filename)
+
+        if os.path.exists(dst):
+            log.warning("Certificate file %s already exists, replacing.", dst)
+
         with open(dst, 'w') as f:
             f.write(cert.cert)
             f.write('\n')

--- a/pyanaconda/modules/security/certificates/installation.py
+++ b/pyanaconda/modules/security/certificates/installation.py
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.modules.common.task import Task
+
+log = get_module_logger(__name__)
+
+
+class ImportCertificatesTask(Task):
+    """Task for importing certificates into a system."""
+
+    def __init__(self, sysroot, certificates):
+        """Create a new certificates import task.
+
+        :param str sysroot: a path to the root of the target system
+        :param certificates: list of certificate data holders
+        """
+        super().__init__()
+        self._sysroot = sysroot
+        self._certificates = certificates
+
+    @property
+    def name(self):
+        return "Import CA certificates"
+
+    def run(self):
+        for cert in self._certificates:
+            log.debug("Importing certificate with filename: %s dir: %s", cert.filename, cert.dir)

--- a/pyanaconda/modules/security/certificates/installation.py
+++ b/pyanaconda/modules/security/certificates/installation.py
@@ -21,6 +21,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.common.errors.installation import SecurityInstallationError
 from pyanaconda.core.util import join_paths, mkdirChain
+from pyanaconda.core.constants import PAYLOAD_TYPE_DNF, INSTALLATION_PHASE_PREINSTALL
 
 log = get_module_logger(__name__)
 
@@ -28,15 +29,19 @@ log = get_module_logger(__name__)
 class ImportCertificatesTask(Task):
     """Task for importing certificates into a system."""
 
-    def __init__(self, sysroot, certificates):
+    def __init__(self, sysroot, certificates, payload_type=None, phase=None):
         """Create a new certificates import task.
 
         :param str sysroot: a path to the root of the target system
         :param certificates: list of certificate data holders
+        :param payload_type: a type of the payload
+        :param phase: installation phase - INSTALLATION_PHASE_PREINSTALL or None for any other
         """
         super().__init__()
         self._sysroot = sysroot
         self._certificates = certificates
+        self._payload_type = payload_type
+        self._phase = phase
 
     @property
     def name(self):
@@ -69,6 +74,12 @@ class ImportCertificatesTask(Task):
 
         Dump the certificates into specified files and directories.
         """
+        if self._phase == INSTALLATION_PHASE_PREINSTALL:
+            if self._payload_type != PAYLOAD_TYPE_DNF:
+                log.debug("Not importing certificates in pre install phase for %s payload.",
+                          self._payload_type)
+                return
+
         for cert in self._certificates:
             log.debug("Importing certificate with filename: %s dir: %s", cert.filename, cert.dir)
             self._dump_certificate(cert, self._sysroot)

--- a/pyanaconda/modules/security/certificates/installation.py
+++ b/pyanaconda/modules/security/certificates/installation.py
@@ -19,6 +19,7 @@ import os
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.task import Task
+from pyanaconda.modules.common.errors.installation import SecurityInstallationError
 from pyanaconda.core.util import join_paths, mkdirChain
 
 log = get_module_logger(__name__)
@@ -43,6 +44,11 @@ class ImportCertificatesTask(Task):
 
     def _dump_certificate(self, cert, root):
         """Dump the certificate into specified file and directory."""
+        if not cert.dir:
+            raise SecurityInstallationError(
+                "Certificate destination is missing for {}".format(cert.filename)
+            )
+
         dst_dir = join_paths(root, cert.dir)
         if not os.path.exists(dst_dir):
             log.debug("Path %s for certificate %s does not exist, creating.",

--- a/pyanaconda/modules/security/certificates/installation.py
+++ b/pyanaconda/modules/security/certificates/installation.py
@@ -15,8 +15,11 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import os
+
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.modules.common.task import Task
+from pyanaconda.core.util import join_paths, mkdirChain
 
 log = get_module_logger(__name__)
 
@@ -38,6 +41,24 @@ class ImportCertificatesTask(Task):
     def name(self):
         return "Import CA certificates"
 
+    def _dump_certificate(self, cert, root):
+        """Dump the certificate into specified file and directory."""
+        dst_dir = join_paths(root, cert.dir)
+        if not os.path.exists(dst_dir):
+            log.debug("Path %s for certificate %s does not exist, creating.",
+                      dst_dir, cert.filename)
+            mkdirChain(dst_dir)
+
+        dst = join_paths(dst_dir, cert.filename)
+        with open(dst, 'w') as f:
+            f.write(cert.cert)
+            f.write('\n')
+
     def run(self):
+        """Import CA certificates.
+
+        Dump the certificates into specified files and directories.
+        """
         for cert in self._certificates:
             log.debug("Importing certificate with filename: %s dir: %s", cert.filename, cert.dir)
+            self._dump_certificate(cert, self._sysroot)

--- a/pyanaconda/modules/security/kickstart.py
+++ b/pyanaconda/modules/security/kickstart.py
@@ -33,9 +33,9 @@ class SecurityKickstartSpecification(KickstartSpecification):
     }
 
     sections = {
-        "certificate": CertificateSection
+        "certificate": (CertificateSection, Certificate)
     }
 
     sections_data = {
-        "certificate": Certificate
+        "certificate": (Certificate, "certificates")
     }

--- a/rpmlint.toml
+++ b/rpmlint.toml
@@ -23,6 +23,7 @@ Filters = [
     'no-manual-page-for-binary anaconda-cleanup',
     'no-manual-page-for-binary anaconda-disable-nm-ibft-plugin',
     'no-manual-page-for-binary anaconda-nm-disable-autocons',
+    'no-manual-page-for-binary anaconda-import-initramfs-certs',
     'no-manual-page-for-binary instperf',
     'no-manual-page-for-binary instperf',
     'no-manual-page-for-binary anaconda',

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -17,7 +17,8 @@
 
 scriptsdir = $(libexecdir)/$(PACKAGE_NAME)
 dist_scripts_SCRIPTS = upd-updates run-anaconda \
-                       anaconda-pre-log-gen log-capture start-module apply-updates
+                       anaconda-pre-log-gen log-capture start-module apply-updates \
+                       anaconda-import-initramfs-certs
 
 dist_noinst_SCRIPTS  = upd-kernel makeupdates makebumpver
 

--- a/scripts/anaconda-import-initramfs-certs
+++ b/scripts/anaconda-import-initramfs-certs
@@ -1,0 +1,6 @@
+#! /bin/bash
+# Transfers CA certificates imported in initramfs via kickstart
+# to anaconda environment after switchroot.
+
+# certificates dumped to the specified file are copied to root
+cp -rv /run/install/certificates/path/* / || true

--- a/tests/unit_tests/dracut_tests/test_parse_kickstart.py
+++ b/tests/unit_tests/dracut_tests/test_parse_kickstart.py
@@ -22,6 +22,19 @@ import shutil
 import subprocess
 import re
 
+CERT_CONTENT = """-----BEGIN CERTIFICATE-----
+MIIBjTCCATOgAwIBAgIUWR5HO3v/0I80Ne0jQWVZFODuWLEwCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJUlZURVNUIENBMB4XDTI0MTEyMDEzNTk1N1oXDTM0MTExODEz
+NTk1N1owFDESMBAGA1UEAwwJUlZURVNUIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAELghFKGEgS8+5/2nx50W0xOqTrKc2Jz/rD/jfL0m4z4fkeAslCOkIKv74
+0wfBXMngxi+OF/b3Vh8FmokuNBQO5qNjMGEwHQYDVR0OBBYEFOJarl9Xkd13sLzI
+mHqv6aESlvuCMB8GA1UdIwQYMBaAFOJarl9Xkd13sLzImHqv6aESlvuCMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMCA0gAMEUCIAet
+7nyre42ReoRKoyHWLDsQmQDzoyU3FQdC0cViqOtrAiEAxYIL+XTTp7Xy9RNE4Xg7
+yNWXfdraC/AfMM8fqsxlVJM=
+-----END CERTIFICATE-----"""
+
+
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
         # create the directory used for file/folder tests
@@ -259,3 +272,60 @@ network --device=lo --vlanid=171 --interfacename=vlan171
             lines = self.execParseKickstart(ks_file.name)
 
             assert lines[0] == "inst.extlinux", lines
+
+    def _check_cert_file(self, cert_file, content):
+        with open(cert_file) as f:
+            # Anaconda adds `\n` to the value when dumping it
+            assert f.read() == content+'\n'
+
+    def test_certificate(self):
+        filename = "rvtest.pem"
+        cdir = os.path.join(self.tmpdir, "cert_dir/subdir")
+        content = CERT_CONTENT
+        ks_cert = f"""
+%certificate --filename={filename} --dir={cdir}
+{content}
+%end
+"""
+        cert_file = os.path.join(cdir, filename)
+
+        with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
+            ks_file.write(ks_cert)
+            ks_file.flush()
+            lines = self.execParseKickstart(ks_file.name)
+            assert lines == []
+
+        self._check_cert_file(cert_file, content)
+
+        # Check existence for file for transport to root
+        CERT_TRANSPORT_DIR = "/run/install/certificates"
+        transport_file = os.path.join(CERT_TRANSPORT_DIR, cert_file)
+        self._check_cert_file(transport_file, content)
+
+    def test_certificate_existing(self):
+        filename = "rvtest.pem"
+        cdir = os.path.join(self.tmpdir, "cert_dir/subdir")
+        content = CERT_CONTENT
+        ks_cert = f"""
+%certificate --filename={filename} --dir={cdir}
+{content}
+%end
+"""
+        cert_file = os.path.join(cdir, filename)
+
+        # Existing file should be overwritten
+        os.makedirs(cdir)
+        open(cert_file, 'w')
+
+        with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
+            ks_file.write(ks_cert)
+            ks_file.flush()
+            lines = self.execParseKickstart(ks_file.name)
+            assert lines == []
+
+        self._check_cert_file(cert_file, content)
+
+        # Check existence for file for transport to root
+        CERT_TRANSPORT_DIR = "/run/install/certificates"
+        transport_file = os.path.join(CERT_TRANSPORT_DIR, cert_file)
+        self._check_cert_file(transport_file, content)

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
@@ -25,6 +25,7 @@ from pyanaconda.modules.common.constants.objects import CERTIFICATES
 from pyanaconda.modules.common.structures.security import CertificateData
 from pyanaconda.modules.security.certificates.certificates import CertificatesModule
 from pyanaconda.modules.security.certificates.certificates_interface import CertificatesInterface
+from pyanaconda.modules.security.certificates.installation import ImportCertificatesTask
 from tests.unit_tests.pyanaconda_tests import check_dbus_property, check_task_creation, \
     patch_dbus_publish_object
 

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
@@ -25,6 +25,7 @@ from dasbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.modules.common.constants.objects import CERTIFICATES
 from pyanaconda.modules.common.structures.security import CertificateData
+from pyanaconda.modules.common.errors.installation import SecurityInstallationError
 from pyanaconda.modules.security.certificates.certificates import CertificatesModule
 from pyanaconda.modules.security.certificates.certificates_interface import CertificatesInterface
 from pyanaconda.modules.security.certificates.installation import ImportCertificatesTask
@@ -235,3 +236,16 @@ class CertificatesInterfaceTestCase(unittest.TestCase):
             ).run()
 
             self._check_cert_file(c1, sysroot)
+
+    def test_import_certificates_missing_destination(self):
+        """Test the ImportCertificatesTask task with missing destination"""
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', ''),
+        ])
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            with self.assertRaises(SecurityInstallationError):
+                ImportCertificatesTask(
+                    sysroot=sysroot,
+                    certificates=certs,
+                ).run()

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
@@ -101,3 +101,30 @@ class CertificatesInterfaceTestCase(unittest.TestCase):
             # read-only property, so provide setter
             setter=self._iface_certificates_setter()
         )
+
+    @patch_dbus_publish_object
+    def test_import_with_task_default(self, publisher):
+        """Test the ImportWithTask method"""
+        task_path = self.certificates_interface.ImportWithTask()
+        obj = check_task_creation(task_path, publisher, ImportCertificatesTask)
+        assert obj.implementation._sysroot == "/"
+
+    @patch_dbus_publish_object
+    def test_import_with_task_configured(self, publisher):
+        """Test the ImportWithTask method"""
+        c1 = (CERT_RVTEST, 'rvtest.pem', '/etc/pki/ca-trust/extracted/pem')
+        c2 = (CERT_RVTEST2, 'rvtest2.pem', '')
+        certs_value = self._get_dbus_certs([
+                c1,
+                c2,
+        ])
+        set_certificates = self._iface_certificates_setter()
+        set_certificates(certs_value)
+
+        task_path = self.certificates_interface.ImportWithTask()
+        obj = check_task_creation(task_path, publisher, ImportCertificatesTask)
+        assert obj.implementation._sysroot == "/"
+        assert len(obj.implementation._certificates) == 2
+        obj_c1, obj_c2 = obj.implementation._certificates
+        assert c1 == (obj_c1.cert, obj_c1.filename, obj_c1.dir)
+        assert c2 == (obj_c2.cert, obj_c2.filename, obj_c2.dir)

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
@@ -1,0 +1,103 @@
+#
+# Copyright (C) 2025  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Radek Vykydal <rvykydal@redhat.com>
+#
+import unittest
+
+from dasbus.typing import *  # pylint: disable=wildcard-import
+
+from pyanaconda.modules.common.constants.objects import CERTIFICATES
+from pyanaconda.modules.common.structures.security import CertificateData
+from pyanaconda.modules.security.certificates.certificates import CertificatesModule
+from pyanaconda.modules.security.certificates.certificates_interface import CertificatesInterface
+from tests.unit_tests.pyanaconda_tests import check_dbus_property, check_task_creation, \
+    patch_dbus_publish_object
+
+
+CERT_RVTEST = """-----BEGIN CERTIFICATE-----
+MIIBjTCCATOgAwIBAgIUWR5HO3v/0I80Ne0jQWVZFODuWLEwCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJUlZURVNUIENBMB4XDTI0MTEyMDEzNTk1N1oXDTM0MTExODEz
+NTk1N1owFDESMBAGA1UEAwwJUlZURVNUIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+AQcDQgAELghFKGEgS8+5/2nx50W0xOqTrKc2Jz/rD/jfL0m4z4fkeAslCOkIKv74
+0wfBXMngxi+OF/b3Vh8FmokuNBQO5qNjMGEwHQYDVR0OBBYEFOJarl9Xkd13sLzI
+mHqv6aESlvuCMB8GA1UdIwQYMBaAFOJarl9Xkd13sLzImHqv6aESlvuCMA8GA1Ud
+EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMCA0gAMEUCIAet
+7nyre42ReoRKoyHWLDsQmQDzoyU3FQdC0cViqOtrAiEAxYIL+XTTp7Xy9RNE4Xg7
+yNWXfdraC/AfMM8fqsxlVJM=
+-----END CERTIFICATE-----"""
+
+CERT_RVTEST2 = """-----BEGIN CERTIFICATE-----
+MIIBkTCCATegAwIBAgIUN6r4TjFJqP/TS6U25iOGL2Wt/6kwCgYIKoZIzj0EAwIw
+FjEUMBIGA1UEAwwLUlZURVNUIDIgQ0EwHhcNMjQxMTIwMTQwMzIxWhcNMzQxMTE4
+MTQwMzIxWjAWMRQwEgYDVQQDDAtSVlRFU1QgMiBDQTBZMBMGByqGSM49AgEGCCqG
+SM49AwEHA0IABOtXBMEhtcH43dIDHkelODXrSWQQ8PW7oo8lQUEYTNAL1rpWJJDD
+1u+bpLe62Z0kzYK0CpeKuXFfwGrzx7eA6vajYzBhMB0GA1UdDgQWBBStV+z7SZSi
+YXlamkx+xjm/W1sMSTAfBgNVHSMEGDAWgBStV+z7SZSiYXlamkx+xjm/W1sMSTAP
+BgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAgNIADBF
+AiEAkQjETC3Yx2xOkA+R0/YR+R+QqpR8p1fd/cGKWFUYxSoCIEuDJcfvPJfFYdzn
+CFOCLuymezWz+1rdIXLU1+XStLuB
+-----END CERTIFICATE-----"""
+
+
+class CertificatesInterfaceTestCase(unittest.TestCase):
+    """Test DBus interface of the Certificates module."""
+
+    def setUp(self):
+        """Set up the module."""
+        self.certificates_module = CertificatesModule()
+        self.certificates_interface = CertificatesInterface(self.certificates_module)
+
+    def _check_dbus_property(self, *args, **kwargs):
+        check_dbus_property(
+            CERTIFICATES,
+            self.certificates_interface,
+            *args, **kwargs
+        )
+
+    @staticmethod
+    def _get_dbus_certs(certs):
+        return [
+            {
+                'cert': get_variant(Str, cert),
+                'filename': get_variant(Str, filename),
+                'dir': get_variant(Str, cdir)
+            }
+            for cert, filename, cdir in certs
+        ]
+
+    def _iface_certificates_setter(self):
+        """Provide setter for testing read-only Certificates property."""
+        return lambda value: self.certificates_module.set_certificates(
+            CertificateData.from_structure_list(value)
+        )
+
+    def test_certificates_property(self):
+        """Test the certificates property."""
+        assert self.certificates_interface.Certificates == []
+
+        certs_value = self._get_dbus_certs([
+                (CERT_RVTEST, 'rvtest.pem', '/etc/pki/ca-trust/extracted/pem'),
+                (CERT_RVTEST2, 'rvtest2.pem', ''),
+        ])
+
+        self._check_dbus_property(
+            "Certificates",
+            certs_value,
+            # read-only property, so provide setter
+            setter=self._iface_certificates_setter()
+        )

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
@@ -215,3 +215,23 @@ class CertificatesInterfaceTestCase(unittest.TestCase):
 
             for c in certs:
                 self._check_cert_file(c, sysroot)
+
+    def test_import_certificates_task_existing_file(self):
+        """Test the ImportCertificatesTask task with existing file to be imported"""
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', '/etc/pki/dir1'),
+        ])
+
+        c1 = certs[0]
+        with tempfile.TemporaryDirectory() as sysroot:
+            # certificate file to be dumped already exists
+            os.makedirs(sysroot+c1.dir)
+            c1_file = sysroot + c1.dir + "/" + c1.filename
+            open(c1_file, 'w')
+
+            ImportCertificatesTask(
+                sysroot=sysroot,
+                certificates=[c1],
+            ).run()
+
+            self._check_cert_file(c1, sysroot)

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -184,6 +184,68 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
 
+    def test_certificates_kickstart(self):
+        """Test the %certificates section."""
+        ks_in = """
+        %certificate --filename=rvtest.pem --dir=/cert_dir
+        -----BEGIN CERTIFICATE-----
+        MIIBjTCCATOgAwIBAgIUWR5HO3v/0I80Ne0jQWVZFODuWLEwCgYIKoZIzj0EAwIw
+        FDESMBAGA1UEAwwJUlZURVNUIENBMB4XDTI0MTEyMDEzNTk1N1oXDTM0MTExODEz
+        NTk1N1owFDESMBAGA1UEAwwJUlZURVNUIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+        AQcDQgAELghFKGEgS8+5/2nx50W0xOqTrKc2Jz/rD/jfL0m4z4fkeAslCOkIKv74
+        0wfBXMngxi+OF/b3Vh8FmokuNBQO5qNjMGEwHQYDVR0OBBYEFOJarl9Xkd13sLzI
+        mHqv6aESlvuCMB8GA1UdIwQYMBaAFOJarl9Xkd13sLzImHqv6aESlvuCMA8GA1Ud
+        EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMCA0gAMEUCIAet
+        7nyre42ReoRKoyHWLDsQmQDzoyU3FQdC0cViqOtrAiEAxYIL+XTTp7Xy9RNE4Xg7
+        yNWXfdraC/AfMM8fqsxlVJM=
+        -----END CERTIFICATE-----
+        %end
+
+        %certificate --filename=rvtest2.pem --dir=/cert_dir2
+        -----BEGIN CERTIFICATE-----
+        MIIBkTCCATegAwIBAgIUN6r4TjFJqP/TS6U25iOGL2Wt/6kwCgYIKoZIzj0EAwIw
+        FjEUMBIGA1UEAwwLUlZURVNUIDIgQ0EwHhcNMjQxMTIwMTQwMzIxWhcNMzQxMTE4
+        MTQwMzIxWjAWMRQwEgYDVQQDDAtSVlRFU1QgMiBDQTBZMBMGByqGSM49AgEGCCqG
+        SM49AwEHA0IABOtXBMEhtcH43dIDHkelODXrSWQQ8PW7oo8lQUEYTNAL1rpWJJDD
+        1u+bpLe62Z0kzYK0CpeKuXFfwGrzx7eA6vajYzBhMB0GA1UdDgQWBBStV+z7SZSi
+        YXlamkx+xjm/W1sMSTAfBgNVHSMEGDAWgBStV+z7SZSiYXlamkx+xjm/W1sMSTAP
+        BgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAgNIADBF
+        AiEAkQjETC3Yx2xOkA+R0/YR+R+QqpR8p1fd/cGKWFUYxSoCIEuDJcfvPJfFYdzn
+        CFOCLuymezWz+1rdIXLU1+XStLuB
+        -----END CERTIFICATE-----
+        %end
+        """
+        ks_out = """
+        %certificate --filename=rvtest.pem --dir=/cert_dir
+        -----BEGIN CERTIFICATE-----
+        MIIBjTCCATOgAwIBAgIUWR5HO3v/0I80Ne0jQWVZFODuWLEwCgYIKoZIzj0EAwIw
+        FDESMBAGA1UEAwwJUlZURVNUIENBMB4XDTI0MTEyMDEzNTk1N1oXDTM0MTExODEz
+        NTk1N1owFDESMBAGA1UEAwwJUlZURVNUIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0D
+        AQcDQgAELghFKGEgS8+5/2nx50W0xOqTrKc2Jz/rD/jfL0m4z4fkeAslCOkIKv74
+        0wfBXMngxi+OF/b3Vh8FmokuNBQO5qNjMGEwHQYDVR0OBBYEFOJarl9Xkd13sLzI
+        mHqv6aESlvuCMB8GA1UdIwQYMBaAFOJarl9Xkd13sLzImHqv6aESlvuCMA8GA1Ud
+        EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMCA0gAMEUCIAet
+        7nyre42ReoRKoyHWLDsQmQDzoyU3FQdC0cViqOtrAiEAxYIL+XTTp7Xy9RNE4Xg7
+        yNWXfdraC/AfMM8fqsxlVJM=
+        -----END CERTIFICATE-----
+        %end
+
+        %certificate --filename=rvtest2.pem --dir=/cert_dir2
+        -----BEGIN CERTIFICATE-----
+        MIIBkTCCATegAwIBAgIUN6r4TjFJqP/TS6U25iOGL2Wt/6kwCgYIKoZIzj0EAwIw
+        FjEUMBIGA1UEAwwLUlZURVNUIDIgQ0EwHhcNMjQxMTIwMTQwMzIxWhcNMzQxMTE4
+        MTQwMzIxWjAWMRQwEgYDVQQDDAtSVlRFU1QgMiBDQTBZMBMGByqGSM49AgEGCCqG
+        SM49AwEHA0IABOtXBMEhtcH43dIDHkelODXrSWQQ8PW7oo8lQUEYTNAL1rpWJJDD
+        1u+bpLe62Z0kzYK0CpeKuXFfwGrzx7eA6vajYzBhMB0GA1UdDgQWBBStV+z7SZSi
+        YXlamkx+xjm/W1sMSTAfBgNVHSMEGDAWgBStV+z7SZSiYXlamkx+xjm/W1sMSTAP
+        BgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAgNIADBF
+        AiEAkQjETC3Yx2xOkA+R0/YR+R+QqpR8p1fd/cGKWFUYxSoCIEuDJcfvPJfFYdzn
+        CFOCLuymezWz+1rdIXLU1+XStLuB
+        -----END CERTIFICATE-----
+        %end
+        """
+        self._test_kickstart(ks_in, ks_out)
+
     @patch_dbus_publish_object
     def test_realm_discover_default(self, publisher):
         """Test module in default state with realm discover task."""

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -68,7 +68,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         """Test kickstart properties."""
         assert self.security_interface.KickstartCommands == \
             ["auth", "authconfig", "authselect", "selinux", "realm"]
-        assert self.security_interface.KickstartSections == []
+        assert self.security_interface.KickstartSections == ["certificate"]
         assert self.security_interface.KickstartAddons == []
         self.callback.assert_not_called()
 

--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -28,8 +28,8 @@ from pykickstart.errors import KickstartParseError
 from pykickstart.commands.skipx import FC3_SkipX
 from pykickstart.commands.user import F24_User, F19_UserData
 from pykickstart.options import KSOptionParser
-from pykickstart.parser import Packages
-from pykickstart.sections import PackageSection
+from pykickstart.parser import Packages, Certificate
+from pykickstart.sections import PackageSection, CertificateSection
 from pykickstart.version import F30
 
 from pyanaconda import kickstart
@@ -206,6 +206,16 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         addons = {
             "my_test_1": TestData1,
             "my_test_2": TestData2
+        }
+
+    class SpecificationG(KickstartSpecification):
+
+        sections = {
+            "certificate": CertificateSection,
+        }
+
+        sections_data = {
+            "certificate": Certificate,
         }
 
     def setUp(self):
@@ -385,6 +395,20 @@ class KickstartSpecificationTestCase(unittest.TestCase):
            %addon my_test_unknown
            %end
            """)
+
+    def test_certificates_specification(self):
+        specification = self.SpecificationG
+
+        ks_in = """
+        %certificate --filename=cert1.pem
+        -----BEGIN CERTIFICATE-----
+        MIIDazCCAlOgAwIBAgIJAJzQz1Zz1Zz1MA0GCSqGSIb3DQEBCwUAMIGVMQswCQYD
+        -----END CERTIFICATE-----
+        %end
+        """
+        handler = self.parse_kickstart(specification, ks_in)
+        assert isinstance(handler.certificates[0], Certificate)
+        assert len(handler.certificates) == 1
 
 
 class ModuleSpecificationsTestCase(unittest.TestCase):


### PR DESCRIPTION
Port of https://github.com/rhinstaller/anaconda/pull/6045 to rhel9.
Port to rhel10 is used as it does not contain updates for module import ordering fixes.
The (minor) modifications of [rhel10 port patch](https://github.com/rhinstaller/anaconda/pull/6082):
- SubmoduleManager is not in rhel-9 yet (minor modification) - https://github.com/rvykydal/anaconda/commit/c257b4ab125ba359a3c3bed6dc9ce48852a5be6f 
- join_paths utility function in a different module, make_directories not available yet - https://github.com/rvykydal/anaconda/commit/5567034cac2a805b9b12fa3b8ea44a75109c5594

TODO
- [x] update required pykickstart version