### PR TITLE
Fix more master -> main renaming

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -447,7 +447,7 @@ check-branching:
 	@echo "===================================="
 	@echo "Testing pykickstart configuration"
 	@echo "===================================="
-	@substituted_branch=$$(echo "$(GIT_BRANCH)" | sed 's/^master$$/DEVEL/'); \
+	@substituted_branch=$$(echo "$(GIT_BRANCH)" | sed 's/^main$$/DEVEL/'); \
 	for i in $$(git grep 'from pykickstart.version import DEVEL as VERSION' -- pyanaconda/ dracut/ | awk -F "[: ]" '!/.j2:/ {print $$1 ";" $$5}'); do \
 		i=$${i^^}; \
 		if [ "$${i#*;}" != "$$substituted_branch" ]; then \

--- a/dracut/README-driver-updates.md
+++ b/dracut/README-driver-updates.md
@@ -298,7 +298,7 @@ handled by `parse-kickstart`:
 
 Check the [kickstart documentation] for more info.
 
-[kickstart documentation]: https://github.com/pykickstart/pykickstart/blob/master/docs/kickstart-docs.rst#driverdisk
+[kickstart documentation]: https://github.com/pykickstart/pykickstart/blob/main/docs/kickstart-docs.rst#driverdisk
 
 ## initqueue: `driver-updates@.service`
 

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -289,7 +289,7 @@ The launcher scripts are listed under `TESTS` in `tests/Makefile.am`.
 .. _pytest -k: https://docs.pytest.org/en/7.1.x/reference/reference.html#command-line-flags
 .. _GitHub workflows: https://docs.github.com/en/free-pro-team@latest/actions
 .. _kickstart-tests.yml workflow: ../.github/workflows/kickstart-tests.yml
-.. _kickstart launch script: https://github.com/rhinstaller/kickstart-tests/blob/master/containers/runner/README.md
+.. _kickstart launch script: https://github.com/rhinstaller/kickstart-tests/blob/main/containers/runner/README.md
 .. _container-autoupdate.yml workflow: ../.github/workflows/container-autoupdate.yml
 .. _actions tab: https://github.com/rhinstaller/anaconda/actions?query=workflow%3A%22Refresh+container+images%22
 .. _unittests library: https://docs.python.org/3/library/unittest.html


### PR DESCRIPTION
The kickstart-tests repository just switched from master to main so let's fix links in our documentation.

Also there was one left-over in our Makefile check-branching.