### PR TITLE
fix fetching kickstarts from OEMDRV

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -57,10 +57,14 @@ debug_msg "Trying to find a root image on the device $dev."
 # However, it will fail if one of its partitions is already mounted, for example here.
 # Therefore, skip the partitions and use the disk to find our root image.
 # See the bug 1878784.
-if [[ "$root" =~ "by-label"|"by-uuid" ]] && dev_is_on_disk_with_iso9660 "$dev"; then
-  debug_msg "Skipping $dev on a disk with iso9660."
-  exit 1
-fi
+case $root in
+  *"by-label"*|*"by-uuid"*)
+    if dev_is_on_disk_with_iso9660 "$dev"; then
+      debug_msg "Skipping $dev on a disk with iso9660."
+      exit 1
+    fi
+    ;;
+esac
 
 # If we're waiting for a cdrom kickstart, the user might need to swap discs.
 # So if this is a CDROM drive, make a note of it, but don't mount it (yet).

--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -52,12 +52,12 @@ debug_msg "Trying to find a root image on the device $dev."
 # Then do not run again.
 [ -e "/dev/root" ] && exit 1
 
-# Skip partitions on a disk with the iso9660 filesystem. Blivet doesn't
-# recognize these partitions, so we mount the disk in stage2. However, it
-# will fail if one of its partitions is already mounted, for example here.
+# Skip partitions on a disk with the iso9660 filesystem, set by LABEL or UUID.
+# Blivet doesn't recognize these partitions, so we mount the disk in stage2.
+# However, it will fail if one of its partitions is already mounted, for example here.
 # Therefore, skip the partitions and use the disk to find our root image.
 # See the bug 1878784.
-if dev_is_on_disk_with_iso9660 "$dev"; then
+if [[ "$root" =~ "by-label"|"by-uuid" ]] && dev_is_on_disk_with_iso9660 "$dev"; then
   debug_msg "Skipping $dev on a disk with iso9660."
   exit 1
 fi

--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -57,7 +57,7 @@ debug_msg "Trying to find a root image on the device $dev."
 # However, it will fail if one of its partitions is already mounted, for example here.
 # Therefore, skip the partitions and use the disk to find our root image.
 # See the bug 1878784.
-case $root in
+case "$root" in
   *"by-label"*|*"by-uuid"*)
     if dev_is_on_disk_with_iso9660 "$dev"; then
       debug_msg "Skipping $dev on a disk with iso9660."


### PR DESCRIPTION
See [dracut/kickstart-genrules.sh](https://github.com/rhinstaller/anaconda/blob/main/dracut/kickstart-genrules.sh) for fetching kickstarts broken functionality:
```sh
        if [ -z "$kickstart" ] && [ -z "$(getarg inst.ks=)" ]; then
            when_diskdev_appears "$(disk_to_dev_path LABEL=OEMDRV)" \
                fetch-kickstart-disk "\$env{DEVNAME}" "/ks.cfg"
            wait_for_disks
        fi
```
The `OEMDRV` partition couldn't be mounted because the _whole_ installation media disk is _always_ mounted before as `iso9660` first, blocking all the other mounts.

This patch allows workaround the problem by unambiguously specifying cmdline ISO partition by file directly, e.g.:
`inst.stage2=hd:/dev/disk/by-partlabel/ISO9660`
instead of default specifying by LABEL, e.g.:
`inst.stage2=hd:LABEL=Fedora-SB-ostree-x86_64-41`
See https://github.com/rhinstaller/anaconda/commit/301a09d06ee0f0df7a3a1c818d7051f31a12bbd1 for details.

Fixes [Bug 2346192](https://bugzilla.redhat.com/show_bug.cgi?id=2346192).

Related Lorax issue:
https://github.com/weldr/lorax/issues/1451

@poncovka @bcl