### PR TITLE
rpm_ostree/installation.py: fix image deployment on s390x

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -15,11 +15,13 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import glob
 import os
 from subprocess import CalledProcessError
 
 import blivet.util
 import gi
+from blivet import arch
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
@@ -584,6 +586,41 @@ class ConfigureBootloader(Task):
 
         safe_exec_with_redirect("ostree", set_kargs_args, root=self._sysroot)
 
+        if arch.is_s390():
+            # Deployment was done. Enable ostree's zipl support; this is how things are currently done in e.g.
+            # https://github.com/coreos/coreos-assembler/blob/7d6fa376fc9f73625487adbb9386785bb09f1bb2/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml#L261
+            safe_exec_with_redirect(
+                "ostree",
+                ["config",
+                 "--repo=" + self._sysroot + "/ostree/repo",
+                 "set", "sysroot.bootloader", "zipl"]
+            )
+
+            for bls_path in sorted(glob.glob(self._sysroot + "/boot/loader/entries/*.conf")):
+                log.info("found %s", bls_path)
+                with open(bls_path, "r") as bls:
+                    for line in bls.readlines():
+                        if line.startswith("options "):
+                            cmdline = line.split()[1]
+                        if line.startswith("linux"):
+                            kernel = self._sysroot + "/boot" + line.split()[1]
+                        if line.startswith("initrd"):
+                            initrd = self._sysroot + "/boot" + line.split()[1]
+                break
+
+            # pylint: disable=possibly-used-before-assignment
+            safe_exec_with_redirect(
+                "zipl",
+                ["-V",
+                 "-i",
+                 kernel,
+                 "-r",
+                 initrd,
+                 "-P",
+                 f"\"{cmdline}\"",
+                 "-t",
+                 self._sysroot + "/boot"])
+
 
 class DeployOSTreeTask(Task):
     """Task to deploy OSTree."""
@@ -607,6 +644,16 @@ class DeployOSTreeTask(Task):
         stateroot = _get_stateroot(self._data)
 
         self.report_progress(_("Deployment starting: {}").format(ref))
+
+        if arch.is_s390():
+            # Disable ostree's builtin zipl support; this is how things are currently done in e.g.
+            # https://github.com/coreos/coreos-assembler/blob/7d6fa376fc9f73625487adbb9386785bb09f1bb2/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml#L168
+            safe_exec_with_redirect(
+                "ostree",
+                ["config",
+                 "--repo=" + self._physroot + "/ostree/repo",
+                 "set", "sysroot.bootloader", "none"]
+            )
 
         safe_exec_with_redirect(
             "ostree",


### PR DESCRIPTION

When user installs OS on s390x using some container image, it fails whith an error:
```
INFO:program:Running... ostree container image deploy --sysroot=/mnt/sysimage --image=quay.io/fedora/fedora-bootc:41-s390x
INFO:program:Error: Config file '/lib/s390-tools/zipl.conf': Cannot build automenu: no IPL entries available
INFO:program:Using config file '/lib/s390-tools/zipl.conf'
```

This happens, because `ostree` doesn't call `zipl` on installed deployment, but on `/` (without bubblewrapping).

This PR first sets bootloader to `none`, so `ostree` doesn't perform `post_bls_sync`, and than calls `zipl` direct from anaconda (similar to what we do in `coreos-assembler`).

Here is an eaxmple kickstart `ostree.ks`:
```
text
lang en_US.UTF-8
keyboard us
timezone --utc Etc/UTC
selinux --enforcing
rootpw --plaintext foobar
network --bootproto=dhcp --device=link --activate --onboot=on
zerombr
clearpart --all --initlabel
autopart --nohome --type=lvm
ostreecontainer --url quay.io/fedora/fedora-bootc:41-s390x
firewall --disabled
services --enabled=sshd
sshkey --username root YOUR_KEY_HERE
```

Using that config and kargs `inst.ks=http://172.23.236.43/ostree.ks inst.sshd` injected into Fedora 41 `boot.iso`,
installation succeeded:
```

Setting up the installation environment                                                                                    .
Configuring storage
Creating disklabel on /dev/vdb
Creating ext4 on /dev/vdb1
Creating lvmpv on /dev/vdb2
Creating ext4 on /dev/mapper/fedora_fedora-root
.
Running pre-installation scripts
.
Running pre-installation tasks
.
Installing the software
Deployment starting: quay.io/fedora/fedora-bootc:41-s390x
Deployment complete: quay.io/fedora/fedora-bootc:41-s390x
.
Configuring storage
.
Installing boot loader
.
Performing post-installation setup tasks
```

Issue: https://issues.redhat.com/browse/RHEL-63237