### PR TITLE
spec: Remove ntfs-3g from install-env-deps

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -223,7 +223,6 @@ Recommends: kdump-anaconda-addon
 # basic filesystem tools
 %if ! 0%{?rhel}
 Requires: btrfs-progs
-Requires: ntfs-3g
 Requires: ntfsprogs
 Requires: f2fs-tools
 %endif


### PR DESCRIPTION
The ntfs3 kernel module should now be in all supported versions of Fedora so we no longer need to depend on ntfs-3g.