### PR TITLE
infra: fix Differential ShellCheck workflow condition

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lint:
-    if: github.event.repository == 'rhinstaller/anaconda'
+    if: github.repository == 'rhinstaller/anaconda'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
The previous condition was not working as expected. Currently, the Differential ShellCheck workflow is always skipped.

follow-up to 5c1adef840ec80dcec3b9e313c1724dfa37a92f1 and #6177
