### PR TITLE
Add the locale1-x11-sync script to the anaconda-live subpackage (#2346855)

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -182,6 +182,11 @@ BuildRequires: desktop-file-utils
 Requires: anaconda-gui = %{version}-%{release}
 Requires: zenity
 Recommends: xhost
+# FIXME: This is currently needed by the locale1-x11-sync script.
+# It makes little sense for Anaconda to pull in two Python DBus libraries,
+# so we should either split the script to a separate or change it to also
+# use dasbus like the rest of Anaconda.
+Requires: python3-dbus-next
 
 %description live
 The anaconda-live package contains scripts, data and dependencies required
@@ -381,6 +386,8 @@ rm -rf \
   %{buildroot}/%{_sysconfdir}/xdg/autostart/liveinst-setup.desktop \
   %{buildroot}/%{_bindir}/liveinst \
   %{buildroot}/%{_libexecdir}/liveinst-setup.sh \
+  %{buildroot}/%{_libexecdir}/locale1-x11-sync \
+  %{buildroot}/%{_userunitdir}/locale1-x11-sync.service \
   %{buildroot}/%{_datadir}/anaconda/gnome \
   %{buildroot}/%{_datadir}/anaconda/gnome/fedora-welcome \
   %{buildroot}/%{_datadir}/anaconda/gnome/org.fedoraproject.welcome-screen.desktop \
@@ -443,9 +450,11 @@ rm -rf \
 # do not provide the live subpackage on RHEL
 
 %files live
+%{_userunitdir}/locale1-x11-sync.service
 %{_bindir}/liveinst
 %{_datadir}/polkit-1/actions/*
 %{_libexecdir}/liveinst-setup.sh
+%{_libexecdir}/locale1-x11-sync
 %{_datadir}/applications/*.desktop
 %{_datadir}/anaconda/gnome
 %config(noreplace) %{_sysconfdir}/xdg/autostart/*.desktop

--- a/data/liveinst/Makefile.am
+++ b/data/liveinst/Makefile.am
@@ -21,7 +21,11 @@ dist_bin_SCRIPTS  = liveinst
 desktopdir         = $(datadir)/applications
 dist_desktop_DATA  = liveinst.desktop
 
-dist_libexec_SCRIPTS = liveinst-setup.sh
+dist_libexec_SCRIPTS = liveinst-setup.sh \
+                       locale1-x11-sync
+
+systemddir = $(prefix)/lib/systemd/user
+dist_systemd_DATA = locale1-x11-sync.service
 
 autostartdir       = $(sysconfdir)/xdg/autostart
 dist_autostart_DATA = liveinst-setup.desktop

--- a/data/liveinst/locale1-x11-sync
+++ b/data/liveinst/locale1-x11-sync
@@ -1,0 +1,147 @@
+#!/usr/bin/python3
+"""
+Sync X11 input configuration with org.freedesktop.locale1.
+
+Usage:
+    Configure keyboard mappings with `localectl set-x11-keymap`.
+    Enable service file for this script.
+
+See also:
+    https://www.freedesktop.org/software/systemd/man/org.freedesktop.locale1.html
+
+Dependencies: dbus-next, setxkbmap
+"""
+import argparse
+import asyncio
+import logging
+from typing import Any, Dict
+
+from dbus_next import BusType, DBusError, Variant
+from dbus_next.aio import MessageBus
+
+DEFAULT_DEVICE = 'type:keyboard'
+LOG = logging.getLogger("locale1-x11-sync")
+LOCALE1_BUS_NAME = "org.freedesktop.locale1"
+LOCALE1_OBJECT_PATH = "/org/freedesktop/locale1"
+LOCALE1_INTERFACE = "org.freedesktop.locale1"
+PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
+PROPERTIES = {
+    'X11Layout': 'layout',
+    'X11Model': 'model',
+    'X11Variant': 'variant',
+    'X11Options': 'options'
+}
+SETXKBMAP = "/usr/bin/setxkbmap"
+
+
+class Locale1Client:
+    """Handle org.freedesktop.locale1 updates and pass XKB configuration to Sway"""
+
+    layout: str = ''
+    model: str = ''
+    variant: str = ''
+    options: str = ''
+
+    def __init__(self,
+                 bus: MessageBus,
+                 device: str = DEFAULT_DEVICE):
+        self._bus = bus
+        self._proxy = None
+        self._device = device
+
+    async def connect(self):
+        """asynchronous initialization code"""
+        introspection = await self._bus.introspect(LOCALE1_BUS_NAME,
+                                                   LOCALE1_OBJECT_PATH)
+        self._proxy = self._bus.get_proxy_object(LOCALE1_BUS_NAME,
+                                                 LOCALE1_OBJECT_PATH,
+                                                 introspection)
+        self._proxy.get_interface(PROPERTIES_INTERFACE).on_properties_changed(
+            self.on_properties_changed)
+
+        locale1 = self._proxy.get_interface(LOCALE1_INTERFACE)
+        self.layout = await locale1.get_x11_layout()
+        self.model = await locale1.get_x11_model()
+        self.variant = await locale1.get_x11_variant()
+        self.options = await locale1.get_x11_options()
+
+        await self.update()
+
+    async def on_properties_changed(self,
+                                    interface: str,
+                                    changed: Dict[str, Any],
+                                    _invalidated=None):
+        """Handle updates from localed"""
+        if interface != LOCALE1_INTERFACE:
+            return
+
+        apply = False
+
+        for name, value in changed.items():
+            if name not in PROPERTIES:
+                continue
+            if isinstance(value, Variant):
+                value = value.value
+            self.__dict__[PROPERTIES[name]] = value
+            apply = True
+
+        if apply:
+            await self.update()
+
+    async def update(self):
+        """Pass the updated xkb configuration to Sway"""
+        LOG.info("xkb(%s): layout '%s' model '%s', variant '%s' options '%s'",
+                 self._device, self.layout, self.model, self.variant,
+                 self.options)
+
+        if not self.layout and not self.variant and not self.model:
+            return
+
+        proc = await asyncio.create_subprocess_exec(
+            SETXKBMAP,
+            self.layout, self.variant, self.options,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE)
+
+        stdout, stderr = await proc.communicate()
+
+        if stdout or stderr:
+            LOG.info("output of setxkbmap: stdout: '%s' stderr: '%s'", stdout, stderr)
+
+
+async def main(ns: argparse.Namespace):
+    """Async entrypoint"""
+    try:
+        bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+        await Locale1Client(bus).connect()
+
+        if not ns.oneshot:
+            await bus.wait_for_disconnect()
+    except DBusError as exc:
+        LOG.error("DBus connection error: %s", exc)
+    except (ConnectionError, EOFError) as exc:
+        LOG.error("Sway IPC connection error: %s", exc)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Sync X11 desktop system input configuration with org.freedesktop.locale1"
+    )
+    parser.add_argument(
+        "-l",
+        "--loglevel",
+        choices=["critical", "error", "warning", "info", "debug"],
+        default="info",
+        dest="loglevel",
+        help="set logging level",
+    )
+    parser.add_argument("--oneshot",
+                        action='store_true',
+                        help="apply current settings and exit immediately")
+    args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel.upper())
+
+    try:
+        asyncio.run(main(args))
+    except KeyboardInterrupt:
+        LOG.info("Quitting")

--- a/data/liveinst/locale1-x11-sync.service
+++ b/data/liveinst/locale1-x11-sync.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sync localed configuration with running X11 system
+Documentation=https://github.com/rhinstaller/localed-x11-sync
+
+[Service]
+Type=exec
+ExecStart=/usr/libexec/locale1-x11-sync
+Restart=on-failure
+
+[Install]
+WantedBy=graphical.target
+


### PR DESCRIPTION
This script installed to the libexec folder and the systemd unit triggering it are needed for controlling X11 system keyboard layouts using the systemd-localed DBus API.

Without the script and the systemd unit keyboard switching will not work on X11 Fedora Live spins.

Both might end up in a separate package eventually but for now it should be enough to ship them as part of the anaconda-live package.

(cherry picked from commit a8c00353b0acf7e53d169d685a2bff859cead8f3)

Resolves: rhbz#2346855

Fedora 42 port of #6149.