### PR TITLE
Disable systemd-resolved when enabling dnsconfd

### DIFF
--- a/dracut/anaconda-dnsconfd.sh
+++ b/dracut/anaconda-dnsconfd.sh
@@ -6,4 +6,5 @@ dns_backend=$(getarg rd.net.dns-backend=)
 
 if [ "${dns_backend}" == "dnsconfd" ]; then
     systemctl --root=/sysroot enable dnsconfd.service
+    systemctl --root=/sysroot is-enabled systemd-resolved.service && systemctl --root=/sysroot disable systemd-resolved.service
 fi


### PR DESCRIPTION
The mechanisms for mutual exclusion of dnsconfd and systemd-resolved don't work in installer environment.
This should be rather safe workaround.