### PR TITLE
storage: remove EFI and BIOS boot partition requirements for MBR disks

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -618,6 +618,12 @@ class DeviceTreeViewer(ABC):
                     constraint.recommended = True
                 else:
                     constraint.required = True
+                # On MBR BIOS boot partition (typically labelled as biosboot) is not required.
+                if p.fstype == "biosboot":
+                    stage1_disk = self.storage.bootloader.stage1_disk
+                    is_gpt = (stage1_disk and getattr(stage1_disk.format, "label_type", None) == "gpt")
+                    if not is_gpt:
+                        constraint.required = False
                 constraints.append(constraint)
 
         return constraints


### PR DESCRIPTION
Port of https://github.com/rhinstaller/anaconda/pull/6306 from main branch

Resolves: rhbz#2353002