### PR TITLE
RHEL-10: Fix inst.text switching to GUI

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -423,6 +423,9 @@ def setup_display(anaconda, options):
 
 
 def _set_gui_mode_on_rdp(anaconda, use_rdp):
+    if not use_rdp:
+        return
+
     if not anaconda.gui_mode:
         log.info("RDP requested via RDP question, switching Anaconda to GUI mode.")
     anaconda.display_mode = constants.DisplayModes.GUI


### PR DESCRIPTION
Issue was introduced by 4863cc6a9de4c5bd2af9ab2f5cea8c8e996fd5c2 which was refactoring the display code and missed one if.

Partial backport of https://github.com/rhinstaller/anaconda/pull/6127

Resolves: [RHEL-77162](https://issues.redhat.com/browse/RHEL-77162)