### PR TITLE
infra: increase default terminal width in test GitHub workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# FIXME: Can be removed once https://github.com/rpm-software-management/dnf5/pull/2110 reaches composes
+env:
+  COLUMNS: 120
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# FIXME: Can be removed once https://github.com/rpm-software-management/dnf5/pull/2110 reaches composes
+env:
+  COLUMNS: 120
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tested it on my fork, RPM tests passed: https://github.com/KKoukiou/anaconda/actions/runs/13719484921/job/38371570367?pr=12