### PR TITLE
Add ability to get keyboard layouts as read-only

### DIFF
--- a/pyanaconda/modules/localization/live_keyboard.py
+++ b/pyanaconda/modules/localization/live_keyboard.py
@@ -34,7 +34,6 @@ def get_live_keyboard_instance():
     if conf.system.provides_liveuser:
         return GnomeShellKeyboard()
 
-    # TODO: Add support for other Live systems
     return None
 
 

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -50,6 +50,7 @@ from pyanaconda.modules.localization.runtime import (
     ApplyKeyboardTask,
     AssignGenericKeyboardSettingTask,
     GetMissingKeyboardConfigurationTask,
+    GetKeyboardConfigurationTask,
 )
 
 log = get_module_logger(__name__)
@@ -367,6 +368,23 @@ class LocalizationService(KickstartService):
         x_layouts, vc_keymap = result
         self.set_vc_keymap(vc_keymap)
         self.set_x_layouts(x_layouts)
+
+    def get_keyboard_configuration_with_task(self):
+        """Get current keyboard configuration without storing it into module.
+
+        NOTE: This is temporary API and will be removed when Gnome Shell have support for localed.
+        
+        This configuration will be used for the installation at the time of task execution.
+        The task is read only, the results are not stored anywhere.
+        
+        :returns: a task reading keyboard configuration
+        """
+        task = GetKeyboardConfigurationTask(
+            localed_wrapper=self.localed_wrapper,
+            x_layouts=self.x_layouts,
+            vc_keymap=self.vc_keymap,
+        )
+        return task
 
     def apply_keyboard_with_task(self):
         """Apply keyboard configuration to the current system.

--- a/pyanaconda/modules/localization/localization_interface.py
+++ b/pyanaconda/modules/localization/localization_interface.py
@@ -255,6 +255,18 @@ class LocalizationInterface(KickstartModuleInterface):
             self.implementation.populate_missing_keyboard_configuration_with_task()
         )
 
+    def GetKeyboardConfigurationWithTask(self) -> ObjPath:
+        """Get current keyboard configuration without storing it into module.
+
+        NOTE: This is temporary API and will be removed when Gnome Shell have support for localed.
+        
+        This configuration will be used for the installation at the time of task execution.
+        The task is read only, the results are not stored anywhere.
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.get_keyboard_configuration_with_task()
+        )
+
     def ApplyKeyboardWithTask(self) -> ObjPath:
         """Apply keyboard configuration to the current system.
 

--- a/pyanaconda/modules/localization/runtime.py
+++ b/pyanaconda/modules/localization/runtime.py
@@ -21,6 +21,7 @@ from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.errors.configuration import KeyboardConfigurationError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.localization.installation import write_vc_configuration
+from pyanaconda.modules.localization.live_keyboard import get_live_keyboard_instance
 from pyanaconda.modules.localization.utils import get_missing_keyboard_configuration
 
 log = get_module_logger(__name__)
@@ -94,6 +95,27 @@ class GetMissingKeyboardConfigurationTask(Task):
         return get_missing_keyboard_configuration(self._localed_wrapper,
                                                   self._x_layouts,
                                                   self._vc_keymap)
+
+
+# TODO: Remove this API when localed is supported by Gnome Shell
+class GetKeyboardConfigurationTask(GetMissingKeyboardConfigurationTask):
+
+    @property
+    def name(self):
+        return "Get keyboard configuration with Live"
+
+    def run(self):
+        """Get current keyboard settings.
+        
+        :returns: tuple of X layouts, VC keyboard, bool if Live system has unsupported methods
+        :rtype: (list(str), str, bool)"""
+        live_keyboard = get_live_keyboard_instance()
+        ret = get_missing_keyboard_configuration(self._localed_wrapper,
+                                                 self._x_layouts,
+                                                 self._vc_keymap,
+                                                 live_keyboard=live_keyboard)
+        unsupported = live_keyboard.have_unsupported_layouts()
+        return *ret, unsupported
 
 
 class ApplyKeyboardTask(Task):

--- a/pyanaconda/modules/localization/utils.py
+++ b/pyanaconda/modules/localization/utils.py
@@ -22,7 +22,7 @@ from pyanaconda.modules.localization.live_keyboard import get_live_keyboard_inst
 log = get_module_logger(__name__)
 
 
-def get_missing_keyboard_configuration(localed_wrapper, x_layouts, vc_keymap):
+def get_missing_keyboard_configuration(localed_wrapper, x_layouts, vc_keymap, live_keyboard=None):
     """Get keyboard configuration if not set by user.
 
     Algorithm works as this:
@@ -41,6 +41,8 @@ def get_missing_keyboard_configuration(localed_wrapper, x_layouts, vc_keymap):
     :type x_layouts: list(str)
     :param vc_keymap: virtual console keyboard mapping name
     :type vc_keymap: str
+    :param live_keyboard: instance to read compositor keyboard layouts or None to create it locally
+    :type live_keyboard: LiveSystemKeyboardBase instance or None
     :returns: tuple of X layouts and VC keyboard settings
     :rtype: (list(str), str))
     """
@@ -48,7 +50,8 @@ def get_missing_keyboard_configuration(localed_wrapper, x_layouts, vc_keymap):
         log.debug("Keyboard layouts and virtual console keymap already set - nothing to do")
         return x_layouts, vc_keymap
 
-    live_keyboard = get_live_keyboard_instance()
+    if not live_keyboard:
+        live_keyboard = get_live_keyboard_instance()
     # layouts are not set by user, we should take a look for live configuration if available
     if not x_layouts and live_keyboard:
         log.debug("Keyboard configuration from Live system is available")

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -38,6 +38,7 @@ from pyanaconda.modules.localization.localization_interface import LocalizationI
 from pyanaconda.modules.localization.runtime import (
     ApplyKeyboardTask,
     GetMissingKeyboardConfigurationTask,
+    GetKeyboardConfigurationTask,
 )
 from tests.unit_tests.pyanaconda_tests import (
     PropertiesChangedCallback,
@@ -350,6 +351,18 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         task_path = self.localization_interface.PopulateMissingKeyboardConfigurationWithTask()
 
         obj = check_task_creation(task_path, publisher, GetMissingKeyboardConfigurationTask)
+        assert obj.implementation._vc_keymap == 'us'
+        assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
+
+    @patch_dbus_publish_object
+    def test_get_keyboard_configuration_with_task(self, publisher):
+        """Test GetKeyboardConfigurationWithTask."""
+        self.localization_interface.VirtualConsoleKeymap = 'us'
+        self.localization_interface.XLayouts = ['cz', 'cz (qwerty)']
+
+        task_path = self.localization_interface.GetKeyboardConfigurationWithTask()
+
+        obj = check_task_creation(task_path, publisher, GetKeyboardConfigurationTask)
         assert obj.implementation._vc_keymap == 'us'
         assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
 


### PR DESCRIPTION
Add API and extend current code in a way that web UI is able to tell user that the current configuration of layouts to be installed is correct. We need this because web UI is using Gnome Shell keyboard layouts for the installed system. However, Gnome Shell have support for ibus input method which is not supported by the installed system.

This API will allow web UI to easily read what is going to be installed with additional information if Gnome Shell have unsupported methods set.

This API is only temporary and should be removed when Gnome Shell get support for Localed.