### PR TITLE
Fix bad formatting for `format` function

### DIFF
--- a/pyanaconda/modules/localization/live_keyboard.py
+++ b/pyanaconda/modules/localization/live_keyboard.py
@@ -95,7 +95,7 @@ class GnomeShellKeyboard(LiveSystemKeyboardBase):
             # keep only 'xkb' type and raise an error on 'ibus' variants which can't
             # be used in localed
             if t[0] != "xkb":
-                msg = _("The live system has layout '%s' which can't be used for installation.")
+                msg = _("The live system has layout '{}' which can't be used for installation.")
                 raise KeyboardConfigurationError(msg.format(t[1]))
 
             layout = t[1]

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_live_keyboard.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_live_keyboard.py
@@ -42,14 +42,15 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
                                               mocked_exec_with_capture,
                                               system_input,
                                               output,
-                                              should_raise):
+                                              unsupported_layout):
         mocked_exec_with_capture.reset_mock()
         mocked_exec_with_capture.return_value = system_input
 
         gs = GnomeShellKeyboard()
 
-        if should_raise:
-            with pytest.raises(KeyboardConfigurationError):
+        if unsupported_layout:
+            match = fr'.*{unsupported_layout}.*'
+            with pytest.raises(KeyboardConfigurationError, match=match):
                 gs.read_keyboard_layouts()
             return
 
@@ -69,7 +70,7 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('xkb', 'cz')]",
             output=["cz"],
-            should_raise=False
+            unsupported_layout=None
         )
 
         # test one complex layout is set
@@ -77,7 +78,7 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('xkb', 'cz+qwerty')]",
             output=["cz (qwerty)"],
-            should_raise=False
+            unsupported_layout=None
         )
 
         # test multiple layouts are set
@@ -85,7 +86,7 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('xkb', 'cz+qwerty'), ('xkb', 'us'), ('xkb', 'cz+dvorak-ucw')]",
             output=["cz (qwerty)", "us", "cz (dvorak-ucw)"],
-            should_raise=False
+            unsupported_layout=None
         )
 
         # test layouts with ibus (ibus will raise error)
@@ -93,7 +94,7 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('xkb', 'cz'), ('ibus', 'libpinyin')]",
             output=[],
-            should_raise=True
+            unsupported_layout='libpinyin'
         )
 
         # test only ibus layout (raise the error)
@@ -101,7 +102,7 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('ibus', 'libpinyin')]",
             output=[],
-            should_raise=True
+            unsupported_layout='libpinyin'
         )
 
         # test wrong input
@@ -109,5 +110,5 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"wrong input",
             output=[],
-            should_raise=False
+            unsupported_layout=None
         )


### PR DESCRIPTION
I used %s as formatting input where it needs to be {}.

Related: rhbz#2348726
Backport of https://github.com/rhinstaller/anaconda/pull/6231.