### PR TITLE
Limit support for only RAID1 on /boot

### DIFF
--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -117,8 +117,7 @@ class GRUB2(BootLoader):
 
     # requirements for boot devices
     stage2_device_types = ["partition", "mdarray", "btrfs volume", "btrfs subvolume"]
-    stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
-                          raid.RAID5, raid.RAID6, raid.RAID10]
+    stage2_raid_levels = [raid.RAID1]
     stage2_raid_member_types = ["partition"]
     stage2_raid_metadata = ["0", "0.90", "1.0", "1.2"]
 


### PR DESCRIPTION
Originally Anaconda allowed most of the raids. However, based on the RHEL documentation, Arch Linux documentation and testing only the RAID1 seems to be correct RAID to be used on /boot.

Let's limit the RAID support for /boot to just RAID1 to avoid issues with unsupported / not tested support for other RAID alternatives.

Resolves: rhbz#2354805

Based on PR https://github.com/rhinstaller/anaconda/pull/6311