### PR TITLE
F42: Fix race condition when reading localed layouts

### DIFF
--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -317,7 +317,10 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
         :return: a list of "layout (variant)" or "layout" layout specifications
         :rtype: list(str)
         """
-        return "" if not self.layouts_variants else self.layouts_variants[0]
+        # TODO: This is a hotfix for a race condition because layouts_variants is read from DBus
+        #       and can change between the calls - caused rhbz#2357836
+        layouts_variants = self.layouts_variants
+        return "" if not layouts_variants else layouts_variants[0]
 
     @property
     def layouts_variants(self):


### PR DESCRIPTION
This bug is causing crash on Workstation when different layout is set in compositor. The issue is that even when this is property the layouts_variants values are read from localed, so it could happen that the value changes between layout_variants calls which is causing crash.

This solution is a hotfix, we need to make visible that there is more logic when reading this value by changing this from property to function.

Resolves: [rhbz#2357836](https://bugzilla.redhat.com/show_bug.cgi?id=2357836)
(cherry picked from commit 353c59c6cafaee85366763d03e717d035ab0abd4)