### PR TITLE
Disable LVM auto-activation during installation

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -81,6 +81,13 @@ def exitHandler(rebootData):
         task_proxy = STORAGE.get_proxy(task_path)
         sync_run_task(task_proxy)
 
+    # reenable LVM auto-activation disabled in enable_installer_mode
+    from blivet.devicelibs import lvm
+    try:
+        lvm.reenable_lvm_autoactivation()
+    except RuntimeError as e:
+        log.error("Failed to reenable LVM auto-activation: %s", str(e))
+
     # Stop the DBus session.
     anaconda.dbus_launcher.stop()
 

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -40,7 +40,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define nmver 1.0
 %define pykickstartver 3.63-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.9.0-1
+%define pythonblivetver 1:3.12.0-1
 %define rpmver 4.15.0
 %define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.29.31

--- a/pyanaconda/modules/storage/initialization.py
+++ b/pyanaconda/modules/storage/initialization.py
@@ -17,7 +17,7 @@
 #
 from blivet import arch, blockdev, udev
 from blivet import util as blivet_util
-from blivet.devicelibs import crypto
+from blivet.devicelibs import crypto, lvm
 from blivet.flags import flags as blivet_flags
 from blivet.formats import get_device_format_class
 from blivet.static_data import luks_data
@@ -80,6 +80,13 @@ def enable_installer_mode():
 
     # We need this so all the /dev/disk/* stuff is set up.
     udev.trigger(subsystem="block", action="change")
+
+    # Disable LVM auto-activation during installation
+    if not conf.target.is_directory and not conf.target.is_image:
+        try:
+            lvm.disable_lvm_autoactivation()
+        except RuntimeError as e:
+            log.error("Failed to disable LVM auto-activation: %s", str(e))
 
 
 def _set_default_label_type():


### PR DESCRIPTION
We don't want udev randomly activating LVs during installation, any activation should be done manually by blivet.
Unfortunately the only way to do this system-wide is to change LVM config. We change the config during the storage module initialization and change it back when shutting down Anaconda.

Related: rhbz#2309350

Blocked by: https://github.com/storaged-project/blivet/pull/1340