### PR TITLE
rpmostree: Use `--merge` for kargs

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -477,7 +477,7 @@ class ConfigureBootloader(Task):
             device_tree.GetDeviceData(root_name)
         )
 
-        set_kargs_args = ["admin", "instutil", "set-kargs"]
+        set_kargs_args = ["admin", "instutil", "set-kargs", "--merge"]
         set_kargs_args.extend(bootloader.GetArguments())
         set_kargs_args.append("root=" + device_tree.GetFstabSpec(root_name))
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -623,8 +623,15 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             )
             exec_mock.assert_called_once_with(
                 "ostree",
-                ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC",
-                 "rootflags=subvol=device-name", "rw"],
+                ["admin",
+                 "instutil",
+                 "set-kargs",
+                 "--merge",
+                 "BOOTLOADER-ARGS",
+                 "root=FSTAB-SPEC",
+                 "rootflags=subvol=device-name",
+                 "rw"
+                 ],
                 root=sysroot
             )
 
@@ -660,7 +667,14 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
             )
             exec_mock.assert_called_once_with(
                 "ostree",
-                ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
+                ["admin",
+                 "instutil",
+                 "set-kargs",
+                 "--merge",
+                 "BOOTLOADER-ARGS",
+                 "root=FSTAB-SPEC",
+                 "rw"
+                 ],
                 root=sysroot
             )
 
@@ -700,7 +714,14 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                 ),
                 call(
                     "ostree",
-                    ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
+                    ["admin",
+                     "instutil",
+                     "set-kargs",
+                     "--merge",
+                     "BOOTLOADER-ARGS",
+                     "root=FSTAB-SPEC",
+                     "rw"
+                     ],
                     root=sysroot
                 )
             ])


### PR DESCRIPTION
Without `--merge`, all kernel arguments will be replaced, which is not what is desired in general. Especially with bootc karg support which we definitely want to work with Anaconda.

Signed-off-by: Colin Walters <walters@verbum.org>

Backport of https://github.com/rhinstaller/anaconda/pull/6084

Resolves: [RHEL-76923](https://issues.redhat.com/browse/RHEL-76923)