### PR TITLE
Disable support of kernel 'nokill' option in anaconda

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -46,9 +46,9 @@ def exitHandler(rebootData):
 
     # pylint: disable=possibly-used-before-assignment
     # pylint: disable=used-before-assignment
-    if "nokill" in kernel_arguments:
+    if "inst.nokill" in kernel_arguments:
         util.vtActivate(1)
-        print("anaconda halting due to nokill flag.")
+        print("Anaconda halting due to inst.nokill flag.")
         print("The system will be rebooted when you press Ctrl-Alt-Delete.")
         while True:
             time.sleep(10000)


### PR DESCRIPTION
Anaconda should recognize only 'inst.nokill' option as a valid trigger to stop automatic reboot.
Warning notice for general 'nokill' kernel parameter has been added.

Resolves: INSTALLER-2495


