### PR TITLE
infra: Revert "infra: bump redhat-plumbers-in-action/differential-shellcheck"

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -23,7 +23,7 @@ jobs:
 
       - id: ShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit 730ae779d9de31ea0f05dd77be9e555d375030ad.

There is an issue with v5, see recent failures. Ex: https://github.com/rhinstaller/anaconda/pull/6151