### PR TITLE
Stop parsing PLATFORM_ID from os-release

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -42,7 +42,6 @@ from pyanaconda.core.constants import (
 )
 from pyanaconda.core.i18n import _
 from pyanaconda.core.payload import ProxyString, ProxyStringError
-from pyanaconda.core.util import get_os_release_value
 from pyanaconda.modules.common.errors.installation import PayloadInstallationError
 from pyanaconda.modules.common.errors.payload import (
     UnknownCompsEnvironmentError,
@@ -150,13 +149,6 @@ class DNFManager:
         # Set the installation root.
         base.conf.installroot = conf.target.system_root
         base.conf.prepend_installroot('persistdir')
-
-        # Set the platform id based on the /os/release present
-        # in the installation environment.
-        platform_id = get_os_release_value("PLATFORM_ID")
-
-        if platform_id is not None:
-            base.conf.module_platform_id = platform_id
 
         # Start with an empty comps so we can go ahead and use
         # the environment and group properties. Unset reposdir

--- a/tests/unit_tests/pyanaconda_tests/core/test_util.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_util.py
@@ -739,7 +739,6 @@ class MiscTests(unittest.TestCase):
                 f.write("# blah\nVERSION_ID=foo256bar  \n VERSION_ID = wrong\n\n")
             version = util.get_os_release_value("VERSION_ID", root)
             assert version == "foo256bar"
-            assert util.get_os_release_value("PLATFORM_ID", root) is None
 
             # main file and backup too
             with open(root + "/etc/os-release", "w") as f:
@@ -755,9 +754,8 @@ class MiscTests(unittest.TestCase):
 
             # quoted values
             with open(root + "/etc/os-release", "w") as f:
-                f.write("PRETTY_NAME=\"Fedora 32\"\nPLATFORM_ID='platform:f32'\n")
+                f.write("PRETTY_NAME=\"Fedora 32\"\n")
             assert util.get_os_release_value("PRETTY_NAME", root) == "Fedora 32"
-            assert util.get_os_release_value("PLATFORM_ID", root) == "platform:f32"
 
             # no files
             os.remove(root + "/usr/lib/os-release")

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -127,13 +127,6 @@ class DNFManagerTestCase(unittest.TestCase):
             "releasever_minor": "",
         })
 
-    @patch("pyanaconda.modules.payloads.payload.dnf.dnf_manager.get_os_release_value")
-    def test_set_module_platform_id(self, get_platform_id):
-        """Test the configuration of module_platform_id."""
-        get_platform_id.return_value = "platform:f32"
-        self.dnf_manager.reset_base()
-        self._check_configuration("module_platform_id = platform:f32")
-
     def test_configure_proxy(self):
         """Test the proxy configuration."""
         self.dnf_manager.configure_proxy("http://user:pass@example.com/proxy")


### PR DESCRIPTION
The PLATFORM_ID key in os-release was used for the deprecated Fedora Modularity initiative & it looks very likely it will be dropped via this Fedora 43 change in the near future:

https://fedoraproject.org/wiki/Changes/Drop_PLATFORM_ID

Given that we don't really support modularity anymore in upstream Anaconda, we might as well drop parsing of PLATFORM_ID right away.