### PR TITLE
RHEL-9: Relabel /var/log/ and /root/original-ks.cfg

### DIFF
--- a/data/post-scripts/99-copy-logs.ks
+++ b/data/post-scripts/99-copy-logs.ks
@@ -45,10 +45,19 @@ fi
 %end
 
 %post
+RESCUE_MODE=/run/install/RESCUE_MODE
+
+# Do not automatically modify files on the system being rescued.
+if [ -e ${RESCUE_MODE} ]; then
+    exit 0
+fi
+
 # Relabel the anaconda logs we've just coppied, since they could be incorrectly labeled, like
 # hawkey.log: https://bugzilla.redhat.com/show_bug.cgi?id=1885772.
 # Execution of this %post script will not be logged in the log files on the installed system.
 
+restorecon -i /root/original-ks.cfg
+restorecon -i /var/log/
 restorecon -ir /var/log/anaconda/
 
 %end


### PR DESCRIPTION
If nothing creates /var/log during the installation, it's going to be created by mkdir /var/log/anaconda with the wrong SELinux context (var_t), after the restorecon in 80-setfilecons.ks. On first boot, systemd-journald will then fail to create /var/log/journal, so the first boot logs are lost.

While at it also relabel /root/original-ks.cfg,
and avoid relabeling in rescue mode.

Resolves: https://issues.redhat.com/browse/RHEL-85298