### PR TITLE
spec: Properly strip objects and fix generation of debuginfo packages

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -80,9 +80,6 @@ Requires: anaconda-tui = %{version}-%{release}
 The anaconda package is a metapackage for the Anaconda installer.
 
 %package core
-# Since the binaries in anaconda-core are shell or Python scripts,
-# there's no need to generate a debuginfo package
-%define debug_package %{nil}
 Summary: Core of the Anaconda installer
 # core/signal.py is under MIT
 License: GPL-2.0-or-later AND MIT
@@ -176,7 +173,7 @@ system.
 
 %package live
 Summary: Live installation specific files and dependencies
-BuildArchitectures: noarch
+BuildArch: noarch
 BuildRequires: desktop-file-utils
 # live installation currently implies a graphical installation
 Requires: anaconda-gui = %{version}-%{release}

--- a/rpmlint.toml
+++ b/rpmlint.toml
@@ -3,6 +3,7 @@
 Filters = [
     # Discard no-binary error for anaconda packages which cant be a noarch type
     'anaconda.x86_64: E: no-binary',
+    'anaconda-core-debuginfo.x86_64: E: no-binary',
     'anaconda-install-env-deps.x86_64: E: no-binary',
     'anaconda-install-img-deps.x86_64: E: no-binary',
     # Discard explicite library dependencies


### PR DESCRIPTION
Originally filed here: https://src.fedoraproject.org/rpms/anaconda/pull-request/232

But also submitting upstream since this package doesn't follow the rules for [spec file canonicity](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_spec_maintenance_and_canonicity).

TL;DR: The current packaging is wrong, it disables generation of debuginfo packages for the entire package, which also causes no debuginfo to be stripped from any ELF objects shipped by anaconda and any of its subpackages.

Additionally, `BuildArchitectures` seems to be an undocumented alias of `BuildArch` - just use the canonical and documented form.
