### PR TITLE
Update logic for removing efi boot target

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/utils.py
+++ b/pyanaconda/modules/payloads/payload/dnf/utils.py
@@ -163,7 +163,7 @@ def get_kernel_version_list():
     :return: a list of kernel versions
     """
     files = []
-    efi_dir = conf.bootloader.efi_dir
+    efi_dir = conf.bootloader.efi_dir + get_product_version()
 
     # Find all installed RPMs that provide 'kernel'.
     ts = rpm.TransactionSet(conf.target.system_root)
@@ -174,7 +174,7 @@ def get_kernel_version_list():
         files.extend((
             f.split("/")[-1][8:] for f in hdr.filenames
             if fnmatch.fnmatch(f, "/boot/vmlinuz-*") or
-            fnmatch.fnmatch(f, "/boot/efi/EFI/%s/vmlinuz-*" % efi_dir)
+            fnmatch.fnmatch(f, "/boot/efi/EFI/%s/vmlinuz-*" % efi_dir + get_product_version())
         ))
 
     # Sort the kernel versions.

--- a/pyanaconda/modules/storage/bootloader/utils.py
+++ b/pyanaconda/modules/storage/bootloader/utils.py
@@ -20,7 +20,7 @@ from glob import glob
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
-from pyanaconda.core.product import get_product_name
+from pyanaconda.core.product import get_product_name, get_product_version
 from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
 from pyanaconda.modules.storage.bootloader.image import LinuxBootLoaderImage
@@ -108,7 +108,7 @@ def _get_rescue_kernel_versions(sysroot):
     :return: a list of rescue kernel versions
     """
     rescue_versions = glob(sysroot + "/boot/vmlinuz-*-rescue-*")
-    rescue_versions += glob(sysroot + "/boot/efi/EFI/%s/vmlinuz-*-rescue-*" % conf.bootloader.efi_dir)
+    rescue_versions += glob(sysroot + "/boot/efi/EFI/%s/vmlinuz-*-rescue-*" % conf.bootloader.efi_dir + get_product_version())
     return [f.split("/")[-1][8:] for f in rescue_versions]
 
 
@@ -157,8 +157,8 @@ def _write_sysconfig_kernel(sysroot, storage):
     kernel_basename = "vmlinuz-" + storage.bootloader.default.version
     kernel_file = "/boot/%s" % kernel_basename
     if not os.path.isfile(sysroot + kernel_file):
-        efi_dir = conf.bootloader.efi_dir
-        kernel_file = "/boot/efi/EFI/%s/%s" % (efi_dir, kernel_basename)
+        efi_dir = conf.bootloader.efi_dir + get_product_version()
+        kernel_file = "/boot/efi/EFI/%s/%s" % (efi_dir + get_product_version(), kernel_basename)
         if not os.path.isfile(sysroot + kernel_file):
             log.error("failed to recreate path to default kernel image")
             return


### PR DESCRIPTION
Trying to modify the efi path from efi/EFI/fedora, to a more specific efi/EFI/fedora_[version] to avoid deleting the boot target when installing dual boot fedora