### PR TITLE
spec: Add libblockdev-tools to install-env-deps

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -193,6 +193,7 @@ for live installations.
 Summary: Installation environment specific dependencies
 Requires: udisks2-iscsi
 Requires: libblockdev-plugins-all >= %{libblockdevver}
+Requires: libblockdev-tools
 %if ! 0%{?rhel}
 Requires: libblockdev-lvm-dbus
 %endif

--- a/rpmlint.toml
+++ b/rpmlint.toml
@@ -8,6 +8,7 @@ Filters = [
     # Discard explicite library dependencies
     'explicit-lib-dependency flatpak-libs',
     'explicit-lib-dependency libblockdev-lvm-dbus',
+    'explicit-lib-dependency libblockdev-tools',
     'explicit-lib-dependency librsvg2',
     # Discard warning about binary debug symbols. Those are our helper
     # binaries and it is not important for them to be stripped


### PR DESCRIPTION
Latest blivet added support for resizing FAT filesystem which needs the vfat-resize tool from the libblockdev-tools package. Because the package is missing from the installer image the FAT filesystem and EFI filesystem are both marked as not fully supported by Blivet which means Anaconda doesn't allow creating EFI System Partition in custom spoke. Including the package in install-env-deps is the quickest way to fix this.

Resolves: rhbz#2346436

F42 version of #6190