### PR TITLE
Update GH ubuntu runners to 24.04

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   add-label:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Add labels
         uses: actions/labeler@v5

--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   refresh-container:
     name: Refresh anaconda container
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: quay.io
     strategy:
       fail-fast: false

--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   commit-message-check:
     if: contains(github.event.pull_request.labels.*.name, 'infrastructure') && github.event.pull_request.merged != 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Infra tags in commit messages
 
     steps:

--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Clone repository

--- a/.github/workflows/push-tests.yml.j2
+++ b/.github/workflows/push-tests.yml.j2
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Clone repository

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release-note-check:
     if: contains(github.event.pull_request.labels.*.name, 'release note required')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Release notes present
 
     steps:

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   infra-reload-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Templates match results
 
     steps:
@@ -61,7 +61,7 @@ jobs:
           done
 
   infra-template-main-match-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Compare templates files with main branch
     if: github.event.pull_request.base.ref != 'main'
 

--- a/.github/workflows/tests-daily.yml
+++ b/.github/workflows/tests-daily.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
@@ -86,7 +86,7 @@ jobs:
           path: test-logs/*
 
   rpm-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'

--- a/.github/workflows/tests-daily.yml.j2
+++ b/.github/workflows/tests-daily.yml.j2
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
@@ -83,7 +83,7 @@ jobs:
           path: test-logs/*
 
   rpm-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   rpm-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -99,7 +99,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   rpm-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -29,7 +29,7 @@ on:
       - 'main'
 jobs:
   trigger:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
     environment: gh-cockpituous
     container: registry.fedoraproject.org/fedora:40

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -23,7 +23,7 @@ on:
       - 'main'
 jobs:
   trigger:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
     environment: gh-cockpituous
     container: registry.fedoraproject.org/fedora:40

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Configuration of the documentation build process
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
 


### PR DESCRIPTION
We are currently using 22.04 which has quite old podman and other software. Let's get closer to our development environment.

This should resolve issue with recently merged https://github.com/rhinstaller/anaconda/pull/6162 which is failing because of old podman.