### PR TITLE
Revert "Do not copy resolv.conf to target system at the end of installation

### DIFF
--- a/pyanaconda/modules/network/installation.py
+++ b/pyanaconda/modules/network/installation.py
@@ -20,6 +20,7 @@ import shutil
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core import service
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.path import join_paths, make_directories
 from pyanaconda.modules.common.errors.installation import NetworkInstallationError
@@ -108,6 +109,7 @@ class NetworkInstallationTask(Task):
 
     SYSCONF_NETWORK_FILE_PATH = "/etc/sysconfig/network"
     ANACONDA_SYSCTL_FILE_PATH = "/etc/sysctl.d/anaconda.conf"
+    RESOLV_CONF_FILE_PATH = "/etc/resolv.conf"
     NETWORK_SCRIPTS_DIR_PATH = IFCFG_DIR
     PREFIXDEVNAME_CONFIG_FILE_PREFIX = "71-net-ifnames-prefix-"
     NETWORK_SCRIPTS_CONFIG_FILE_PREFIXES = ("ifcfg-", "keys-", "route-")
@@ -167,6 +169,18 @@ Name={}
             self._disable_ipv6_on_system(self._sysroot)
         self._copy_device_config_files(self._sysroot)
         self._copy_dhclient_config_files(self._sysroot, self._network_ifaces)
+
+        # Make sure DNS resolution works in %post scripts
+        # when systemd-resolved is not available.
+        #
+        # Main use-case for this is currently image mode on RHEL.
+        # In this case there is no systemd-resolved in use by default and
+        # image mode deploys the target system rootfs only after the early
+        # resolv.conf copy action has run, clobbering the resolv.conf we copy earlier
+        # in the copy_resolv_conf_to_root() method.
+        if conf.system.provides_resolver_config and \
+                not service.is_service_installed("systemd-resolved.service"):
+            self._copy_resolv_conf(self._sysroot, self._overwrite)
         if self._configure_persistent_device_names:
             self._copy_prefixdevname_files(self._sysroot)
         self._copy_global_dns_config(self._sysroot)
@@ -234,6 +248,16 @@ Name={}
         except OSError as e:
             msg = "Cannot disable ipv6 on the system: {}".format(e.strerror)
             raise NetworkInstallationError(msg) from e
+
+    def _copy_resolv_conf(self, root, overwrite):
+        """Copy resolf.conf file to target system.
+
+        :param root: path to the root of the target system
+        :type root: str
+        :param overwrite: overwrite existing configuration file
+        :type overwrite: bool
+        """
+        self._copy_file_to_root(root, self.RESOLV_CONF_FILE_PATH, follow_symlinks=False)
 
     def _copy_file_to_root(self, root, config_file, overwrite=False, follow_symlinks=True):
         """Copy the file to target system.


### PR DESCRIPTION
This reverts commit 4be7bb9902baec66a07b9e861430e7fe7a884a31 introduced in the https://github.com/rhinstaller/anaconda/pull/3818 PR.

What this means is that will now again copy the /etc/resolv.conf file from the installation environment to installed system root for a second time, after the payload installation is done, but before kickstart %post script run. This is necessary for DNS to work for %post scripts in image mode on RHEL 10.

There is no systemd-resolved in use by default on RHEL 10 & image mode apparently re-mounts the sysroot folder, so the resolv.conf file we copy in early via the copy_resolv_conf_to_root() method is not in place anymore in sysroot when image mode finishes installing the container image.

For this reason we need to re-introduce this second pass, gated on systemd-resolved not being used, that copies resolv.conf to sysroot again. This should fix DNS in %post scripts to work again with image mode on RHEL 10.

(cherry picked from commit c9b84d8c9974a42f1c5fd23636f43bd2497a2c77)

Resolves: RHEL-84110

Upstream port of PR #6276.