### PR TITLE
spec: Add libblockdev-tools to install-env-deps

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -193,6 +193,7 @@ for live installations.
 Summary: Installation environment specific dependencies
 Requires: udisks2-iscsi
 Requires: libblockdev-plugins-all >= %{libblockdevver}
+Requires: libblockdev-tools
 %if ! 0%{?rhel}
 Requires: libblockdev-lvm-dbus
 %endif


### PR DESCRIPTION
Latest blivet added support for resizing FAT filesystem which needs the vfat-resize tool from the libblockdev-tools package. Because the package is missing from the installer image the FAT filesystem and EFI filesystem are both marked as not fully supported by Blivet which means Anaconda doesn't allow creating EFI System Partition in custom spoke. Including the package in install-env-deps is the quickest way to fix this.

Resolves: rhbz#2346436

----

We definitely need to rework the "supported filesystems" in both Blivet and Anaconda -- resize support is definitely not needed to simply create the filesystem, but that will require a bigger change, including probably some API changes in Blivet, which will take some time and we have a blocker that needs to be fixed as soon as possible.
