### PR TITLE
pyanaconda: storage: add some checks for MDRAID devices as stage1/stage2

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -557,11 +557,12 @@ class BootLoader:
                                        desc=description):
             valid = False
 
-        if not self._is_valid_md(device,
-                                 raid_levels=constraints[PLATFORM_RAID_LEVELS],
-                                 metadata=constraints[PLATFORM_RAID_METADATA],
-                                 desc=description):
-            valid = False
+        for dev in [device, *device.parents]:
+            if not self._is_valid_md(dev,
+                                     raid_levels=constraints[PLATFORM_RAID_LEVELS],
+                                     metadata=constraints[PLATFORM_RAID_METADATA],
+                                     desc=description):
+                valid = False
 
         if not self.stage2_bootable and not getattr(device, "bootable", True):
             log.warning("%s not bootable", device.name)

--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -167,7 +167,9 @@ class X86(Platform):
     def stage1_constraints(self):
         """The platform-specific constraints for the stage1 device."""
         constraints = {
-            PLATFORM_DEVICE_TYPES: ["disk"]
+            PLATFORM_DEVICE_TYPES: ["disk"],
+            PLATFORM_RAID_LEVELS: [raid.RAID1],
+            PLATFORM_RAID_METADATA: ["1.0"]
         }
         return dict(super().stage1_constraints, **constraints)
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
@@ -84,7 +84,7 @@ class PlatformTestCase(unittest.TestCase):
             "mountpoints": [],
             "max_end": None,
             "raid_levels": [],
-            "raid_metadata": [],
+            "raid_metadata": []
         }
         all_constraints.update(constraints)
 
@@ -112,6 +112,8 @@ class PlatformTestCase(unittest.TestCase):
         self._check_constraints(
             constraints={
                 "device_types": ["disk"],
+                "raid_levels": [raid.RAID1],
+                "raid_metadata": ["1.0"]
             },
             descriptions={
                 "disk": "Master Boot Record",


### PR DESCRIPTION
When validating devices that are on MDRAID for stage1 and stage2 usage we need to check their parents, aka the MDRAID device itself for validity.

Relevant to: rhbz#2352953

With this PR I get in Web UI:
![127 0 0 2_9091_cockpit_@localhost_anaconda-webui_index html](https://github.com/user-attachments/assets/14d7b071-1b1e-4ace-8d64-71c2779a3653)

Without this PR SOMERAID1 is recognized as valid stage1 device and the installation finishes, but it does not boot.