### PR TITLE
pyanaconda: grub2: Avoid RAID0, RAID4, RAID10, or anything requiring parity for boot

### DIFF
--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -117,8 +117,7 @@ class GRUB2(BootLoader):
 
     # requirements for boot devices
     stage2_device_types = ["partition", "mdarray", "btrfs volume", "btrfs subvolume"]
-    stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
-                          raid.RAID5, raid.RAID6, raid.RAID10]
+    stage2_raid_levels = [raid.RAID1, raid.RAID5, raid.RAID6]
     stage2_raid_member_types = ["partition"]
     stage2_raid_metadata = ["0", "0.90", "1.0", "1.2"]
 


### PR DESCRIPTION
GRUB does not implement a full RAID driver, it can only read simple disk layouts without requiring data reconstruction.

Remaining support for:
- RAID1 (mirroring): GRUB can read from any disk in the array as if it were a standalone disk.
- RAID5/6: As long as GRUB reads from a disk without needing parity reconstruction, it works.

Removed support for RAID0, RAID4, RAID10 as GRUB cannot reconstruct striped/parity data at boot

Resolves: rhbz#2354805
