### PR TITLE
F42: Disable keyboard shortcuts for layouts switching

### DIFF
--- a/docs/developer/keyboard-control.rst
+++ b/docs/developer/keyboard-control.rst
@@ -57,7 +57,6 @@ To resolve this flaw of Wayland systems on Fedora 42 is proposal to require all 
 
   * Ideally by listening to signals on systemd-localed configuration and reacting on these
   * Includes configuration of X11Layout, X11Variant, X11Options
-* Reflect changes in running system to systemd-localed
 
 Anaconda is also required to follow systemd-localed in similar way:
 
@@ -83,6 +82,11 @@ Anaconda is also required to follow systemd-localed in similar way:
         "qwerty,"
 
     Beware of the X11Variant needs to also change to follow the ordering of the X11Layout!
+
+.. note::
+
+    After facing issues we have decided to drop requirement ``Reflect changes in running system to systemd-localed`` as it is hard to achieve from the system side.
+    TODO: Add a link to release notes
 
 Keyboard control implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/release-notes/disabled-keyboard-shortcuts-to-switch-layouts.rst
+++ b/docs/release-notes/disabled-keyboard-shortcuts-to-switch-layouts.rst
@@ -1,0 +1,29 @@
+:Type: GUI
+:Summary: Disable keyboard shortcuts to switch keyboard layouts (#2307282)
+
+:Description:
+    As part of the system wide change in Fedora to migrate Anaconda to Wayland we also had
+    to remove libXklavier from our codebase. That resulted in a new solution built on localed.
+
+    The original idea was to have bidirectional communication between Anaconda and the running
+    system using localed as middle layer to control keyboard layouts in the system but also
+    to give a system a possibility to reflect changes from system to Anaconda. Unfortunately,
+    we are facing issues that the system have a hard time reacting to keyboard layout changes.
+    The selected layout is especially problematic as it is not a term to be easily defined and
+    is tricky to resolve. One of the reasons is that the layout could be specific to a window
+    and Anaconda is not the same process as the localed daemon.
+
+    To simplify this issue we have decided to disable keyboard layout switching by keyboard
+    shortcuts. This will allow us to change the bidirectional solution in Anaconda to one direction
+    which is only::
+
+        Anaconda > localed > system
+
+    That should make Anaconda solution more robust and also will remove burden from the Desktop
+    maintainers that they don't need to add implementation to be able to detect changes and set
+    them correctly to the localed.
+
+:Links:
+    - https://fedoraproject.org/wiki/Changes/Anaconda_As_Native_Wayland_Application
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2307282
+    - https://bugzilla.redhat.com/show_bug.cgi?id=1955025

--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -187,8 +187,3 @@ class SystemSection(Section):
     def supports_web_ui(self):
         """Can we run Web UI on this system?"""
         return self._is_boot_iso or self._is_live_os
-
-    @property
-    def supports_compositor_keyboard_layout_shortcut(self):
-        """Does the compositor support keyboard layout options correctly?"""
-        return not self._is_boot_iso

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -263,6 +263,7 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
 
         self._user_layouts_variants = []
         self._last_layouts_variants = []
+
         self.compositor_layouts_changed = Signal()
         self.compositor_selected_layout_changed = Signal()
 
@@ -361,14 +362,14 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
                 options,
             )
 
-        # TODO: Remove when https://issues.redhat.com/browse/RHEL-71880 is fixed
-        # Because of the bug above Anaconda is not able to detect keyboard layout changed by the
-        # keyboard shortcuts, however, layouts will change. To avoid confusion of users
-        # let's rather disable this feature completely.
-        if conf.system.supports_compositor_keyboard_layout_shortcut is not True:
-            log.debug("Keyboard layout switching from shortcut is broken in compositor. "
-                      "Filter these out from the options: '%s'.", options)
-            options = list(filter(lambda x: not x.startswith("grp:"), options))
+        # Disable keyboard layout switching by keyboard shortcut as it is hard to make this
+        # working from the system to localed. The current layout is in general problematic to
+        # decide.
+        log.debug(
+            "Disable keyboard layouts switching shortcut to compositor from the options: '%s'",
+            options,
+        )
+        options = list(filter(lambda x: not x.startswith("grp:"), options))
 
         # store configuration from user
         super().set_layouts(layouts_variants, options, convert)

