### PR TITLE
dracut: depend on net-lib not ifcfg

### DIFF
--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -8,7 +8,7 @@ check() {
 }
 
 depends() {
-    echo livenet nfs img-lib convertfs ifcfg
+    echo livenet nfs img-lib convertfs net-lib
     case "$(uname -m)" in
         s390*) echo cms ;;
     esac


### PR DESCRIPTION
ifcfg is gone in dracut-ng 204. Looking at the module and its history, I'm pretty sure we don't actually use anything from the ifcfg module any more. anaconda-ifcfg.sh only uses save_netinfo, which is in net-lib. So let's turn the ifcfg dep into a net-lib dep instead.

If I missed anything and we really are still relying on the ifcfg module then we need to fix that, since it's gone now.

Resolves: rhbz#2343125

Port of PR: #6125