### PR TITLE
Use tmpfs for /var/tmp in CI containers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -98,7 +98,7 @@ RELEASE_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-release
 ISO_CREATOR_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-iso-creator
 LIVE_ISO_CREATOR_NAME ?= $(CONTAINER_REGISTRY)/rhinstaller/anaconda-live-iso-creator
 CI_TAG := $(or $(CI_TAG),$(GIT_BRANCH))
-CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:z
+CI_TEST_ARGS ?= --rm -v $(srcdir):/anaconda:z --tmpfs=/var/tmp:rw,mode=1777
 CI_CMD ?= make ci
 
 SKIP_BRANCHING_CHECK ?= "false"

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_live.py
@@ -106,7 +106,7 @@ class InstallFromImageTaskTestCase(unittest.TestCase):
         exec_readlines.return_value = self._make_reader(0)
         exec_with_redirect.return_value = 0
 
-        with tempfile.TemporaryDirectory() as mount_point:
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as mount_point:
             task = InstallFromImageTask(
                 sysroot="/mnt/root",
                 mount_point=mount_point

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/source/test_source_live_image.py
@@ -356,7 +356,7 @@ class LiveImageInstallationTestCase(unittest.TestCase):
     @contextmanager
     def _create_directory(self):
         """Create a temporary directory."""
-        with tempfile.TemporaryDirectory() as d:
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as d:
             self.directory = d
             yield
             self.directory = None


### PR DESCRIPTION
From time when we fixed rsync
https://github.com/rhinstaller/anaconda/pull/6006/commits/44bde41afed8b19876a84df5fe4635a47707fcd4 to fail on any non-zero return code we are facing issue of getting this failed in tests in some containers. This failure is however correct.

The issue we are facing is that overlayfs doesn't support extended attributes which cause an error with -X argument of rsync. That is expected and correct failure. Unfortunately, containers are using overlayfs for `/` so when we create temporary directory for the rsync in tests it will fail.

To fix this issue let's change /var/tmp to tmpfs so our temporary directory will not be on overlayfs anymore.

Also force the test to always use /var/tmp as the temporary directory to avoid race conditions.