### PR TITLE
network: start network-online.target if network is needed

### DIFF
--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -35,6 +35,7 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-copy-cmdline.sh \
                       anaconda-copy-dhclient.sh \
                       anaconda-copy-prefixdevname.sh \
+                      anaconda-start-network-online-target.sh \
                       anaconda-ifcfg.sh \
                       anaconda-set-kernel-hung-timeout.sh \
                       anaconda-error-reporting.sh \

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -298,7 +298,6 @@ dev_is_on_disk_with_iso9660() {
 set_neednet() {
     # if there's no netroot, make sure /tmp/net.ifaces exists
     [ -z "$netroot" ] && true >> /tmp/net.ifaces
-    systemctl start --no-block network-online.target
 }
 
 parse_kickstart() {

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -298,6 +298,7 @@ dev_is_on_disk_with_iso9660() {
 set_neednet() {
     # if there's no netroot, make sure /tmp/net.ifaces exists
     [ -z "$netroot" ] && true >> /tmp/net.ifaces
+    systemctl start --no-block network-online.target
 }
 
 parse_kickstart() {

--- a/dracut/anaconda-start-network-online-target.sh
+++ b/dracut/anaconda-start-network-online-target.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This should start network-online.target which is wanted by anaconda
+# based on its boot options. These options are parsed by parse-anaconda-*
+# scripts and /tmp/net.iface file is updated accordingly. The file is
+# the trigger used by anaconda to start in initramfs.
+#
+# We want to start the target because some services are wanted / triggered
+# by the network-online.target, like dnsconfd.
+
+if [ -f /tmp/net.ifaces ]; then
+    systemctl start --no-block network-online.target
+fi

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -38,6 +38,8 @@ install() {
     inst_hook cmdline 26 "$moddir/parse-anaconda-kickstart.sh"
     inst_hook cmdline 27 "$moddir/parse-anaconda-repo.sh"
     inst_hook cmdline 28 "$moddir/parse-anaconda-net.sh"
+    # needs to be run after all options are parsed
+    inst_hook cmdline 99 "$moddir/anaconda-start-network-online-target.sh"
     inst_hook pre-udev 30 "$moddir/anaconda-modprobe.sh"
     inst_hook pre-trigger 50 "$moddir/repo-genrules.sh"
     inst_hook pre-trigger 50 "$moddir/kickstart-genrules.sh"


### PR DESCRIPTION
Activation of the micro-dnsconfd and unbound services depend on it (are wanted by the target).

This is rather dirty solution forced by the way anaconda currently signals to dracut that it needs network. (Starting the target multiple times as it can happen if several boot options require networing should not matter though).

One improvement would be have a script hooked that would check the /tmp/net.ifaces just once at the right time.

Proper solution would probably involve anaconda service wanting the target in case the installation requires network. This is logic the service would need to implement (the service start conditions) is now scattered among the parse-anaconda-* hooks creating the /tmp/net.ifaces in the set_neednet function.  Migrating to the service This has high potential to break some use cases though, so it should be checked upstream first.