### PR TITLE
pyanaconda: storage: fix getting of usable devices

### DIFF
--- a/pyanaconda/modules/storage/partitioning/manual/manual_module.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_module.py
@@ -156,7 +156,7 @@ class ManualPartitioningModule(PartitioningModule):
                 continue
 
             # All device's disks have to be in selected disks.
-            if selected_disks and not selected_disks.issuperset({d.name for d in device.disks}):
+            if selected_disks and not selected_disks.issuperset({d.device_id for d in device.disks}):
                 continue
 
             yield device


### PR DESCRIPTION
Stop mixing device ids and device names when comparing.

Fixup for ab7c0d25fe680471cd0955fa2ecc481ee117e966.

Resolves: rhbz#2351848
