### PR TITLE
Revert "Remove 'linear' from list of expected MD RAID levels"

### DIFF
--- a/dracut/anaconda-modprobe.sh
+++ b/dracut/anaconda-modprobe.sh
@@ -34,7 +34,7 @@ if [ "$ARCH" = "ppc" ]; then
     MODULE_LIST+=" spufs "
 fi
 
-MODULE_LIST+=" raid0 raid1 raid5 raid6 raid456 raid10 dm-mod dm-zero  \
+MODULE_LIST+=" raid0 raid1 raid5 raid6 raid456 raid10 linear dm-mod dm-zero  \
               dm-mirror dm-snapshot dm-multipath dm-round-robin dm-crypt cbc \
               lrw xts "
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -190,7 +190,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
     def test_get_supported_raid_levels(self):
         """Test GetSupportedRaidLevels."""
         assert self.interface.GetSupportedRaidLevels(DEVICE_TYPE_MD) == \
-            ['raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6']
+            ['linear', 'raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6']
 
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.get_format')
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.platform', new_callable=EFI)


### PR DESCRIPTION
The md-linear module is back: https://github.com/torvalds/linux/commit/127186cfb184eaccdfe948e6da66940cfa03efc5

Blocked by https://github.com/storaged-project/blivet/pull/1338