### PR TITLE
data: profiles: enable language screen for Web UI on Workstation

### DIFF
--- a/data/profile.d/fedora-workstation.conf
+++ b/data/profile.d/fedora-workstation.conf
@@ -24,7 +24,6 @@ hidden_spokes =
     UserSpoke
 hidden_webui_pages =
     anaconda-screen-accounts
-    anaconda-screen-language
 
 [Localization]
 # disable localization for the Fedora Workstation live image to avoid


### PR DESCRIPTION
GIS is still not in place [1], let's use our language solution.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2308654

