### PR TITLE
Add systemd override to make /usr RW in Dracut

### DIFF
--- a/dracut/20_rw_usr.conf
+++ b/dracut/20_rw_usr.conf
@@ -1,0 +1,2 @@
+[Manager]
+ProtectSystem=no

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -56,6 +56,7 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       driver_updates.py \
                       anaconda-nfsrepo-cleanup.sh
 
-dist_dracut_DATA = driver-updates@.service
+dist_dracut_DATA = driver-updates@.service \
+                   20_rw_usr.conf
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -71,6 +71,8 @@ install() {
     inst "$moddir/driver_updates.py" "/bin/driver-updates"
     inst "/usr/sbin/modinfo"
     inst_simple "$moddir/driver-updates@.service" "/etc/systemd/system/driver-updates@.service"
+    # Make the /usr mountpoint RW in Dracut with systemd version >= 256, see RHEL-77192 for details.
+    inst_simple "$moddir/20_rw_usr.conf" "/etc/systemd/system.conf.d/20_rw_usr.conf"
     # rpm configuration file (needed by dd_extract)
     inst "/usr/lib/rpm/rpmrc"
     # timeout script for errors reporting


### PR DESCRIPTION
Since systemd 256 the /usr mountpoint in the Dracut initrd is read only.

Our driver disk tooling currently requires a read-write /usr in Dracut, so lets install a Dracut-only systemd override for now.

So add a config override to the systemd config drop dir, that only gets installed when the Anaconda initrd is being generated.

Like this installed systems should not be influenced by this override, only installation images.

(cherry picked from commit cd1d5639253b1db671794b97a589ee7b96070e5b)

Resolves: RHEL-77192