### PR TITLE
Fix race condition when reading localed layouts

### DIFF
--- a/pyanaconda/modules/localization/installation.py
+++ b/pyanaconda/modules/localization/installation.py
@@ -191,7 +191,7 @@ def write_x_configuration(localed_wrapper, x_layouts, switch_options, x_conf_dir
     if root != "/":
         # Writing to a different root, we need to save these values, so that
         # we can restore them when we have the file written out.
-        saved_layouts_variants = localed_wrapper.layouts_variants
+        saved_layouts_variants = localed_wrapper.get_layouts_variants()
         saved_options = localed_wrapper.options
 
     # Set systemd-localed's layouts, variants and switch options, which

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -317,7 +317,10 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
         :return: a list of "layout (variant)" or "layout" layout specifications
         :rtype: list(str)
         """
-        return "" if not self.layouts_variants else self.layouts_variants[0]
+        # TODO: This is a hotfix for a race condition because layouts_variants is read from DBus
+        #       and can change between the calls - caused rhbz#2357836
+        layouts_variants = self.layouts_variants
+        return "" if not layouts_variants else layouts_variants[0]
 
     @property
     def layouts_variants(self):

--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -52,9 +52,8 @@ class LocaledWrapperBase(ABC):
 
         self._localed_proxy = LOCALED.get_proxy()
 
-    @property
-    def layouts_variants(self):
-        """Get current X11 layouts with variants.
+    def get_layouts_variants(self):
+        """Read current X11 layouts with variants from system.
 
         :return: a list of "layout (variant)" or "layout" layout specifications
         :rtype: list(str)
@@ -190,7 +189,7 @@ class LocaledWrapper(LocaledWrapperBase):
 
         # hack around systemd's lack of functionality -- no function to just
         # convert without changing keyboard configuration
-        orig_layouts_variants = self.layouts_variants
+        orig_layouts_variants = self.get_layouts_variants()
         orig_keymap = self.keymap
         converted_layouts = self.set_and_convert_keymap(keymap)
         self.set_layouts(orig_layouts_variants)
@@ -209,7 +208,7 @@ class LocaledWrapper(LocaledWrapperBase):
         """
         self.set_keymap(keymap, convert=True)
 
-        return self.layouts_variants
+        return self.get_layouts_variants()
 
     def set_and_convert_layouts(self, layouts_variants):
         """Set X11 layouts and set and get converted VConsole keymap.
@@ -243,7 +242,7 @@ class LocaledWrapper(LocaledWrapperBase):
 
         # hack around systemd's lack of functionality -- no function to just
         # convert without changing keyboard configuration
-        orig_layouts_variants = self.layouts_variants
+        orig_layouts_variants = self.get_layouts_variants()
         orig_keymap = self.keymap
         ret = self.set_and_convert_layouts(layouts_variants)
         self.set_layouts(orig_layouts_variants)
@@ -317,21 +316,18 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
         :return: a list of "layout (variant)" or "layout" layout specifications
         :rtype: list(str)
         """
-        # TODO: This is a hotfix for a race condition because layouts_variants is read from DBus
-        #       and can change between the calls - caused rhbz#2357836
-        layouts_variants = self.layouts_variants
+        layouts_variants = self.get_layouts_variants()
         return "" if not layouts_variants else layouts_variants[0]
 
-    @property
-    def layouts_variants(self):
-        """Get current X11 layouts with variants.
+    def get_layouts_variants(self):
+        """Read current X11 layouts with variants from system.
 
         Store information about the last selected layout variant used.
 
         :return: a list of "layout (variant)" or "layout" layout specifications
         :rtype: list(str)
         """
-        self._last_layouts_variants = super().layouts_variants
+        self._last_layouts_variants = super().get_layouts_variants()
         return self._last_layouts_variants
 
     def set_layouts(self, layouts_variants, options=None, convert=False):

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -423,7 +423,7 @@ class LocalizationService(KickstartService):
         return self.localed_compositor_wrapper.select_next_layout()
 
     def get_compositor_layouts(self):
-        return self.localed_compositor_wrapper.layouts_variants
+        return self.localed_compositor_wrapper.get_layouts_variants()
 
     def set_compositor_layouts(self, layout_variants, options):
         self.localed_compositor_wrapper.set_layouts(layout_variants, options)

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_localed_wrapper.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_localed_wrapper.py
@@ -37,7 +37,7 @@ class LocaledWrapperTestCase(unittest.TestCase):
         """Test that calls to LocaledWrapper are guarded not to fail."""
         assert localed_wrapper.keymap == ""
         assert localed_wrapper.options == []
-        assert localed_wrapper.layouts_variants == []
+        assert localed_wrapper.get_layouts_variants() == []
         localed_wrapper.set_keymap("cz")
         localed_wrapper.set_keymap("cz", convert=True)
         localed_wrapper.convert_keymap("cz")
@@ -66,7 +66,7 @@ class LocaledWrapperTestCase(unittest.TestCase):
         mocked_localed_proxy.X11Options = "grp:alt_shift_toggle,grp:ctrl_alt_toggle"
         assert localed_wrapper.keymap == \
             "cz"
-        assert localed_wrapper.layouts_variants == \
+        assert localed_wrapper.get_layouts_variants() == \
             ["cz (qwerty)", "fi", "us (euro)", "fr"]
         assert localed_wrapper.options == \
             ["grp:alt_shift_toggle", "grp:ctrl_alt_toggle"]
@@ -77,7 +77,7 @@ class LocaledWrapperTestCase(unittest.TestCase):
         mocked_localed_proxy.X11Options = ""
         assert localed_wrapper.keymap == ""
         assert localed_wrapper.options == []
-        assert localed_wrapper.layouts_variants == []
+        assert localed_wrapper.get_layouts_variants() == []
 
     @patch("pyanaconda.modules.localization.localed.SystemBus")
     @patch("pyanaconda.modules.localization.localed.LOCALED")
@@ -182,7 +182,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
         mocked_localed_proxy.X11Layout = "cz,fi,us,fr"
         mocked_localed_proxy.X11Variant = "qwerty,,euro"
         mocked_localed_proxy.X11Options = "grp:alt_shift_toggle,grp:ctrl_alt_toggle"
-        assert localed_wrapper.layouts_variants == \
+        assert localed_wrapper.get_layouts_variants() == \
             ["cz (qwerty)", "fi", "us (euro)", "fr"]
         assert localed_wrapper.current_layout_variant == "cz (qwerty)"
         assert localed_wrapper.options == \
@@ -193,7 +193,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
         mocked_localed_proxy.X11Variant = ""
         mocked_localed_proxy.X11Options = ""
         assert localed_wrapper.options == []
-        assert localed_wrapper.layouts_variants == []
+        assert localed_wrapper.get_layouts_variants() == []
         assert localed_wrapper.current_layout_variant == ""
 
     @patch("pyanaconda.modules.localization.localed.SystemBus")
@@ -565,7 +565,7 @@ class CompositorLocaledWrapperTestCase(LocaledWrapperTestCase):
             mocked_localed_proxy.X11Variant = ",".join(map(lambda x: x[1], last_known_state))
             # loading the above values to local last known list
             # pylint: disable=pointless-statement
-            localed_wrapper.layouts_variants
+            localed_wrapper.get_layouts_variants()
 
             for k in compositor_state:
                 compositor_state[k] = Variant('s', compositor_state[k])

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -530,7 +530,7 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         # pylint: disable=no-member
         manager_mock.select_next_layout.assert_called_once()
 
-        manager_mock.layouts_variants = ["us", "es"]
+        manager_mock.get_layouts_variants.return_value = ["us", "es"]
         assert self.localization_interface.GetCompositorLayouts() == ["us", "es"]
 
         self.localization_interface.SetCompositorLayouts(["cz (qwerty)", "cn (mon_todo_galik)"],

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization_tasks.py
@@ -20,7 +20,7 @@ import tempfile
 import unittest
 from contextlib import contextmanager
 from textwrap import dedent
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, call, create_autospec, patch
 
 import pytest
 
@@ -36,6 +36,7 @@ from pyanaconda.modules.localization.installation import (
     write_vc_configuration,
     write_x_configuration,
 )
+from pyanaconda.modules.localization.localed import LocaledWrapper
 from pyanaconda.modules.localization.runtime import (
     ApplyKeyboardTask,
     AssignGenericKeyboardSettingTask,
@@ -536,12 +537,12 @@ class LocalizationTasksTestCase(unittest.TestCase):
 
     def test_write_x_configuration(self):
         """Test write_x_configuration_test."""
-        localed_wrapper = Mock()
+        localed_wrapper = create_autospec(LocaledWrapper)
         runtime_x_layouts = ["us (euro)"]
         runtime_options = []
         configured_x_layouts = ["cz (qwerty)"]
         configured_options = ["grp:alt_shift_toggle"]
-        localed_wrapper.layouts_variants = runtime_x_layouts
+        localed_wrapper.get_layouts_variants.return_value = runtime_x_layouts
         localed_wrapper.options = runtime_options
 
         def create_config(conf_dir):


### PR DESCRIPTION
This bug is causing crash on Workstation when different layout is set in compositor. The issue is that even when this is property the layouts_variants values are read from localed, so it could happen that the value changes between layout_variants calls which is causing crash.

This solution is a hotfix, we need to make visible that there is more logic when reading this value by changing this from property to function.

Resolves: [rhbz#2357836](https://bugzilla.redhat.com/show_bug.cgi?id=2357836)