### PR TITLE
Add mesa-vulkan-drivers as a dependency

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -272,10 +272,11 @@ Requires: gnome-kiosk
 Requires: gnome-remote-desktop
 # needed to generate RDP certs at runtime
 Requires: openssl
-# needed by GNOME kiosk but not declared a as explicit dep,
-# instead expected to be declared like this according to the
-# maintainers
+# the mesa packages are needed by GNOME kiosk but not declared as explicit dependency,
+# instead expected to be declared like this for image creation purposes,
+# according to the GNOME kiosk maintainers
 Requires: mesa-dri-drivers
+Requires: mesa-vulkan-drivers
 Requires: brltty
 Requires: python3-pam
 # dependencies for rpm-ostree payload module


### PR DESCRIPTION
We had to do this during the initial Wayland porting work already for mesa-dri-drivers but it looks like we now need to also add mesa-vulkan-drivers or else the GNOME kiosk Wayland session will crash on the boot.iso with mesa-25.0.3 in some scenarios (such as virtio GPU using VMs without 3D acceleration).

For more details see:
https://bugzilla.redhat.com/show_bug.cgi?id=2357471 https://pagure.io/fedora-qa/blocker-review/issue/1836

(cherry picked from commit 6979e7f7a6352b50d2ffc258365875535222ebbd)