### PR TITLE
Update RAID array name after scheduling its creation

### DIFF
--- a/pyanaconda/core/kickstart/commands.py
+++ b/pyanaconda/core/kickstart/commands.py
@@ -55,7 +55,7 @@ from pykickstart.commands.nvdimm import F40_Nvdimm as Nvdimm
 from pykickstart.commands.ostreecontainer import F38_OSTreeContainer as OSTreeContainer
 from pykickstart.commands.ostreesetup import F38_OSTreeSetup as OSTreeSetup
 from pykickstart.commands.partition import F41_Partition as Partition
-from pykickstart.commands.raid import F29_Raid as Raid
+from pykickstart.commands.raid import F43_Raid as Raid
 from pykickstart.commands.realm import F19_Realm as Realm
 from pykickstart.commands.reboot import F23_Reboot as Reboot
 from pykickstart.commands.repo import F40_Repo as Repo

--- a/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
@@ -627,6 +627,9 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
             request = storage.new_mdarray(**kwargs)
             storage.create_device(request)
 
+            # in case we had to truncate or otherwise adjust the specified name
+            data.onPart[devicename] = request.name
+
             if ty == "swap":
                 add_fstab_swap = request
 


### PR DESCRIPTION
Blivet can change the name for multiple reasons (invalid chars,
name conflict etc.) so we need to make sure we have both the old
and new name saved in case it is used in other kickstart commands
like volgroup for example.

-------

We already do the same for the volgroup command in `_execute_volgroup_data`. This is currently blocked by related pykickstart fix for RAID names, see https://github.com/pykickstart/pykickstart/pull/534