### PR TITLE
Revert "Remove 'linear' from list of expected MD RAID levels"

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -169,7 +169,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
     def test_get_supported_raid_levels(self):
         """Test GetSupportedRaidLevels."""
         assert self.interface.GetSupportedRaidLevels(DEVICE_TYPE_MD) == \
-            ['raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6']
+            ['linear', 'raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6']
 
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.get_format')
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.platform', new_callable=EFI)


### PR DESCRIPTION
This reverts commit 7ff5cd29784d9a176cc1dd092edf7f19eaef6338.

Cherry-picked from: e70814372bd3d8e275557e659496679056a37a3c

Related to: RHEL-76805
