### PR TITLE
pyanaconda: storage: efi: never try to decode utf8 when calling efibootmgr

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -250,6 +250,7 @@ def _run_program(argv, root='/', stdin=None, stdout=None, env_prune=None,
 
 def execWithRedirect(command, argv, stdin=None, stdout=None, root='/',
                      env_prune=None, env_add=None, log_output=True, binary_output=False,
+                     replace_utf_decode_errors=False,
                      do_preexec=True):
     """ Run an external program and redirect the output to a file.
 
@@ -260,6 +261,7 @@ def execWithRedirect(command, argv, stdin=None, stdout=None, root='/',
         :param root: The directory to chroot to before running command.
         :param env_prune: environment variable to remove before execution
         :param env_add: environment variables added for the execution
+        :param replace_utf_decode_errors: whether to ignore decode errors
         :param log_output: whether to log the output of command
         :param binary_output: whether to treat the output of command as binary data
         :param do_preexec: whether to use a preexec_fn for subprocess.Popen
@@ -269,6 +271,7 @@ def execWithRedirect(command, argv, stdin=None, stdout=None, root='/',
     return _run_program(argv, stdin=stdin, stdout=stdout, root=root,
                         env_prune=env_prune, env_add=env_add,
                         log_output=log_output, binary_output=binary_output,
+                        replace_utf_decode_errors=replace_utf_decode_errors,
                         do_preexec=do_preexec)[0]
 
 

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -80,6 +80,10 @@ class EFIBase:
         if "root" not in kwargs:
             kwargs["root"] = conf.target.system_root
 
+        # Add replace_utf_decode_errors=True to kwargs
+        # to avoid decoding errors with non-utf8 characters
+        kwargs["replace_utf_decode_errors"] = True
+
         return exec_func("efibootmgr", list(args), **kwargs)
 
     @property
@@ -111,9 +115,7 @@ class EFIBase:
                 self._add_single_efi_boot_target(parent)
 
     def remove_efi_boot_target(self):
-        # FIXME: Stop using replace_utf_decode_errors=True once
-        # https://github.com/rhboot/efibootmgr/pull/221/ is merged
-        buf = self.efibootmgr(capture=True, replace_utf_decode_errors=True)
+        buf = self.efibootmgr(capture=True)
         for line in buf.splitlines():
             try:
                 (slot, _product) = line.split(None, 1)

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -1547,7 +1547,7 @@ class StorageTasksTestCase(unittest.TestCase):
         core_run_program.assert_any_call(
                 ['mount', '--rbind', '/mnt/sysimage', '/mnt/sysroot'],
                 stdin=None, stdout=None, root='/', env_prune=None, env_add=None,
-                log_output=True, binary_output=False, do_preexec=True)
+                log_output=True, binary_output=False, replace_utf_decode_errors=False, do_preexec=True)
 
     @patch_dbus_get_proxy
     @patch("pyanaconda.modules.storage.installation.conf")


### PR DESCRIPTION
There is not guarantee that efibootmgr output if utf8 only. Also stop linking the efibootmgr PR as possible fix, this is rejected by maintainers already.

Resolves: rhbz#2254801
