### PR TITLE
Fix tui error after rd question

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -421,6 +421,7 @@ def setup_display(anaconda, options):
 
 def _set_gui_mode_on_rdp(anaconda, use_rdp):
     if not use_rdp:
+        anaconda.display_mode = constants.DisplayModes.TUI
         return
 
     if not anaconda.gui_mode:


### PR DESCRIPTION
When Wayland fails, the choice is between remote desktop and TUI, but if TUI is selected, the anaconda display_mode is not changed. This solves this error. 

Resolves: [2349658](https://bugzilla.redhat.com/show_bug.cgi?id=2349658) , and [2349658](https://bugzilla.redhat.com/show_bug.cgi?id=2348382)
