### PR TITLE
Support redirects in apply-updates

### DIFF
--- a/scripts/apply-updates
+++ b/scripts/apply-updates
@@ -37,4 +37,4 @@ if [[ "$EUID" -ne 0 ]]; then
 fi
 
 # Download and extract the updates image.
-(cd / ; curl -f "${URL}" | gzip -dc  | cpio -idu )
+(cd / ; curl -L -f "${URL}" | gzip -dc  | cpio -idu )


### PR DESCRIPTION
The apply-updates script is used to apply updates images on Live system. However, without this patch it will not work for HTTP servers which will return 3XX replies to redirect the call. Let's enable that which will allow us to use:

```
sudo /usr/libexec/anaconda/apply-updates 'https://bugzilla.redhat.com/attachment.cgi?id=2080720'
```

and other similar cases.