### PR TITLE
F42 limit boot on raid1

### DIFF
--- a/docs/release-notes/limit-boot-on-RAID1.rst
+++ b/docs/release-notes/limit-boot-on-RAID1.rst
@@ -1,0 +1,13 @@
+:Type: General
+:Summary: Limit /boot on RAID1 only (#2354805)
+
+:Description:
+    Anaconda allowed all RAID supports in the past for /boot partition, however, based on
+    the current RHEL documentation and validation with the bootloader team, we have decided to
+    limit the support to RAID1 only. As RAID1 is the only tested and supported FS.
+
+    This change should increase robustness of the systems installed by Anaconda.
+
+:Links:
+    - https://bugzilla.redhat.com/show_bug.cgi?id=2354805
+    - https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/automatically_installing_rhel/index#raid_kickstart-commands-for-handling-storage

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -117,8 +117,7 @@ class GRUB2(BootLoader):
 
     # requirements for boot devices
     stage2_device_types = ["partition", "mdarray", "btrfs volume", "btrfs subvolume"]
-    stage2_raid_levels = [raid.RAID0, raid.RAID1, raid.RAID4,
-                          raid.RAID5, raid.RAID6, raid.RAID10]
+    stage2_raid_levels = [raid.RAID1]
     stage2_raid_member_types = ["partition"]
     stage2_raid_metadata = ["0", "0.90", "1.0", "1.2"]
 


### PR DESCRIPTION
Originally Anaconda allowed most of the raids. However, based on the RHEL documentation, Arch Linux documentation and testing only the RAID1 seems to be correct RAID to be used on /boot.

Let's limit the RAID support for /boot to just RAID1 to avoid issues with unsupported / not tested support for other RAID alternatives.

Resolves: [rhbz#2354805](https://bugzilla.redhat.com/show_bug.cgi?id=2354805)

Backport of https://github.com/rhinstaller/anaconda/pull/6313