### PR TITLE
Disable centos production repo, keep only development enabled. 

### DIFF
--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -23,7 +23,6 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # Add development repositories instead of the production ones
 # We need development repositories to get our dependencies sooner
-RUN rm -f /etc/yum.repos.d/*.repo
 COPY ["anaconda-centos.repo", "/etc/yum.repos.d/"]
 
 # The anaconda.spec.in is in the repository root. This file will be copied automatically here if
@@ -32,6 +31,8 @@ COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 
 # Prepare environment and install build dependencies
 RUN set -ex; \
+  # Disable production repositories
+  dnf config-manager --disable baseos appstream crb; \
   dnf update -y; \
   # Install dependencies
   dnf install -y \


### PR DESCRIPTION
The issue this patch is trying to resolve is older version of package in developemnt CentOS repository than in the production CentOS repository. For example for gtk package:

```
Error:
 Problem 1: package gtk3-devel-docs-3.24.43-2.el10.x86_64 from
crb-development requires gtk3 = 3.24.43-2.el10, but none of the providers can be installed
  - cannot install both gtk3-3.24.43-3.el10.x86_64 from appstream and gtk3-3.24.43-2.el10.x86_64 from appstream-development
  - cannot install both gtk3-3.24.43-3.el10.x86_64 from appstream and gtk3-3.24.43-2.el10.x86_64 from appstream
  - package gtk3-devel-3.24.43-3.el10.x86_64 from appstream requires gtk3(x86-64) = 3.24.43-3.el10, but none of the providers can be installed
  - cannot install the best candidate for the job
  - conflicting requests
```

If it the solution is  acceptable, I'll update also anaconda-ci Dockerfile in the same manner?