### PR TITLE
F42:  Start/stop locale-sync systemd unit in liveinst #6295 

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -22,6 +22,21 @@ BACKEND_READY_FLAG=/run/anaconda/backend_ready
 
 WAYLAND_DISPLAY_SOCKET=/tmp/anaconda-wldisplay
 
+
+# Start locale1-x11-sync.service unit to enable Anaconda to control keyboard layouts
+# This needs to be started only on X11 based systems
+start_locale_sync_unit() {
+    if rpm -q "xorg-x11-server-Xorg" > /dev/null && [ -e "/usr/lib/systemd/user/locale1-x11-sync.service" ]; then
+        systemctl --user start locale1-x11-sync.service
+    fi
+}
+
+stop_locale_sync_unit() {
+    if rpm -q "xorg-x11-server-Xorg" > /dev/null && [ -e "/usr/lib/systemd/user/locale1-x11-sync.service" ]; then
+        systemctl --user stop locale1-x11-sync.service
+    fi
+}
+
 # Detect and save the wayland socket before re-exec
 if [ -n "$WAYLAND_DISPLAY" ]; then
     if [ -e "$WAYLAND_DISPLAY_SOCKET" ]; then
@@ -37,8 +52,13 @@ if [ "$(id -u)" -ne 0 ]; then
     if [ -z "$WAYLAND_DISPLAY" ]; then
         xhost +si:localuser:root
     fi
+
+    start_locale_sync_unit
     pkexec "$0" "$@"
-    exit $?
+    ret=$?
+    stop_locale_sync_unit
+
+    exit $ret
 fi
 
 # pkexec clears the environment, so get it back

--- a/data/liveinst/locale1-x11-sync.service
+++ b/data/liveinst/locale1-x11-sync.service
@@ -8,5 +8,4 @@ ExecStart=/usr/libexec/locale1-x11-sync
 Restart=on-failure
 
 [Install]
-WantedBy=graphical.target
-
+WantedBy=default.target


### PR DESCRIPTION
There is an issue to enable this unit in livesys scripts so instead
let's start it in liveinst script just for the installation.

Also fix `WantedBy` of the systemd user unit `locale1-x11-sync.service`.

Backport of https://github.com/rhinstaller/anaconda/pull/6295.