### PR TITLE
RHEL 10: Disable keyboard switching with a shortcut in boot.iso

### DIFF
--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -186,3 +186,8 @@ class SystemSection(Section):
     def supports_web_ui(self):
         """Can we run Web UI on this system?"""
         return self._is_boot_iso or self._is_live_os
+
+    @property
+    def supports_compositor_keyboard_layout_shortcut(self):
+        """Does the compositor support keyboard layout options correctly?"""
+        return not self._is_boot_iso

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -353,8 +353,19 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
         # If options are not set let's use from a system so we don't change the system settings
         if options is None:
             options = self.options
-            log.debug("Keyboard layouts for compositor are missing options. "
-                      "Use compositor options: %s", options)
+            log.debug(
+                "Keyboard layouts for compositor are missing options. Use compositor options: %s",
+                options,
+            )
+
+        # TODO: Remove when https://issues.redhat.com/browse/RHEL-71880 is fixed
+        # Because of the bug above Anaconda is not able to detect keyboard layout changed by the
+        # keyboard shortcuts, however, layouts will change. To avoid confusion of users
+        # let's rather disable this feature completely.
+        if conf.system.supports_compositor_keyboard_layout_shortcut is not True:
+            log.debug("Keyboard layout switching from shortcut is broken in compositor. "
+                      "Filter these out from the options: '%s'.", options)
+            options = list(filter(lambda x: not x.startswith("grp:"), options))
 
         # store configuration from user
         super().set_layouts(layouts_variants, options, convert)

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -359,12 +359,11 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
         # store configuration from user
         super().set_layouts(layouts_variants, options, convert)
 
-    # TODO: rename to select_layout
-    def set_current_layout(self, layout_variant):
-        """Set given layout as first (current) layout for compositor.
+    def select_layout(self, layout_variant):
+        """Select layout from the list of current layouts set.
 
         This will search for the given layout variant in the list and move it as first
-        in the list.
+        in the list. The first layout in systemd is taken as the used one.
 
         :param layout_variant: The layout to set, with format "layout (variant)"
             (e.g. "cz (qwerty)")

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from abc import ABC
+
 from pyanaconda.core.dbus import SystemBus
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.constants.services import LOCALED
@@ -26,15 +28,14 @@ from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
 
 
-class LocaledWrapper(object):
+__all__ = ["CompositorLocaledWrapper", "LocaledWrapper"]
+
+
+class LocaledWrapperBase(ABC):
     """Class wrapping systemd-localed daemon functionality."""
 
     def __init__(self):
         self._localed_proxy = None