--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -21,7 +21,6 @@ import locale as locale_mod
 
 from pyanaconda import flags, keyboard
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import (
     DEFAULT_KEYBOARD,
     THREAD_ADD_LAYOUTS_INIT,
@@ -497,27 +496,18 @@ class KeyboardSpoke(NormalSpoke):
         store.remove(itr)
 
     def _refresh_switching_info(self):
-        switch_options = self._l12_module.LayoutSwitchOptions
         if flags.flags.use_rd:
             self._layoutSwitchLabel.set_text(_("Keyboard layouts are not "
                                                "supported when using RDP.\n"
                                                "However the settings will be used "
                                                "after the installation."))
-        elif not conf.system.supports_compositor_keyboard_layout_shortcut:
+        else:
             self._layoutSwitchLabel.set_text(
                 _(
                     "Switching keyboard layouts by using keyboard shortcuts is not supported. "
                     "To change the layout, use the keyboard icon in the top bar."
                 )
             )
-        elif switch_options:
-            first_option = switch_options[0]
-            desc = self._xkl_wrapper.get_switch_opt_description(first_option)
-
-            self._layoutSwitchLabel.set_text(_(LAYOUT_SWITCHING_INFO) % desc)
-        else:
-            self._layoutSwitchLabel.set_text(_("Layout switching not "
-                                               "configured."))
 
     # Signal handlers.
     def on_add_clicked(self, button):

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_localed_wrapper.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_localed_wrapper.py
@@ -227,6 +227,12 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
         localed_wrapper.set_layouts(["cz", "us (euro)"])
         assert localed_wrapper._user_layouts_variants == ["cz", "us (euro)"]
 
+        # we are removing all the grp: switching keyboard layouts below as we don't support
+        # this to easy the life of the compositors
+        # The issue is that in this case they need to signal us current layout change which
+        # is tricky for more reasons but one of it is that it could be window specific and
+        # backend doesn't own window
+
         # test set_layout on proxy without options
         mocked_localed_proxy.SetX11Keyboard.reset_mock()
         localed_wrapper.set_layouts(["cz (qwerty)", "us"])
@@ -234,7 +240,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
             "cz,us",
             "pc105",  # hardcoded
             "qwerty,",
-            "eurosign:2,grp:alt_shift_toggle,grp:ctrl_alt_toggle,grp_led:caps",
+            "eurosign:2,grp_led:caps",
             False,
             False
         )
@@ -246,13 +252,12 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
             "cz,us",
             "pc105",  # hardcoded
             "qwerty,",
-            "eurosign:2,grp:alt_shift_toggle,grp:ctrl_alt_toggle,grp_led:caps",
+            "eurosign:2,grp_led:caps",
             False,
             False
         )
 
-        # test set_layout on proxy when shortcut layout switching is broken
-        # TODO: Remove when https://issues.redhat.com/browse/RHEL-71880 is fixed
+        # test set_layout on proxy when shortcut layout switching is disabled
         mocked_localed_proxy.SetX11Keyboard.reset_mock()
         mocked_conf.system.supports_compositor_keyboard_layout_shortcut = False
         localed_wrapper.set_layouts(["cz (qwerty)", "us"], options=None)
@@ -260,12 +265,12 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
             "cz,us",
             "pc105",  # hardcoded
             "qwerty,",
-            "eurosign:2,grp_led:caps",  # Remove after fix of RHEL-71880
+            "eurosign:2,grp_led:caps",
             False,
             False
         )
 
-        # test set_layout on proxy when layout switching is broken and options are specified
+        # test set_layout on proxy when layout switching is disabled and options are specified
         mocked_localed_proxy.SetX11Keyboard.reset_mock()
         localed_wrapper.set_layouts(["us"], options=("grp:ctrl_alt_toggle", "grp_led:caps"))
         mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(
@@ -277,7 +282,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
             False
         )
 
-        # test set_layout on proxy when layout switching is broken and options are empty
+        # test set_layout on proxy when layout switching is disabled and options are empty
         mocked_localed_proxy.SetX11Keyboard.reset_mock()
         localed_wrapper.set_layouts(["us"], options="", convert=True)
         mocked_localed_proxy.SetX11Keyboard.assert_called_once_with(


### PR DESCRIPTION
After a long investigation and lot of discussions we decided to drop support to control keyboard layouts by keyboard shortcuts as it will lower complexity level from the Desktop to Anaconda.

To be able to control keyboard layouts by Anaconda we only need: Anaconda -> localed -> system

However, keyboard shortcuts are processed on level of system which needs opposite direction:
system -> localed -> Anaconda

which could be quite tricky because there is no easy way to know about the current layout which might be even specific to a window. And window is not the same process as Anaconda backend controlling the localed.

Anaconda will still be configurable from localed, because there is no need to limit this, however, we won't request a system to write their configuration to localed.

Users can still click to the banner in Anaconda to switch keyboard layouts.

Backport: https://github.com/rhinstaller/anaconda/pull/6301