### PR TITLE
Fix failing Differential ShellCheck job

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,6 +1,7 @@
 name: Differential ShellCheck
 on:
   push:
+    branches: [ main, rhel-*, fedora-* ]
   pull_request:
     branches: [ main, rhel-*, fedora-* ]
 

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -23,7 +23,7 @@ jobs:
 
       - id: ShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v4
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -32,7 +32,7 @@ jobs:
             *.j2
             **/*.j2
 
-      - if: ${{ always() }}
+      - if: ${{ runner.debug == '1' && ! cancelled()}}
         name: Upload artifact with ShellCheck defects in SARIF format
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   lint:
+    if: github.event.repository == 'rhinstaller/anaconda'
     runs-on: ubuntu-latest
     
     permissions:

--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     if: github.event.repository == 'rhinstaller/anaconda'
     runs-on: ubuntu-latest
-    
+
     permissions:
       security-events: write
       pull-requests: write


### PR DESCRIPTION

This will mitigate the issue when the Differential ShellCheck Job fails with:

```
fatal: Invalid revision range 0000000000000000000000000000000000000000..81375bf5d11901e029aa298f36c8c984ab180adf
```

/cc @KKoukiou 
