### PR TITLE
Fstab handling moves to blivet

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -40,7 +40,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define nmver 1.0
 %define pykickstartver 3.61-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.9.0-1
+%define pythonblivetver 1:3.12.0-1
 %define rpmver 4.15.0
 %define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.29.31

--- a/tests/gettext_tests/style_guide.py
+++ b/tests/gettext_tests/style_guide.py
@@ -62,9 +62,6 @@ expected_badness = {
     'pyanaconda/startup_utils.py': {
         'HOSTNAME': 1,    # ssh to install@HOSTNAME
     },
-    'pyanaconda/modules/storage/devicetree/fsset.py': {
-        'mountpoint': 1,  # format string specifier mount_point
-    },
     'pyanaconda/ui/gui/spokes/subscription.glade': {
        'hostname': 1      # hostname:port placeholder for proxy URL entry
     }

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_fsset.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_fsset.py
@@ -15,6 +15,8 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -23,6 +25,7 @@ from blivet.devicetree import DeviceTree
 from blivet.formats import get_format
 
 from pyanaconda.modules.storage.devicetree.fsset import FSSet
+from pyanaconda.modules.storage.devicetree.root import _parse_fstab
 from pyanaconda.modules.storage.platform import EFI, X86
 
 
@@ -200,3 +203,48 @@ class FSSetTestCase(unittest.TestCase):
             'selinuxfs',
             'tmpfs',
         ]
+
+    def test_parse_fstab(self):
+        """ test the fsset.py parse_fstab method: unrecognized devices
+            from fstab are supposed to be stored in preserve entries
+            the rest of devices should stay in devicetree
+        """
+
+        UNRECOGNIZED_ENTRY = "UUID=111111 /mnt/fakemount ext3 defaults 0 0\n"
+        DEVICE_ENTRY = "/dev/dev2 /mnt ext4 defaults 0 0\n"
+
+        self._add_device(StorageDevice("dev2", fmt=get_format("ext4", mountpoint="/")))
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            fstab_path = os.path.join(tmpdirname, 'etc/fstab')
+            os.makedirs(os.path.dirname(fstab_path), exist_ok=True)
+            with open(fstab_path, "w") as f:
+                f.write(UNRECOGNIZED_ENTRY)
+                f.write(DEVICE_ENTRY)
+
+            self.fsset.parse_fstab(chroot=tmpdirname)
+
+        self.assertEqual(self.fsset.preserve_entries[0].file, "/mnt/fakemount")
+        self.assertIsNotNone(self.devicetree.get_device_by_path('/dev/dev2'))
+
+    def test_root_parse_fstab(self):
+        """ test the root.py _parse_fstab function: return mounts and devices obtained from fstab
+        """
+
+        test_dev = StorageDevice("dev2", fmt=get_format("ext4", mountpoint="/mnt/testmount"))
+
+        devicetree = DeviceTree()
+        devicetree._add_device(test_dev)
+        DEVICE_ENTRY = "/dev/dev2 /mnt/testmount ext4 defaults 0 0\n"
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            fstab_path = os.path.join(tmpdirname, 'etc/fstab')
+            os.makedirs(os.path.dirname(fstab_path), exist_ok=True)
+            with open(fstab_path, "w") as f:
+                f.write(DEVICE_ENTRY)
+
+            mounts, devices, options = _parse_fstab(devicetree, chroot=tmpdirname)
+
+        self.assertEqual(mounts["/mnt/testmount"], test_dev)
+        self.assertTrue(test_dev in devices)
+        self.assertEqual(options["/mnt/testmount"], "defaults")


### PR DESCRIPTION
Rebased and updated version of #5793 Requires some fixes and changes in blivet that are not yet released so I am marking this as blocked. Blivet 3.12 will be available in Fedora 42, but this targets Fedora 43.