### PR TITLE
infra: use single copr for both main and branched fedora

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -97,7 +97,7 @@ jobs:
       - fedora-42
     branch: fedora-42
     owner: "@rhinstaller"
-    project: Anaconda-devel
+    project: Anaconda
     preserve_project: True
     additional_repos:
       - "copr://@storage/blivet-daily"

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -157,7 +157,7 @@ jobs:
       - fedora-{$ distro_release $}
     branch: fedora-{$ distro_release $}
     owner: "@rhinstaller"
-    project: Anaconda-devel
+    project: Anaconda
     preserve_project: True
     additional_repos:
       - "copr://@storage/blivet-daily"

--- a/branch-config.mk
+++ b/branch-config.mk
@@ -29,5 +29,5 @@
 GIT_BRANCH ?= fedora-42
 L10N_DIR ?= f42
 BASE_CONTAINER ?= registry.fedoraproject.org/fedora:42
-COPR_REPO ?= \@rhinstaller/Anaconda-devel
+COPR_REPO ?= \@rhinstaller/Anaconda
 

--- a/branch-config.mk.j2
+++ b/branch-config.mk.j2
@@ -31,7 +31,6 @@ L10N_DIR ?= main
 BASE_CONTAINER ?= registry.fedoraproject.org/fedora:rawhide
 
 # COPR repo for use in container builds.
-# Can be @rhinstaller/Anaconda for main, or @rhinstaller/Anaconda-devel for branched Fedora.
 COPR_REPO ?= \@rhinstaller/Anaconda
 
 {% elif distro_name == "fedora" %}
@@ -39,7 +38,7 @@ COPR_REPO ?= \@rhinstaller/Anaconda
 GIT_BRANCH ?= fedora-{$ distro_release $}
 L10N_DIR ?= f{$ distro_release $}
 BASE_CONTAINER ?= registry.fedoraproject.org/fedora:{$ distro_release $}
-COPR_REPO ?= \@rhinstaller/Anaconda-devel
+COPR_REPO ?= \@rhinstaller/Anaconda
 
 {% elif distro_name == "rhel" and distro_release != 10 %}
 

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -22,7 +22,6 @@ ARG git_branch
 # The `copr_repo` arg will set Anaconda daily builds copr repository.
 # possible values:
 #   @rhinstaller/Anaconda
-#   @rhinstaller/Anaconda-devel
 ARG copr_repo
 LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 


### PR DESCRIPTION
After all copr support targets, so builds for different fedora versions are categorized correctly.

https://copr.fedorainfracloud.org/coprs/g/rhinstaller/Anaconda-devel/ can be obsoleted by this and deleted.