### PR TITLE
packit: Enable downstream automation

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -48,7 +48,39 @@ jobs:
   - job: propose_downstream
     trigger: release
     packages: [anaconda-fedora]
-    dist_git_branches: main
+    dist_git_branches:
+      - main
+
+  - job: koji_build
+    trigger: commit
+    packages: [anaconda-fedora]
+    sidetag_group: anaconda-releases
+    dist_git_branches:
+      - main
+    allowed_committers:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+    allowed_pr_authors:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+
+  - job: bodhi_update
+    trigger: koji_build
+    packages: [anaconda-fedora]
+    sidetag_group: anaconda-releases
+    dependencies:
+      - anaconda-webui
+    dist_git_branches:
+      - main
+    allowed_builders:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
 
   - job: tests
     trigger: pull_request

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -46,7 +46,39 @@ jobs:
   - job: propose_downstream
     trigger: release
     packages: [anaconda-fedora]
-    dist_git_branches: main
+    dist_git_branches:
+      - main
+
+  - job: koji_build
+    trigger: commit
+    packages: [anaconda-fedora]
+    sidetag_group: anaconda-releases
+    dist_git_branches:
+      - main
+    allowed_committers:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+    allowed_pr_authors:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+
+  - job: bodhi_update
+    trigger: koji_build
+    packages: [anaconda-fedora]
+    sidetag_group: anaconda-releases
+    dependencies:
+      - anaconda-webui
+    dist_git_branches:
+      - main
+    allowed_builders:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
 
   - job: tests
     trigger: pull_request
@@ -77,7 +109,39 @@ jobs:
   - job: propose_downstream
     trigger: release
     packages: [anaconda-fedora]
-    dist_git_branches: f{$ distro_release $}
+    dist_git_branches:
+      - f{$ distro_release $}
+
+  - job: koji_build
+    trigger: commit
+    packages: [anaconda-fedora]
+    sidetag_group: anaconda-releases
+    dist_git_branches:
+      - f{$ distro_release $}
+    allowed_committers:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+    allowed_pr_authors:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+
+  - job: bodhi_update
+    trigger: koji_build
+    packages: [anaconda-fedora]
+    sidetag_group: anaconda-releases
+    dependencies:
+      - anaconda-webui
+    dist_git_branches:
+      - f{$ distro_release $}
+    allowed_builders:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
This commit adds a `koji_build` job configured to build in a sidetag and a `bodhi_update` job configured to be created from a sidetag and depending on `anaconda` (implicitly) and `anaconda_webui`. A successful Koji build will trigger the `bodhi_update` job if a build of `anaconda-webui` is also in the sidetag.
In case you want to release only `anaconda`, you will have to tag the latest stable build of `anaconda-webui` into the sidetag by commenting `/packit koji-tag` in any `anaconda-webui` dist-git PR (that will satisfy the dependency but only the not-yet-released build of `anaconda` will be added to the update).

This PR complements https://github.com/rhinstaller/anaconda-webui/pull/643.

See also: https://packit.dev/docs/fedora-releases-guide/releasing-multiple-packages

Note: the cross-package automation will not work properly until Packit configuration is updated in dist-git repos of both packages.

@KKoukiou please have a look.