### PR TITLE
infra: add packit copr builds for PRs on fedora branches

### DIFF
--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -151,6 +151,12 @@ jobs:
       - fedora-{$ distro_release $}
 
   - job: copr_build
+    trigger: pull_request
+    packages: [anaconda-fedora]
+    targets:
+      - fedora-{$ distro_release $}
+
+  - job: copr_build
     trigger: commit
     packages: [anaconda-fedora]
     targets:


### PR DESCRIPTION
This will enable testing WebUI on anaconda PRs.

