### PR TITLE
Run restorecon after copying logs

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -163,6 +163,6 @@ class Boss(Service):
         :return: a list of installation tasks
         """
         return [
-            SetContextsTask(conf.target.system_root),
-            CopyLogsTask(conf.target.system_root)
+            CopyLogsTask(conf.target.system_root),
+            SetContextsTask(conf.target.system_root)
         ]

--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -50,7 +50,7 @@ class CopyLogsTask(Task):
 
         - Copy logs of all kinds, incl. ks scripts, journal dump, and lorax pkg list
         - Copy input kickstart file
-        - Autorelabel everything in the destination
+        - SELinux contexts are left as is (fixed by SetContextsTask)
         """
         self._copy_kickstart()
         self._copy_logs()
@@ -70,7 +70,6 @@ class CopyLogsTask(Task):
         self._copy_dnf_debugdata()
         self._copy_post_script_logs()
         self._dump_journal()
-        self._relabel_log_files()
 
     def _create_logs_directory(self):
         """Create directory for Anaconda logs on the install target"""
@@ -144,15 +143,6 @@ class CopyLogsTask(Task):
         else:
             log.warning("Input kickstart will not be saved to the installed system due to the "
                         "nosave option.")
-
-    def _relabel_log_files(self):
-        """Relabel the anaconda logs.
-
-        The files we've just copied could be incorrectly labeled, like hawkey.log:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1885772
-        """
-        if not restorecon([TARGET_LOG_DIR], root=self._sysroot, skip_nonexistent=True):
-            log.error("Log file contexts were not restored because restorecon was not installed.")
 
     def _copy_file_to_sysroot(self, src, dest):
         """Copy a file, if it exists, and set its access bits.

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -249,14 +249,14 @@ class BossInterfaceTestCase(unittest.TestCase):
         assert len(task_list) == 2
 
         task_path = task_list[0]
-        task_proxy = check_task_creation(task_path, publisher, SetContextsTask, 0)
-        task = task_proxy.implementation
-        assert task.name == "Set file contexts"
-
-        task_path = task_list[1]
-        task_proxy = check_task_creation(task_path, publisher, CopyLogsTask, 1)
+        task_proxy = check_task_creation(task_path, publisher, CopyLogsTask, 0)
         task = task_proxy.implementation
         assert task.name == "Copy installation logs"
+
+        task_path = task_list[1]
+        task_proxy = check_task_creation(task_path, publisher, SetContextsTask, 1)
+        task = task_proxy.implementation
+        assert task.name == "Set file contexts"
 
     def test_quit(self):
         """Test Quit."""


### PR DESCRIPTION
Before this change /var/log and /root/original-ks.cfg were not relabeled, running restorecon last avoid
regressing next time we copy a new file.
