### PR TITLE
infra: skip kickstart tests not working for anaconda PR CI workflow

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -198,7 +198,7 @@ jobs:
         working-directory: ./kickstart-tests
         run: |
           LAUNCH_ARGS=$(scripts/generate-launch-args.py ${{ needs.pr-info.outputs.comment_args }} \
-             --branch ${{ needs.pr-info.outputs.target_branch }} ) || RC=$?
+             --branch ${{ needs.pr-info.outputs.target_branch }} ) --anaconda-pr || RC=$?
           if [ -z ${RC} ] || [ ${RC} == 0 ]; then
             echo "Generated launch arguments: $LAUNCH_ARGS"
           else

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -192,7 +192,7 @@ jobs:
         working-directory: ./kickstart-tests
         run: |
           LAUNCH_ARGS=$(scripts/generate-launch-args.py ${{ needs.pr-info.outputs.comment_args }} \
-             --branch ${{ needs.pr-info.outputs.target_branch }} ) || RC=$?
+             --branch ${{ needs.pr-info.outputs.target_branch }} ) --anaconda-pr || RC=$?
           if [ -z ${RC} ] || [ ${RC} == 0 ]; then
             echo "Generated launch arguments: $LAUNCH_ARGS"
           else


### PR DESCRIPTION
Currently these are the tests of type stage2-from-compose. See https://github.com/rhinstaller/kickstart-tests/pull/1398

Example of the issue: https://github.com/rhinstaller/anaconda/pull/6276#issuecomment-2731935140