### PR TITLE
network: update NM autoconnections configuration for centos

### DIFF
--- a/data/systemd/anaconda-nm-disable-autocons-rhel.service
+++ b/data/systemd/anaconda-nm-disable-autocons-rhel.service
@@ -2,10 +2,9 @@
 ConditionKernelCommandLine=|ip
 ConditionKernelCommandLine=|inst.ks
 ConditionKernelCommandLine=|BOOTIF
-ConditionOSRelease=ID=rhel
 Description=NetworkManager autoconnections configuration for Anaconda installation environment for RHEL
 Before=NetworkManager.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/anaconda-nm-disable-autocons
+ExecStart=/usr/bin/anaconda-nm-disable-autocons rhel

--- a/scripts/anaconda-nm-disable-autocons
+++ b/scripts/anaconda-nm-disable-autocons
@@ -1,4 +1,15 @@
-#!/bin/sh
+#!/bin/bash
+
+# Disable only on system with rhel policy (RHEL, CentOS, Alma Linux, Rocky Linux, ...)
+if [ "$1" == "rhel" ]; then
+    source /etc/os-release
+    if [[ ! "${ID}" == "rhel" ]] && [[ ! "${ID}" == "centos" ]] && [[ ! "${ID_LIKE}" =~ "rhel" ]]; then
+        echo "Skipping the RHEL NM autoconnections policy setting on system with ID: ${ID}, ID_LIKE: ${ID_LIKE}."
+        exit 0
+    fi
+fi
+
+echo "Disabling NetworkManager autoconnections."
 cat > /etc/NetworkManager/conf.d/90-anaconda-no-auto-default.conf << EOF
 [main]
 no-auto-default=*


### PR DESCRIPTION
The policy should be the same for RHEL and CentOS Stream.

Resolves: RHEL-67815

TODO:
- [x] create autoconnection test checking the policy: https://github.com/rhinstaller/kickstart-tests/pull/1367
- [x] retest when updated systemd is in