### PR TITLE
infra: use `dnf install --allowerasing` instead of `dnf swap` for systemd

### DIFF
--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -27,7 +27,7 @@ COPY ["anaconda.spec.in", "/root/"]
 
 # Replace standalone systemd package with systemd as these are conflicting
 RUN set -ex; \
-    dnf swap -y systemd-standalone-sysusers systemd
+    dnf install -y systemd --allowerasing
 
 # Prepare environment and install build dependencies
 RUN set -ex; \


### PR DESCRIPTION
Replaced the `dnf swap` command with `dnf install -y systemd --allowerasing` to ensure smoother handling of package conflicts. The previous swap approach was insufficient in resolving dependencies cleanly in some environments.

