### PR TITLE
dracut: add static linkage to internal functions

### DIFF
--- a/dracut/dd/dd_extract.c
+++ b/dracut/dd/dd_extract.c
@@ -80,7 +80,7 @@ void show_help() {
  * during cpio extraction, only extract files we need
  * eg. module .ko files and firmware directory
  */
-int dlabelFilter(const char* name, const struct stat *fstat, int packageflags, void *userptr)
+static int dlabelFilter(const char* name, const struct stat *fstat, int packageflags, void *userptr)
 {
     int l = strlen(name);
 

--- a/dracut/dd/dd_list.c
+++ b/dracut/dd/dd_list.c
@@ -58,7 +58,7 @@ struct _version_struct {
     char* anaconda;
 };
 
-int globErrFunc(const char *epath, int eerrno)
+static int globErrFunc(const char *epath, int eerrno)
 {
     /* TODO check fatal errors */
 
@@ -86,7 +86,7 @@ void show_help() {
  * we use it to check if kernel-modules = <kernel version>
  * and installer-enhancement = <anaconda version>
  */
-int dlabelProvides(const char* dep, const char* version, uint32_t sense, void *userptr)
+static int dlabelProvides(const char* dep, const char* version, uint32_t sense, void *userptr)
 {
     char *kernelver = ((struct _version_struct*)userptr)->kernel;
     char *anacondaver = ((struct _version_struct*)userptr)->anaconda;
@@ -132,7 +132,7 @@ int dlabelProvides(const char* dep, const char* version, uint32_t sense, void *u
 /**
  * Print information about the rpm to stdout
  */
-int dlabelOK(const char* source, Header *h, int packageflags)
+static int dlabelOK(const char* source, Header *h, int packageflags)
 {
     struct rpmtd_s tdname;
     struct rpmtd_s tddesc;

--- a/dracut/dd/rpmutils.c
+++ b/dracut/dd/rpmutils.c
@@ -54,14 +54,14 @@ struct cpio_mydata {
  * libarchive callbacks
  */
 
-ssize_t rpm_myread(struct archive *a, void *client_data, const void **buff)
+static ssize_t rpm_myread(struct archive *a, void *client_data, const void **buff)
 {
     struct cpio_mydata *mydata = client_data;
     *buff = mydata->buffer;
     return Fread(mydata->buffer, 1, BUFFERSIZE, mydata->gzdi);
 }
 
-int rpm_myclose(struct archive *a, void *client_data)
+static int rpm_myclose(struct archive *a, void *client_data)
 {
     struct cpio_mydata *mydata = client_data;
     if (mydata->gzdi > 0)
@@ -81,7 +81,7 @@ int init_rpm() {
 
 /* read data from RPM header */
 
-const char * headerGetString(Header h, rpmTagVal tag)
+static const char * headerGetString(Header h, rpmTagVal tag)
 {
     const char *res = NULL;
     struct rpmtd_s td;

--- a/dracut/dd/rpmutils.c
+++ b/dracut/dd/rpmutils.c
@@ -78,23 +78,6 @@ int init_rpm() {
     return rpmReadConfigFiles(NULL, NULL);
 }
 
-
-/* read data from RPM header */
-
-static const char * headerGetString(Header h, rpmTagVal tag)
-{
-    const char *res = NULL;
-    struct rpmtd_s td;
-
-    if (headerGet(h, tag, &td, HEADERGET_MINMEM)) {
-        if (rpmtdCount(&td) == 1) {
-            res = rpmtdGetString(&td);
-        }
-        rpmtdFreeData(&td);
-    }
-    return res;
-}
-
 /*
  *
  */

--- a/dracut/dd/rpmutils.h
+++ b/dracut/dd/rpmutils.h
@@ -64,7 +64,6 @@ typedef int (*dependencyfunc)(const char* depname, const char* depversion, const
 */
 typedef int (*okfunc)(const char* filename, Header *rpmheader, int packageflags);
 
-const char * headerGetString(Header h, rpmTagVal tag);
 int init_rpm();
 int checkDDRPM(const char *source,
                 dependencyfunc provides,


### PR DESCRIPTION
Added the `static` keyword to functions that are not used outside their respective source files to limit their linkage and prevent potential symbol conflicts.

