### PR TITLE
Enhance reading of the Live keyboard layouts

### DIFF
--- a/pyanaconda/modules/localization/live_keyboard.py
+++ b/pyanaconda/modules/localization/live_keyboard.py
@@ -20,7 +20,9 @@ from abc import ABC, abstractmethod
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.i18n import _
 from pyanaconda.core.util import execWithCaptureAsLiveUser
+from pyanaconda.modules.common.errors.configuration import KeyboardConfigurationError
 
 log = get_module_logger(__name__)
 
@@ -90,14 +92,18 @@ class GnomeShellKeyboard(LiveSystemKeyboardBase):
         result = []
 
         for t in sources:
-            # keep only 'xkb' type and ignore 'ibus' variants which can't be used in localed
-            if t[0] == "xkb":
-                layout = t[1]
-                # change layout variant from 'cz+qwerty' to 'cz (qwerty)'
-                if '+' in layout:
-                    layout, variant = layout.split('+')
-                    result.append(f"{layout} ({variant})")
-                else:
-                    result.append(layout)
+            # keep only 'xkb' type and raise an error on 'ibus' variants which can't
+            # be used in localed
+            if t[0] != "xkb":
+                msg = _("The live system has layout '%s' which can't be used for installation.")
+                raise KeyboardConfigurationError(msg.format(t[1]))
+
+            layout = t[1]
+            # change layout variant from 'cz+qwerty' to 'cz (qwerty)'
+            if '+' in layout:
+                layout, variant = layout.split('+')
+                result.append(f"{layout} ({variant})")
+            else:
+                result.append(layout)
 
         return result

--- a/pyanaconda/modules/localization/live_keyboard.py
+++ b/pyanaconda/modules/localization/live_keyboard.py
@@ -34,7 +34,6 @@ def get_live_keyboard_instance():
     if conf.system.provides_liveuser:
         return GnomeShellKeyboard()
 
-    # TODO: Add support for other Live systems
     return None
 
 

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -368,6 +368,21 @@ class LocalizationService(KickstartService):
         self.set_vc_keymap(vc_keymap)
         self.set_x_layouts(x_layouts)
 
+    def get_keyboard_configuration_with_task(self):
+        """Get current keyboard configuration without storing it into module.
+
+        This configuration will be used for the installation at the time of task execution.
+        The task is read only, the results are not stored anywhere.
+
+        :returns: a task reading keyboard configuration
+        """
+        task = GetMissingKeyboardConfigurationTask(
+            localed_wrapper=self.localed_wrapper,
+            x_layouts=self.x_layouts,
+            vc_keymap=self.vc_keymap,
+        )
+        return task
+
     def apply_keyboard_with_task(self):
         """Apply keyboard configuration to the current system.
 

--- a/pyanaconda/modules/localization/localization_interface.py
+++ b/pyanaconda/modules/localization/localization_interface.py
@@ -18,7 +18,7 @@
 # Red Hat, Inc.
 #
 
-from dasbus.server.interface import dbus_interface, dbus_signal
+from dasbus.server.interface import dbus_class, dbus_interface, dbus_signal
 from dasbus.server.property import emits_properties_changed
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
@@ -27,6 +27,21 @@ from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.modules.common.containers import TaskContainer
 from pyanaconda.modules.common.structures.keyboard_layout import KeyboardLayout
 from pyanaconda.modules.common.structures.language import LanguageData, LocaleData
+from pyanaconda.modules.common.task import TaskInterface
+
+
+@dbus_class
+class KeyboardConfigurationTaskInterface(TaskInterface):
+    """Interface to get keyboard configuration data."""
+
+    @staticmethod
+    def convert_result(value):
+        """Convert value to publishable result.
+
+        From:
+        (("us", "cs (qwerty)"), "cs-qwerty")
+        """
+        return get_variant(Tuple[List[Str], Str], value)
 
 
 @dbus_interface(LOCALIZATION.interface_name)
@@ -253,6 +268,17 @@ class LocalizationInterface(KickstartModuleInterface):
         """
         return TaskContainer.to_object_path(
             self.implementation.populate_missing_keyboard_configuration_with_task()
+        )
+
+    def GetKeyboardConfigurationWithTask(self) -> ObjPath:
+        """Get current keyboard configuration without storing it into module.
+
+        This task will give you a potential configuration to be installed at the time of
+        task execution. The task is read only, the results are not used anywhere by
+        the localization module.
+        """
+        return TaskContainer.to_object_path(
+            self.implementation.get_keyboard_configuration_with_task()
         )
 
     def ApplyKeyboardWithTask(self) -> ObjPath:

