### PR TITLE
netowrk: enable dnsconfd service in installer environment

### DIFF
--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -35,6 +35,7 @@ dist_dracut_SCRIPTS = module-setup.sh \
                       anaconda-copy-dhclient.sh \
                       anaconda-copy-prefixdevname.sh \
                       anaconda-copy-s390ccwconf.sh \
+                      anaconda-dnsconfd.sh \
                       anaconda-ifcfg.sh \
                       anaconda-set-kernel-hung-timeout.sh \
                       anaconda-error-reporting.sh \

--- a/dracut/anaconda-dnsconfd.sh
+++ b/dracut/anaconda-dnsconfd.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Enable dnsconfd.service in installer environment
+# if dnsconfd backend is used.
+
+dns_backend=$(getarg rd.net.dns-backend=)
+
+if [ ${dns_backend} == "dnsconfd" ]; then
+    systemctl --root=/sysroot enable dnsconfd.service
+fi

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -50,6 +50,7 @@ install() {
     inst_hook pre-pivot 50 "$moddir/anaconda-copy-s390ccwconf.sh"
     inst_hook pre-pivot 90 "$moddir/anaconda-copy-dhclient.sh"
     inst_hook pre-pivot 91 "$moddir/anaconda-copy-prefixdevname.sh"
+    inst_hook pre-pivot 92 "$moddir/anaconda-dnsconfd.sh"
     inst_hook pre-pivot 95 "$moddir/anaconda-set-kernel-hung-timeout.sh"
     inst_hook pre-pivot 99 "$moddir/save-initramfs.sh"
     inst_hook cleanup 98 "$moddir/anaconda-nfsrepo-cleanup.sh"


### PR DESCRIPTION
Enable dnsconfd service based on rd.net.dns-backend kernel option

Resolves: RHEL-80023

Port of https://github.com/rhinstaller/anaconda/pull/6184