### PR TITLE
fix initrd syntax in README-testing-changes.rst

### DIFF
--- a/dracut/README-testing-changes.rst
+++ b/dracut/README-testing-changes.rst
@@ -34,8 +34,8 @@ Using your overlay image
 
 - Start the testing system, and edit boot options.
 
-- After ``initrd=<something>`` add immediately (without space) a comma and a path to your
-  overlay: ``initrd=<something>,<your-overlay-image-file>``.
+- After ``initrd=<something>`` add a space and a path to your
+  overlay: ``initrd=<something> <your-overlay-image-file>``.
 
 - Make `dracut` stop so that you can check your changes were applied. Add to the end of boot
   options also: ``rd.break=pre-pivot rd.shell``.


### PR DESCRIPTION
I'm not sure if `,` syntax is still supported, but it didn't work for me if the second initrd image is not on root partition, so you have to add `(hd..,gpt..)` prefix to the path.

This worked:
```
initrdefi /images/pxeboot/initrd.img (hd0,gpt2)/dracut_patch.img
```