--- a/pyanaconda/modules/localization/runtime.py
+++ b/pyanaconda/modules/localization/runtime.py
@@ -90,6 +90,8 @@ class GetMissingKeyboardConfigurationTask(Task):
 
         :returns: tuple of X layouts and VC keyboard settings
         :rtype: (list(str), str))
+        :raises: KeyboardConfigurationError exception when we should use unsupported layouts
+                 from Live
         """
         return get_missing_keyboard_configuration(self._localed_wrapper,
                                                   self._x_layouts,

--- a/pyanaconda/modules/localization/runtime.py
+++ b/pyanaconda/modules/localization/runtime.py
@@ -21,6 +21,9 @@ from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.errors.configuration import KeyboardConfigurationError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.localization.installation import write_vc_configuration
+from pyanaconda.modules.localization.localization_interface import (
+    KeyboardConfigurationTaskInterface,
+)
 from pyanaconda.modules.localization.utils import get_missing_keyboard_configuration
 
 log = get_module_logger(__name__)
@@ -80,6 +83,9 @@ class GetMissingKeyboardConfigurationTask(Task):
         self._localed_wrapper = localed_wrapper
         self._x_layouts = x_layouts
         self._vc_keymap = vc_keymap
+
+    def for_publication(self):
+        return KeyboardConfigurationTaskInterface(self)
 
     @property
     def name(self):

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -23,18 +23,21 @@ from unittest.mock import Mock, patch
 
 import langtable
 from dasbus.signal import Signal
-from dasbus.typing import Bool, Str, get_variant
+from dasbus.typing import Bool, List, Str, Tuple, get_variant
 
 from pyanaconda.modules.common.constants.services import LOCALIZATION
 from pyanaconda.modules.common.structures.keyboard_layout import KeyboardLayout
 from pyanaconda.modules.common.structures.language import LanguageData, LocaleData
-from pyanaconda.modules.common.task import TaskInterface
+from pyanaconda.modules.common.task import TaskInterface, sync_run_task
 from pyanaconda.modules.localization.installation import (
     KeyboardInstallationTask,
     LanguageInstallationTask,
 )
 from pyanaconda.modules.localization.localization import LocalizationService
-from pyanaconda.modules.localization.localization_interface import LocalizationInterface
+from pyanaconda.modules.localization.localization_interface import (
+    KeyboardConfigurationTaskInterface,
+    LocalizationInterface,
+)
 from pyanaconda.modules.localization.runtime import (
     ApplyKeyboardTask,
     GetMissingKeyboardConfigurationTask,
@@ -350,8 +353,30 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         task_path = self.localization_interface.PopulateMissingKeyboardConfigurationWithTask()
 
         obj = check_task_creation(task_path, publisher, GetMissingKeyboardConfigurationTask)
+        assert isinstance(obj, KeyboardConfigurationTaskInterface)
         assert obj.implementation._vc_keymap == 'us'
         assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
+
+    @patch_dbus_publish_object
+    def test_get_keyboard_configuration_with_task(self, publisher):
+        """Test GetKeyboardConfigurationWithTask."""
+        self.localization_interface.VirtualConsoleKeymap = 'us'
+        self.localization_interface.XLayouts = ['cz', 'cz (qwerty)']
+
+        task_path = self.localization_interface.GetKeyboardConfigurationWithTask()
+
+        obj = check_task_creation(task_path, publisher, GetMissingKeyboardConfigurationTask)
+        assert isinstance(obj, KeyboardConfigurationTaskInterface)
+        assert obj.implementation._vc_keymap == 'us'
+        assert obj.implementation._x_layouts == ['cz', 'cz (qwerty)']
+
+        with patch.object(obj.implementation, "run") as run_mock:
+            run_mock.return_value = ("cz (qwerty)", "us"), "cz-qwerty"
+
+            sync_run_task(obj)
+            # test the conversion from task to DBus variant
+            assert obj.GetResult() == get_variant(Tuple[List[Str], Str],
+                                                  (['cz (qwerty)', 'us'], 'cz-qwerty'))
 
     @patch_dbus_publish_object
     def test_apply_keyboard_with_task(self, publisher):


### PR DESCRIPTION
This PR is doing two parts:
- raise an exception if unsupported keyboard layout is set to the system (ibus methods)
- add API which allows to read keyboard layouts which are going to be installed to the system without modifying localization module

Related: [rhbz#2348726](https://bugzilla.redhat.com/show_bug.cgi?id=2348726) 