### PR TITLE
infra: adjust the containers to use full systemd

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -30,6 +30,10 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 # the build is invoked by Makefile.
 COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 
+# Replace standalone systemd package with systemd as these are conflicting
+RUN set -ex; \
+    dnf swap -y systemd-standalone-sysusers systemd
+
 # Prepare environment and install build dependencies
 RUN set -ex; \
   # disable fedora-cisco repository otherwise freerdp will depend on openh264 from fedora-cisco

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -30,6 +30,10 @@ FROM ${image}
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
+# Replace standalone systemd package with systemd as these are conflicting
+RUN set -ex; \
+    dnf swap -y systemd-standalone-sysusers systemd
+
 # Prepare environment and install build dependencies
 RUN set -ex; \
   dnf update -y; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -25,6 +25,10 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 # the build is invoked by Makefile.
 COPY ["anaconda.spec.in", "/root/"]
 
+# Replace standalone systemd package with systemd as these are conflicting
+RUN set -ex; \
+    dnf swap -y systemd-standalone-sysusers systemd
+
 # Prepare environment and install build dependencies
 RUN set -ex; \
   # disable fedora-cisco repository otherwise freerdp will depend on openh264 from fedora-cisco


### PR DESCRIPTION
The systemd-standalone-sysusers package, which is pre-installed in the containers, conflicts with systemd. Since Anaconda requires systemd as a dependency, this conflict prevents installation during tests.

This update ensures that containers use the full systemd package to resolve the dependency issue.