-        self._user_layouts_variants = []
-        self._last_layouts_variants = []
-        self.compositor_layouts_changed = Signal()
-        self.compositor_selected_layout_changed = Signal()
 
         if not conf.system.provides_system_bus:
             log.debug("Not using localed service: "
@@ -47,6 +48,222 @@ class LocaledWrapper(object):
             return
 
         self._localed_proxy = LOCALED.get_proxy()
+
+    @property
+    def layouts_variants(self):
+        """Get current X11 layouts with variants.
+
+        :return: a list of "layout (variant)" or "layout" layout specifications
+        :rtype: list(str)
+        """
+        if not self._localed_proxy:
+            return []
+
+        layouts = self._localed_proxy.X11Layout
+        variants = self._localed_proxy.X11Variant
+
+        return self._from_localed_format(layouts, variants)
+
+    @staticmethod
+    def _from_localed_format(layouts, variants):
+        layouts = layouts.split(",") if layouts else []
+        variants = variants.split(",") if variants else []
+
+        # if there are more layouts than variants, empty strings should be appended
+        diff = len(layouts) - len(variants)
+        variants.extend(diff * [""])
+
+        return [join_layout_variant(layout, variant) for layout, variant in zip(layouts, variants)]
+
+    @property
+    def options(self):
+        """Get current X11 options.
+
+        :return: a list of X11 options
+        :rtype: list(str)
+        """
+        if not self._localed_proxy:
+            return []
+
+        options = self._localed_proxy.X11Options
+
+        return options.split(",") if options else []
+
+    def set_layouts(self, layouts_variants, options=None, convert=False):
+        """Set X11 layouts.
+
+        :param layouts_variants: list of 'layout (variant)' or 'layout'
+                                 specifications of layouts and variants
+        :type layouts_variants: list(str)
+        :param options: list of X11 options that should be set
+        :type options: list(str) or None
+        :param convert: whether the layouts should be converted to a VConsole keymap
+                        (see set_and_convert_layouts)
+        :type convert: bool
+        """
+        if not self._localed_proxy:
+            return
+
+        layouts = []
+        variants = []
+        parsing_failed = False
+
+        for layout_variant in (nonempty for nonempty in layouts_variants if nonempty):
+            try:
+                (layout, variant) = parse_layout_variant(layout_variant)
+            except InvalidLayoutVariantSpec as e:
+                log.debug("Parsing of %s failed: %s", layout_variant, e)
+                parsing_failed = True
+                continue
+            layouts.append(layout)
+            variants.append(variant)
+
+        if not layouts and parsing_failed:
+            return
+
+        layouts_str = ",".join(layouts)
+        variants_str = ",".join(variants)
+        options_str = ",".join(options) if options else ""
+
+        log.debug("Setting keyboard layouts: '%s' options: '%s' convert: '%s",
+                  layouts_variants, options, convert)
+
+        self._localed_proxy.SetX11Keyboard(
+            layouts_str,
+            "pc105",
+            variants_str,
+            options_str,
+            convert,
+            False
+        )
+
+
+class LocaledWrapper(LocaledWrapperBase):
+    """Localed wrapper class which is used to installation.
+
+    It adds support for keymap and conversion methods between keymap and layouts.
+    """
+
+    @property
+    def keymap(self):
+        """Get current VConsole keymap.
+
+        :return: VConsole keymap specification
+        :rtype: string
+        """
+        if not self._localed_proxy:
+            return ""
+
+        return self._localed_proxy.VConsoleKeymap
+
+    def set_keymap(self, keymap, convert=False):
+        """Set current VConsole keymap.
+
+        :param keymap: VConsole keymap that should be set
+        :type keymap: str
+        :param convert: whether the keymap should be converted and set as X11 layout
+        :type convert: bool
+        """
+        if not self._localed_proxy:
+            return ""
+
+        self._localed_proxy.SetVConsoleKeyboard(keymap, "", convert, False)
+
+    def convert_keymap(self, keymap):
+        """Get X11 layouts and variants by converting VConsole keymap.
+
+        NOTE: Systemd-localed performs the conversion. Current VConsole keymap
+        and X11 layouts are set temporarily to the converted values in the
+        process of conversion.
+
+        :param keymap: VConsole keymap
+        :type keymap: str
+        :return: a list of "layout (variant)" or "layout" layout specifications
+                 obtained by conversion of VConsole keymap
+        :rtype: list(str)
+        """
+        if not self._localed_proxy:
+            return []
+
+        # hack around systemd's lack of functionality -- no function to just
+        # convert without changing keyboard configuration
+        orig_layouts_variants = self.layouts_variants
+        orig_keymap = self.keymap
+        converted_layouts = self.set_and_convert_keymap(keymap)
+        self.set_layouts(orig_layouts_variants)
+        self.set_keymap(orig_keymap)
+
+        return converted_layouts
+
+    def set_and_convert_keymap(self, keymap):
+        """Set VConsole keymap and set and get converted X11 layouts.
+
+        :param keymap: VConsole keymap
+        :type keymap: str
+        :return: a list of "layout (variant)" or "layout" layout specifications
+                 obtained by conversion from VConsole keymap
+        :rtype: list(str)
+        """
+        self.set_keymap(keymap, convert=True)
+
+        return self.layouts_variants
+
+    def set_and_convert_layouts(self, layouts_variants):
+        """Set X11 layouts and set and get converted VConsole keymap.
+
+        :param layouts_variants: list of 'layout (variant)' or 'layout'
+                                 specifications of layouts and variants
+        :type layouts_variants: list(str)
+        :return: a VConsole keymap obtained by conversion from X11 layouts
+        :rtype: str
+        """
+
+        self.set_layouts(layouts_variants, convert=True)
+
+        return self.keymap
+
+    def convert_layouts(self, layouts_variants):
+        """Get VConsole keymap by converting X11 layouts and variants.
+
+        NOTE: Systemd-localed performs the conversion. Current VConsole keymap
+        and X11 layouts are set temporarily to the converted values in the
+        process of conversion.
+
+        :param layouts_variants: list of 'layout (variant)' or 'layout'
+                                 specifications of layouts and variants
+        :type layouts_variants: list(str)
+        :return: a VConsole keymap obtained by conversion from X11 layouts
+        :rtype: str
+        """
+        if not self._localed_proxy:
+            return ""
+
+        # hack around systemd's lack of functionality -- no function to just
+        # convert without changing keyboard configuration
+        orig_layouts_variants = self.layouts_variants
+        orig_keymap = self.keymap
+        ret = self.set_and_convert_layouts(layouts_variants)
+        self.set_layouts(orig_layouts_variants)
+        self.set_keymap(orig_keymap)
+
+        return ret
+
+
+class CompositorLocaledWrapper(LocaledWrapperBase):
+    """Localed wrapper class which is used to control compositor.
+
+    It adds support for layout selection and reactions on the compositor system changes.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self._user_layouts_variants = []
+        self._last_layouts_variants = []
+        self.compositor_layouts_changed = Signal()
+        self.compositor_selected_layout_changed = Signal()
+
+        # to reflect updates from the compositor
         self._localed_proxy.PropertiesChanged.connect(self._on_properties_changed)
 
     def _on_properties_changed(self, interface, changed_props, invalid_props):
@@ -90,45 +307,6 @@ class LocaledWrapper(object):
             self._last_layouts_variants = layouts_variants
 
     @property
-    def keymap(self):
-        """Get current VConsole keymap.
-
-        :return: VConsole keymap specification
-        :rtype: string
-        """
-        if not self._localed_proxy:
-            return ""
-
-        return self._localed_proxy.VConsoleKeymap
-
-    @property
-    def layouts_variants(self):
-        """Get current X11 layouts with variants.
-
-        :return: a list of "layout (variant)" or "layout" layout specifications
-        :rtype: list(str)
-        """
-        if not self._localed_proxy:
-            return []
-
-        layouts = self._localed_proxy.X11Layout
-        variants = self._localed_proxy.X11Variant
-
-        self._last_layouts_variants = self._from_localed_format(layouts, variants)
-        return self._last_layouts_variants
-
-    @staticmethod
-    def _from_localed_format(layouts, variants):
-        layouts = layouts.split(",") if layouts else []
-        variants = variants.split(",") if variants else []
-
-        # if there are more layouts than variants, empty strings should be appended
-        diff = len(layouts) - len(variants)
-        variants.extend(diff * [""])
-
-        return [join_layout_variant(layout, variant) for layout, variant in zip(layouts, variants)]
-
-    @property
     def current_layout_variant(self):
         """Get first (current) layout with variant.
 
@@ -138,73 +316,21 @@ class LocaledWrapper(object):
         return "" if not self.layouts_variants else self.layouts_variants[0]
 
     @property
-    def options(self):
-        """Get current X11 options.
+    def layouts_variants(self):
+        """Get current X11 layouts with variants.
 
-        :return: a list of X11 options
-        :rtype: list(str)
-        """
-        if not self._localed_proxy:
-            return []
+        Store information about the last selected layout variant used.
 
-        options = self._localed_proxy.X11Options
-
-        return options.split(",") if options else []
-
-    def set_keymap(self, keymap, convert=False):
-        """Set current VConsole keymap.
-
-        :param keymap: VConsole keymap that should be set
-        :type keymap: str
-        :param convert: whether the keymap should be converted and set as X11 layout
-        :type convert: bool
-        """
-        if not self._localed_proxy:
-            return ""
-
-        self._localed_proxy.SetVConsoleKeyboard(keymap, "", convert, False)
-
-    def convert_keymap(self, keymap):
-        """Get X11 layouts and variants by converting VConsole keymap.
-
-        NOTE: Systemd-localed performs the conversion. Current VConsole keymap
-        and X11 layouts are set temporarily to the converted values in the
-        process of conversion.
-
-        :param keymap: VConsole keymap
-        :type keymap: str
         :return: a list of "layout (variant)" or "layout" layout specifications
-                 obtained by conversion of VConsole keymap
         :rtype: list(str)
         """
-        if not self._localed_proxy:
-            return []
-
-        # hack around systemd's lack of functionality -- no function to just
-        # convert without changing keyboard configuration
-        orig_layouts_variants = self.layouts_variants
-        orig_keymap = self.keymap
-        converted_layouts = self.set_and_convert_keymap(keymap)
-        self._set_layouts(orig_layouts_variants)
-        self.set_keymap(orig_keymap)
-
-        return converted_layouts
-
-    def set_and_convert_keymap(self, keymap):
-        """Set VConsole keymap and set and get converted X11 layouts.
-
-        :param keymap: VConsole keymap
-        :type keymap: str
-        :return: a list of "layout (variant)" or "layout" layout specifications
-                 obtained by conversion from VConsole keymap
-        :rtype: list(str)
-        """
-        self.set_keymap(keymap, convert=True)
-
-        return self.layouts_variants
+        self._last_layouts_variants = super().layouts_variants
+        return self._last_layouts_variants
 
     def set_layouts(self, layouts_variants, options=None, convert=False):
         """Set X11 layouts.
+
+        Store user selected layouts with variants.
 
         :param layouts_variants: list of 'layout (variant)' or 'layout'
                                  specifications of layouts and variants
@@ -215,98 +341,30 @@ class LocaledWrapper(object):
                         (see set_and_convert_layouts)
         :type convert: bool
         """
-        # store configuration from user
         self._set_layouts(layouts_variants, options, convert)
         log.debug("Storing layouts for compositor configured by user")
         self._user_layouts_variants = layouts_variants
 
     def _set_layouts(self, layouts_variants, options=None, convert=False):
-        if not self._localed_proxy:
-            return
+        """Set a new layouts for compositor.
 
-        layouts = []
-        variants = []
-        parsing_failed = False
-
-        for layout_variant in (nonempty for nonempty in layouts_variants if nonempty):
-            try:
-                (layout, variant) = parse_layout_variant(layout_variant)
-            except InvalidLayoutVariantSpec as e:
-                log.debug("Parsing of %s failed: %s", layout_variant, e)
-                parsing_failed = True
-                continue
-            layouts.append(layout)
-            variants.append(variant)
-
-        if not layouts and parsing_failed:
-            return
-
+        Extension of the parent code with compositor specific code.
+        """
+        # If options are not set let's use from a system so we don't change the system settings
         if options is None:
             options = self.options
-            log.debug("Keyboard layouts for system/compositor are missing options. "
+            log.debug("Keyboard layouts for compositor are missing options. "
                       "Use compositor options: %s", options)
 
-        layouts_str = ",".join(layouts)
-        variants_str = ",".join(variants)
-        options_str = ",".join(options)
-
-        log.debug("Setting system/compositor keyboard layouts: '%s' options: '%s' convert: '%s",
-                  layouts_variants, options, convert)
-
-        self._localed_proxy.SetX11Keyboard(
-            layouts_str,
-            "pc105",
-            variants_str,
-            options_str,
-            convert,
-            False
-        )
-
-    def set_and_convert_layouts(self, layouts_variants):
-        """Set X11 layouts and set and get converted VConsole keymap.
-
-        :param layouts_variants: list of 'layout (variant)' or 'layout'
-                                 specifications of layouts and variants
-        :type layouts_variants: list(str)
-        :return: a VConsole keymap obtained by conversion from X11 layouts
-        :rtype: str
-        """
-
-        self._set_layouts(layouts_variants, convert=True)
-
-        return self.keymap
-
-    def convert_layouts(self, layouts_variants):
-        """Get VConsole keymap by converting X11 layouts and variants.
-
-        NOTE: Systemd-localed performs the conversion. Current VConsole keymap
-        and X11 layouts are set temporarily to the converted values in the
-        process of conversion.
-
-        :param layouts_variants: list of 'layout (variant)' or 'layout'
-                                 specifications of layouts and variants
-        :type layouts_variants: list(str)
-        :return: a VConsole keymap obtained by conversion from X11 layouts
-        :rtype: str
-        """
-        if not self._localed_proxy:
-            return ""
-
-        # hack around systemd's lack of functionality -- no function to just
-        # convert without changing keyboard configuration
-        orig_layouts_variants = self.layouts_variants
-        orig_keymap = self.keymap
-        ret = self.set_and_convert_layouts(layouts_variants)
-        self._set_layouts(orig_layouts_variants)
-        self.set_keymap(orig_keymap)
-
-        return ret
+        # store configuration from user
+        super().set_layouts(layouts_variants, options, convert)
 
     # TODO: rename to select_layout
     def set_current_layout(self, layout_variant):
         """Set given layout as first (current) layout for compositor.
 
-        This will search for the given layout variant in the list and move it as first in the list.
+        This will search for the given layout variant in the list and move it as first
+        in the list.
 
         :param layout_variant: The layout to set, with format "layout (variant)"
             (e.g. "cz (qwerty)")

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -34,7 +34,7 @@ from pyanaconda.modules.localization.installation import LanguageInstallationTas
     KeyboardInstallationTask
 from pyanaconda.modules.localization.runtime import GetMissingKeyboardConfigurationTask, \
     ApplyKeyboardTask, AssignGenericKeyboardSettingTask
-from pyanaconda.modules.localization.localed import LocaledWrapper
+from pyanaconda.modules.localization.localed import CompositorLocaledWrapper, LocaledWrapper
 
 from pyanaconda.anaconda_loggers import get_module_logger
 log = get_module_logger(__name__)
@@ -70,6 +70,7 @@ class LocalizationService(KickstartService):
         self.compositor_layouts_changed = Signal()
 
         self._localed_wrapper = None
+        self._localed_compositor_wrapper = None
 
     def publish(self):
         """Publish the module."""
@@ -248,13 +249,20 @@ class LocalizationService(KickstartService):
         if not self._localed_wrapper:
             self._localed_wrapper = LocaledWrapper()
 
-            self._localed_wrapper.compositor_selected_layout_changed.connect(
+        return self._localed_wrapper
+
+    @property
+    def localed_compositor_wrapper(self):
+        if not self._localed_compositor_wrapper:
+            self._localed_compositor_wrapper = CompositorLocaledWrapper()
+
+            self._localed_compositor_wrapper.compositor_selected_layout_changed.connect(
                 self.compositor_selected_layout_changed.emit
             )
-            self._localed_wrapper.compositor_layouts_changed.connect(
+            self._localed_compositor_wrapper.compositor_layouts_changed.connect(
                 self.compositor_layouts_changed.emit
             )
-        return self._localed_wrapper
+        return self._localed_compositor_wrapper
 
     def install_with_tasks(self):
         """Return the installation tasks of this module.
@@ -327,16 +335,16 @@ class LocalizationService(KickstartService):
         self._update_settings_from_task(result)
 
     def get_compositor_selected_layout(self):
-        return self.localed_wrapper.current_layout_variant
+        return self.localed_compositor_wrapper.current_layout_variant
 
     def set_compositor_selected_layout(self, layout_variant):
-        return self.localed_wrapper.set_current_layout(layout_variant)
+        return self.localed_compositor_wrapper.set_current_layout(layout_variant)
 
     def select_next_compositor_layout(self):
-        return self.localed_wrapper.select_next_layout()
+        return self.localed_compositor_wrapper.select_next_layout()
 
     def get_compositor_layouts(self):
-        return self.localed_wrapper.layouts_variants
+        return self.localed_compositor_wrapper.layouts_variants
 
     def set_compositor_layouts(self, layout_variants, options):
-        self.localed_wrapper.set_layouts(layout_variants, options)
+        self.localed_compositor_wrapper.set_layouts(layout_variants, options)

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -338,7 +338,7 @@ class LocalizationService(KickstartService):
         return self.localed_compositor_wrapper.current_layout_variant
 
     def set_compositor_selected_layout(self, layout_variant):
-        return self.localed_compositor_wrapper.set_current_layout(layout_variant)
+        return self.localed_compositor_wrapper.select_layout(layout_variant)
 
     def select_next_compositor_layout(self):
         return self.localed_compositor_wrapper.select_next_layout()

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -19,6 +19,7 @@
 
 import locale as locale_mod
 
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.ui.gui import GUIObject
 from pyanaconda.ui.gui.spokes import NormalSpoke
 from pyanaconda.ui.categories.localization import LocalizationCategory
@@ -494,6 +495,13 @@ class KeyboardSpoke(NormalSpoke):
                                                "supported when using RDP.\n"
                                                "However the settings will be used "
                                                "after the installation."))
+        elif not conf.system.supports_compositor_keyboard_layout_shortcut:
+            self._layoutSwitchLabel.set_text(
+                _(
+                    "Switching keyboard layouts by using keyboard shortcuts is not supported. "
+                    "To change the layout, use the keyboard icon in the top bar."
+                )
+            )
         elif switch_options:
             first_option = switch_options[0]
             desc = self._xkl_wrapper.get_switch_opt_description(first_option)

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_localed_wrapper.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_localed_wrapper.py
@@ -407,7 +407,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
 
         # check if layout is correctly set
         localed_wrapper._user_layouts_variants = user_defined
-        localed_wrapper.set_current_layout("fi")
+        localed_wrapper.select_layout("fi")
         assert user_defined == localed_wrapper._user_layouts_variants  # must not change
         mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
             "fi,us,fr,cz",
@@ -422,7 +422,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
         mocked_localed_proxy.SetX11Keyboard.reset_mock()
         localed_wrapper._user_layouts_variants = user_defined
 
-        assert localed_wrapper.set_current_layout("us (euro)") is True
+        assert localed_wrapper.select_layout("us (euro)") is True
         assert user_defined == localed_wrapper._user_layouts_variants  # must not change
         mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
             "us,fr,cz,fi",
@@ -440,7 +440,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
         mocked_localed_proxy.X11Options = ""
         localed_wrapper._user_layouts_variants = user_defined
 
-        assert localed_wrapper.set_current_layout("cz") is False
+        assert localed_wrapper.select_layout("cz") is False
         assert user_defined == localed_wrapper._user_layouts_variants  # must not change
         mocked_localed_proxy.SetX11Keyboard.assert_not_called()
 
@@ -450,7 +450,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
         mocked_localed_proxy.X11Variant = ""
         localed_wrapper._user_layouts_variants = user_defined
 
-        assert localed_wrapper.set_current_layout("fr") is True
+        assert localed_wrapper.select_layout("fr") is True
         assert user_defined == localed_wrapper._user_layouts_variants  # must not change
         mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
             "fr,cz,fi,us",
@@ -469,7 +469,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
         user_defined = []
         localed_wrapper._user_layouts_variants = user_defined
 
-        assert localed_wrapper.set_current_layout("cz (qwerty)") is False
+        assert localed_wrapper.select_layout("cz (qwerty)") is False
         assert user_defined == localed_wrapper._user_layouts_variants  # must not change
         mocked_localed_proxy.SetX11Keyboard.assert_not_called()
 

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_localed_wrapper.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_localed_wrapper.py
@@ -20,7 +20,7 @@ from unittest.mock import patch, Mock
 from pyanaconda.core.signal import Signal
 from pyanaconda.core.glib import Variant
 
-from pyanaconda.modules.localization.localed import LocaledWrapper
+from pyanaconda.modules.localization.localed import CompositorLocaledWrapper, LocaledWrapper
 
 
 class LocaledWrapperTestCase(unittest.TestCase):
@@ -68,7 +68,6 @@ class LocaledWrapperTestCase(unittest.TestCase):
             "cz"
         assert localed_wrapper.layouts_variants == \
             ["cz (qwerty)", "fi", "us (euro)", "fr"]
-        assert localed_wrapper.current_layout_variant == "cz (qwerty)"
         assert localed_wrapper.options == \
             ["grp:alt_shift_toggle", "grp:ctrl_alt_toggle"]
 
@@ -79,7 +78,6 @@ class LocaledWrapperTestCase(unittest.TestCase):
         assert localed_wrapper.keymap == ""
         assert localed_wrapper.options == []
         assert localed_wrapper.layouts_variants == []
-        assert localed_wrapper.current_layout_variant == ""
 
     @patch("pyanaconda.modules.localization.localed.SystemBus")
     @patch("pyanaconda.modules.localization.localed.LOCALED")
@@ -118,13 +116,110 @@ class LocaledWrapperTestCase(unittest.TestCase):
         localed_wrapper.set_and_convert_layouts(["us-altgr-intl"])
         localed_wrapper.convert_layouts(["us-altgr-intl"])
 
-        # verify that user defined list doesn't change
-        localed_wrapper._user_layouts_variants = []
-        localed_wrapper.set_keymap("cz")
-        localed_wrapper.convert_keymap("cz")
-        localed_wrapper.set_and_convert_keymap("cz")
-        assert localed_wrapper._user_layouts_variants == []
-        # only set_layouts should change user defined layouts
+        # test set_layout on proxy with options
+        mocked_localed_proxy.SetX11Keyboard.reset_mock()
+        localed_wrapper.set_layouts(["cz (qwerty)", "us"])
+        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
+            "cz,us",
+            "pc105",  # hardcoded
+            "qwerty,",
+            "",
+            False,
+            False
+        )
+
+        # test set_layout on proxy with options not set explicitly (None)
+        mocked_localed_proxy.SetX11Keyboard.reset_mock()
+        localed_wrapper.set_layouts(["cz (qwerty)", "us"], options=None)
+        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
+            "cz,us",
+            "pc105",  # hardcoded
+            "qwerty,",
+            "",
+            False,
+            False
+        )
+
+        mocked_localed_proxy.SetX11Keyboard.reset_mock()
+        localed_wrapper.set_layouts(["us"], "", True)
+        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
+            "us",
+            "pc105",  # hardcoded
+            "",
+            "",  # empty options will remove existing options
+            True,
+            False
+        )
+
+    @patch("pyanaconda.modules.localization.localed.SystemBus")
+    def test_localed_wrapper_no_systembus(self, mocked_system_bus):
+        """Test LocaledWrapper in environment without system bus.
+
+        Which is also the environment of our tests.
+        """
+        # Emulates mock environment
+        mocked_system_bus.check_connection.return_value = False
+        localed_wrapper = LocaledWrapper()
+        self._guarded_localed_wrapper_calls_check(localed_wrapper)
+
+
+class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
+
+    @patch("pyanaconda.modules.localization.localed.SystemBus")
+    @patch("pyanaconda.modules.localization.localed.LOCALED")
+    @patch("pyanaconda.modules.localization.localed.conf")
+    def test_compositor_localed_wrapper_properties(
+        self, mocked_conf, mocked_localed_service, mocked_system_bus
+    ):
+        """Test conversion of return values from Localed service to CompositorLocaledWraper."""
+        mocked_system_bus.check_connection.return_value = True
+        mocked_conf.system.provides_system_bus = True
+        mocked_localed_proxy = Mock()
+        mocked_localed_service.get_proxy.return_value = mocked_localed_proxy
+        localed_wrapper = CompositorLocaledWrapper()
+        mocked_localed_proxy.VConsoleKeymap = "cz"
+        mocked_localed_proxy.X11Layout = "cz,fi,us,fr"
+        mocked_localed_proxy.X11Variant = "qwerty,,euro"
+        mocked_localed_proxy.X11Options = "grp:alt_shift_toggle,grp:ctrl_alt_toggle"
+        assert localed_wrapper.layouts_variants == \
+            ["cz (qwerty)", "fi", "us (euro)", "fr"]
+        assert localed_wrapper.current_layout_variant == "cz (qwerty)"
+        assert localed_wrapper.options == \
+            ["grp:alt_shift_toggle", "grp:ctrl_alt_toggle"]
+
+        mocked_localed_proxy.VConsoleKeymap = ""
+        mocked_localed_proxy.X11Layout = ""
+        mocked_localed_proxy.X11Variant = ""
+        mocked_localed_proxy.X11Options = ""
+        assert localed_wrapper.options == []
+        assert localed_wrapper.layouts_variants == []
+        assert localed_wrapper.current_layout_variant == ""
+
+    @patch("pyanaconda.modules.localization.localed.SystemBus")
+    @patch("pyanaconda.modules.localization.localed.LOCALED")
+    @patch("pyanaconda.modules.localization.localed.conf")
+    def test_compositor_localed_wrapper_safe_calls(
+        self, mocked_conf, mocked_localed_service, mocked_system_bus
+    ):
+        """Test calling CopmositorLocaledWrapper with invalid values does not raise exception."""
+        mocked_system_bus.check_connection.return_value = True
+        mocked_conf.system.provides_system_bus = True
+        mocked_localed_proxy = Mock()
+        mocked_localed_service.get_proxy.return_value = mocked_localed_proxy
+        mocked_localed_proxy.VConsoleKeymap = "cz"
+        mocked_localed_proxy.X11Layout = "cz,fi,us,fr"
+        mocked_localed_proxy.X11Variant = "qwerty,,euro"
+        mocked_localed_proxy.X11Options = "grp:alt_shift_toggle,grp:ctrl_alt_toggle"
+        localed_wrapper = CompositorLocaledWrapper()
+        # valid values
+        localed_wrapper.set_layouts(["cz (qwerty)", "us (euro)"],
+                                    options="grp:alt_shift_toggle",
+                                    convert=True)
+        # invalid values
+        # rhbz#1843379
+        localed_wrapper.set_layouts(["us-altgr-intl"])
+
+        # set_layouts should change user defined layouts
         localed_wrapper.set_layouts(["cz", "us (euro)"])
         assert localed_wrapper._user_layouts_variants == ["cz", "us (euro)"]
 
@@ -164,111 +259,12 @@ class LocaledWrapperTestCase(unittest.TestCase):
         )
 
     @patch("pyanaconda.modules.localization.localed.SystemBus")
-    def test_localed_wrapper_no_systembus(self, mocked_system_bus):
-        """Test LocaledWrapper in environment without system bus.
-
-        Which is also the environment of our tests.
-        """
-        # Emulates mock environment
-        mocked_system_bus.check_connection.return_value = False
-        localed_wrapper = LocaledWrapper()
-        self._guarded_localed_wrapper_calls_check(localed_wrapper)
-
-    @patch("pyanaconda.modules.localization.localed.SystemBus")
     @patch("pyanaconda.modules.localization.localed.LOCALED")
     @patch("pyanaconda.modules.localization.localed.conf")
-    def test_localed_wrapper_set_current_layout(self, mocked_conf,
-                                                mocked_localed_service,
-                                                mocked_system_bus):
-        """Test LocaledWrapper method to set current layout to compositor.
-
-        Verify that the layout to be set is moved to the first place.
-        """
-        mocked_system_bus.check_connection.return_value = True
-        mocked_conf.system.provides_system_bus = True
-        mocked_localed_proxy = Mock()
-        mocked_localed_service.get_proxy.return_value = mocked_localed_proxy
-        mocked_localed_proxy.X11Layout = "cz,fi,us,fr"
-        mocked_localed_proxy.X11Variant = "qwerty,,euro"
-        mocked_localed_proxy.X11Options = ""
-        localed_wrapper = LocaledWrapper()
-        user_defined = ["cz (qwerty)", "fi", "us (euro)", "fr"]
-
-        # check if layout is correctly set
-        localed_wrapper._user_layouts_variants = user_defined
-        localed_wrapper.set_current_layout("fi")
-        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
-        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
-            "fi,us,fr,cz",
-            "pc105",  # hardcoded
-            ",euro,,qwerty",
-            "",
-            False,
-            False
-        )
-
-        # check if layout is correctly set including variant
-        mocked_localed_proxy.SetX11Keyboard.reset_mock()
-        localed_wrapper._user_layouts_variants = user_defined
-
-        assert localed_wrapper.set_current_layout("us (euro)") is True
-        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
-        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
-            "us,fr,cz,fi",
-            "pc105",  # hardcoded
-            "euro,,qwerty,",
-            "",
-            False,
-            False
-        )
-
-        # check when we are selecting non-existing layout
-        mocked_localed_proxy.SetX11Keyboard.reset_mock()
-        mocked_localed_proxy.X11Layout = "fi"
-        mocked_localed_proxy.X11Variant = ""
-        mocked_localed_proxy.X11Options = ""
-        localed_wrapper._user_layouts_variants = user_defined
-
-        assert localed_wrapper.set_current_layout("cz") is False
-        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
-        mocked_localed_proxy.SetX11Keyboard.assert_not_called()
-
-        # check when the layout set is empty
-        mocked_localed_proxy.SetX11Keyboard.reset_mock()
-        mocked_localed_proxy.X11Layout = ""
-        mocked_localed_proxy.X11Variant = ""
-        localed_wrapper._user_layouts_variants = user_defined
-
-        assert localed_wrapper.set_current_layout("fr") is True
-        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
-        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
-            "fr,cz,fi,us",
-            "pc105",  # hardcoded
-            ",qwerty,,euro",
-            "",
-            False,
-            False
-        )
-
-        # can't set layout when we don't have user defined set
-        mocked_localed_proxy.SetX11Keyboard.reset_mock()
-        mocked_localed_proxy.X11Layout = "cz, us"
-        mocked_localed_proxy.X11Variant = ""
-        mocked_localed_proxy.X11Options = ""
-        user_defined = []
-        localed_wrapper._user_layouts_variants = user_defined
-
-        assert localed_wrapper.set_current_layout("cz (qwerty)") is False
-        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
-        mocked_localed_proxy.SetX11Keyboard.assert_not_called()
-
-    @patch("pyanaconda.modules.localization.localed.SystemBus")
-    @patch("pyanaconda.modules.localization.localed.LOCALED")
-    @patch("pyanaconda.modules.localization.localed.conf")
-    def test_localed_wrapper_set_next_layout(self, mocked_conf,
-                                             mocked_localed_service,
-                                             mocked_system_bus):
-        """Test LocaledWrapper method to set current layout to compositor.
+    def test_compositor_localed_wrapper_set_next_layout(
+        self, mocked_conf, mocked_localed_service, mocked_system_bus
+    ):
+        """Test CompositorLocaledWrapper method to set current layout to compositor.
 
         Verify that we are selecting next layout to what is currently set in compositor.
         Because setting current layout changing the ordering we have to decide next layout based
@@ -282,7 +278,7 @@ class LocaledWrapperTestCase(unittest.TestCase):
         mocked_localed_proxy.X11Layout = "cz,fi,us,fr"
         mocked_localed_proxy.X11Variant = "qwerty,,euro"
         mocked_localed_proxy.X11Options = ""
-        localed_wrapper = LocaledWrapper()
+        localed_wrapper = CompositorLocaledWrapper()
 
         # test switch to next layout
         user_defined = ["cz (qwerty)", "fi", "us (euro)", "fr"]
@@ -392,10 +388,98 @@ class LocaledWrapperTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.localization.localed.SystemBus")
     @patch("pyanaconda.modules.localization.localed.LOCALED")
     @patch("pyanaconda.modules.localization.localed.conf")
-    def test_localed_wrapper_signals(self, mocked_conf,
+    def test_compositor_localed_wrapper_set_current_layout(
+        self, mocked_conf, mocked_localed_service, mocked_system_bus
+    ):
+        """Test CompositorLocaledWrapper method to set current layout to compositor.
+
+        Verify that the layout to be set is moved to the first place.
+        """
+        mocked_system_bus.check_connection.return_value = True
+        mocked_conf.system.provides_system_bus = True
+        mocked_localed_proxy = Mock()
+        mocked_localed_service.get_proxy.return_value = mocked_localed_proxy
+        mocked_localed_proxy.X11Layout = "cz,fi,us,fr"
+        mocked_localed_proxy.X11Variant = "qwerty,,euro"
+        mocked_localed_proxy.X11Options = ""
+        localed_wrapper = CompositorLocaledWrapper()
+        user_defined = ["cz (qwerty)", "fi", "us (euro)", "fr"]
+
+        # check if layout is correctly set
+        localed_wrapper._user_layouts_variants = user_defined
+        localed_wrapper.set_current_layout("fi")
+        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
+        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
+            "fi,us,fr,cz",
+            "pc105",  # hardcoded
+            ",euro,,qwerty",
+            "",
+            False,
+            False
+        )
+
+        # check if layout is correctly set including variant
+        mocked_localed_proxy.SetX11Keyboard.reset_mock()
+        localed_wrapper._user_layouts_variants = user_defined
+
+        assert localed_wrapper.set_current_layout("us (euro)") is True
+        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
+        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
+            "us,fr,cz,fi",
+            "pc105",  # hardcoded
+            "euro,,qwerty,",
+            "",
+            False,
+            False
+        )
+
+        # check when we are selecting non-existing layout
+        mocked_localed_proxy.SetX11Keyboard.reset_mock()
+        mocked_localed_proxy.X11Layout = "fi"
+        mocked_localed_proxy.X11Variant = ""
+        mocked_localed_proxy.X11Options = ""
+        localed_wrapper._user_layouts_variants = user_defined
+
+        assert localed_wrapper.set_current_layout("cz") is False
+        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
+        mocked_localed_proxy.SetX11Keyboard.assert_not_called()
+
+        # check when the layout set is empty
+        mocked_localed_proxy.SetX11Keyboard.reset_mock()
+        mocked_localed_proxy.X11Layout = ""
+        mocked_localed_proxy.X11Variant = ""
+        localed_wrapper._user_layouts_variants = user_defined
+
+        assert localed_wrapper.set_current_layout("fr") is True
+        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
+        mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
+            "fr,cz,fi,us",
+            "pc105",  # hardcoded
+            ",qwerty,,euro",
+            "",
+            False,
+            False
+        )
+
+        # can't set layout when we don't have user defined set
+        mocked_localed_proxy.SetX11Keyboard.reset_mock()
+        mocked_localed_proxy.X11Layout = "cz, us"
+        mocked_localed_proxy.X11Variant = ""
+        mocked_localed_proxy.X11Options = ""
+        user_defined = []
+        localed_wrapper._user_layouts_variants = user_defined
+
+        assert localed_wrapper.set_current_layout("cz (qwerty)") is False
+        assert user_defined == localed_wrapper._user_layouts_variants  # must not change
+        mocked_localed_proxy.SetX11Keyboard.assert_not_called()
+
+    @patch("pyanaconda.modules.localization.localed.SystemBus")
+    @patch("pyanaconda.modules.localization.localed.LOCALED")
+    @patch("pyanaconda.modules.localization.localed.conf")
+    def test_compositor_localed_wrapper_signals(self, mocked_conf,
                                      mocked_localed_service,
                                      mocked_system_bus):
-        """Test signals from the localed wrapper
+        """Test signals from the compositor localed wrapper
 
         This one could be tricky. The issue is that this class has to store last known values to
         be able to recognize changes.
@@ -414,24 +498,24 @@ class LocaledWrapperTestCase(unittest.TestCase):
         mocked_localed_service.get_proxy.return_value = mocked_localed_proxy
         mocked_layouts_changed = Mock()
         mocked_selected_layout_changed = Mock()
-        localed_wrapper = LocaledWrapper()
+        localed_wrapper = CompositorLocaledWrapper()
         localed_wrapper.compositor_layouts_changed = mocked_layouts_changed
         localed_wrapper.compositor_selected_layout_changed = mocked_selected_layout_changed
 
         def _check_localed_wrapper_signals(last_known_state, compositor_state,
                                            expected_selected_signal, expected_layouts_signal):
-            """Test the localed wrapper signals are correctly emitted.
+            """Test the compositor localed wrapper signals are correctly emitted.
 
             :param last_known_state: State of the localed before the change. Used to resolve if
                                      selected layout has changed.
             :type last_known_state: [(str,str)] e.g.:[('cz', 'qwerty'), ('us','')...]
             :param compositor_state: New state the compositor will get into.
             :type compositor_state: {str: str} e.g.: {"X11Layout": "cz", "X11Variant": "qwerty"}
-            :param expected_selected_signal: Currently selected layout we expect LocaledWrapper
+            :param expected_selected_signal: Currently selected layout we expect CompositorLocaledWrapper
                                              will signal out. If signal shouldn't set None.
             :type expected_selected_signal: str
             :param expected_layouts_signal: Current configuration of the compositor signaled from
-                                            LocaledWrapper.
+                                            CompositorLocaledWrapper.
             :type expected_layouts_signal: [str] e.g.: ["cz", "us (euro)"]
             """
             mocked_layouts_changed.reset_mock()

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -393,15 +393,14 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         """
         self._test_kickstart(ks_in, ks_out)
 
-    @patch("pyanaconda.modules.localization.localization.LocaledWrapper")
+    @patch("pyanaconda.modules.localization.localization.CompositorLocaledWrapper")
     def test_compositor_layouts_api(self, mocked_localed_wrapper):
-        localed_class_mock = Mock()
+        localed_class_mock = mocked_localed_wrapper.return_value
         localed_class_mock.compositor_selected_layout_changed = Signal()
         localed_class_mock.compositor_layouts_changed = Signal()
-        mocked_localed_wrapper.return_value = localed_class_mock
 
-        self.localization_module._localed_wrapper = None
-        manager_mock = self.localization_module.localed_wrapper
+        self.localization_module._localed_compositor_wrapper = None
+        manager_mock = self.localization_module.localed_compositor_wrapper
 
         manager_mock.current_layout_variant = "cz"
         assert self.localization_interface.GetCompositorSelectedLayout() == "cz"

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -407,7 +407,7 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
 
         self.localization_interface.SetCompositorSelectedLayout("cz (qwerty)")
         # pylint: disable=no-member
-        manager_mock.set_current_layout.assert_called_once_with("cz (qwerty)")
+        manager_mock.select_layout.assert_called_once_with("cz (qwerty)")
 
         self.localization_interface.SelectNextCompositorLayout()
         # pylint: disable=no-member


### PR DESCRIPTION
The keyboard switching recently migrated to localed. However, there is a bug reported that the keyboard switching with a keyboard shortcut doesn't work. However, that is not completely true, the keyboard switching correctly works but is not propagated to localed so Anaconda is not aware of the layout switch.
This behavior is much more problematic. Even reporters of the bug assumed that the keyboard switching doesn't work at all. Users could easily drop into a trap of using different keyboard layout on passwords during the installation then what they think is used.

Manual keyboard switching from Anaconda still works as expected. This is workaround which should be removed when bugs on gnome-kiosk are resolved:
* https://bugzilla.redhat.com/show_bug.cgi?id=2319565
* https://issues.redhat.com/browse/RHEL-71880

**NOTE:**
Part of this change is code re-factorization which splits the LocaledWrapper class based on the usage (compositor / installation). This change improves readability but also fixes potential bug when xkboptions from compositor are stored to the installed system instead of the user defined ones.

Backport of https://github.com/rhinstaller/anaconda/pull/6090
Resolves: [RHEL-74504](https://issues.redhat.com/browse/RHEL-74504)