### PR TITLE
anaconda-tmux@.service: pass TERM

### DIFF
--- a/data/systemd/anaconda-tmux@.service
+++ b/data/systemd/anaconda-tmux@.service
@@ -9,6 +9,7 @@ ConditionKernelCommandLine=!inst.notmux
 Type=idle
 WorkingDirectory=/root
 Environment=LANG=en_US.UTF-8
+PassEnvironment=TERM
 ExecStart=/usr/bin/tmux -u attach -t anaconda
 StandardInput=tty
 StandardOutput=tty

--- a/docs/release-notes/enable-TERM-passthrough.rst
+++ b/docs/release-notes/enable-TERM-passthrough.rst
@@ -1,0 +1,15 @@
+:Type: TUI
+:Summary: Pass of the TERM environment variable to tmux
+
+:Description:
+    Anaconda is now able to pass the ``TERM`` environment variable from kernel parameters to
+    the Anaconda tmux session.
+
+    This could be used for example to pass ``TERM=xterm-256color`` from kernel parameters to
+    make Anaconda tmux use colors in the host's terminal. Useful especially for VMs, as
+    serial terminal type can't properly be detected there.
+
+
+
+:Links:
+    - https://github.com/rhinstaller/anaconda/pull/6318


### PR DESCRIPTION
Allows passing a `TERM` environment variable via kernel cmdline.
This is useful for VMs, as serial terminal type can't properly be detected there.

E.g., adding `TERM=xterm-256color` to kernel cmdline parameters would make anaconda tmux use colors in my host's terminal.