### PR TITLE
network: start dnsconfd in initramfs

### DIFF
--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -36,6 +36,7 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-copy-dhclient.sh \
                       anaconda-copy-prefixdevname.sh \
                       anaconda-dnsconfd.sh \
+                      anaconda-start-dnsconfd.sh \
                       anaconda-ifcfg.sh \
                       anaconda-set-kernel-hung-timeout.sh \
                       anaconda-error-reporting.sh \

--- a/dracut/anaconda-lib.sh
+++ b/dracut/anaconda-lib.sh
@@ -305,6 +305,7 @@ parse_kickstart() {
     unset CMDLINE  # re-read the commandline
     . /tmp/ks.info # save the parsed kickstart
     [ -e "$parsed_kickstart" ] && cp "$parsed_kickstart" /run/install/ks.cfg
+    start_dnsconfd "The certificates may have been imported."
 }
 
 # print a list of net devices that dracut says are set up.
@@ -384,6 +385,10 @@ run_kickstart() {
         udevadm trigger --action=change --subsystem-match=block
     fi
 
+    if [ "$do_net" ]; then
+        start_dnsconfd "The network may have become required"
+    fi
+
     # net: re-run online hooks
     if [ "$do_net" ]; then
         # If NetworkManager is used in initramfs
@@ -451,4 +456,43 @@ wait_for_disks() {
     DISKS_WAIT_DELAY=$(getargnum 5 0 10000 inst.wait_for_disks)
     DISKS_WAIT_RETRIES=$((DISKS_WAIT_DELAY * 2))
     echo "[ \"\$main_loop\" -ge \"$DISKS_WAIT_RETRIES\" ]" > "$finished_hook"
+}
+
+# This script should start dnsconfd if all required conditions to run it are met
+start_dnsconfd() {
+
+    local reason="$1"
+    local start="yes"
+
+    echo "Attempting to start dnsconfd. Reason: ${reason}"
+
+    # dnsconfd is explicitly required by kernel boot option
+    dns_backend=$(getarg rd.net.dns-backend=)
+    if [ "${dns_backend}" != "dnsconfd" ]; then
+        echo "Attempting to start dnsconfd. Not starting because not required by kernel boot option."
+        start="no"
+    fi
+
+    # Network is required in initramfs
+    getargbool 0 rd.neednet && neednet=1
+    if [ ! -e "/tmp/net.ifaces" ] && [ "${neednet}" != "1" ]; then
+        echo "Attempting to start dnsconfd. Not starting because network is not required (yet)."
+        start="no"
+    fi
+
+    # It is not possible certificates for dnsconfd will be imported after start by kickstart
+    kickstart="$(getarg inst.ks=)"
+    # If kickstart has not been parsed yet && is reqiured by boot options
+    if [ ! -e /run/install/ks.cfg ] && ([ -n "$kickstart" ] || getargbool 0 inst.ks); then
+        echo "Attempting to start dnsconfd. Not starting because certificates can be imported via kickstart later."
+        start="no"
+    fi
+
+    if [ "${start}" == "yes" ]; then
+        echo "Attempting to start dnsconfd. Starting."
+        systemctl start --no-block unbound.service
+        return 0
+    else
+        return 1
+    fi
 }

--- a/dracut/anaconda-start-dnsconfd.sh
+++ b/dracut/anaconda-start-dnsconfd.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Attempt to start dnsconfd after boot options are parsed.
+# The script needs to be run only after boot options are parsed,
+# (parse-anaconda-* cmdline hooks are finished).
+# There are also other attempts to start dnsconfd with start_dnsconfd
+# called after parsing kickstart, see anaconda-lib.
+
+. /lib/anaconda-lib.sh
+start_dnsconfd "Anaconda boot options have been parsed"
+

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -38,6 +38,7 @@ install() {
     inst_hook cmdline 26 "$moddir/parse-anaconda-kickstart.sh"
     inst_hook cmdline 27 "$moddir/parse-anaconda-repo.sh"
     inst_hook cmdline 28 "$moddir/parse-anaconda-net.sh"
+    inst_hook cmdline 99 "$moddir/anaconda-start-dnsconfd.sh"
     inst_hook pre-udev 30 "$moddir/anaconda-modprobe.sh"
     inst_hook pre-trigger 50 "$moddir/repo-genrules.sh"
     inst_hook pre-trigger 50 "$moddir/kickstart-genrules.sh"


### PR DESCRIPTION
Resolves: RHEL-80302

I was trying to add dracut unit test (like [here](https://github.com/rhinstaller/anaconda/blob/main/tests/unit_tests/shell_tests/test_dracut_anaconda-lib.py)) but the logic is very sparse here and we'd need to figure so much mocking (boot options, existing files) that I gave up. The only option seemed to me to test a function that would take all the possible contitions as parameters (like "can_import_certificates_later", ore "is_required_by_boot_options") and let an (untested) wrapper collect the parameters.