### PR TITLE
Rhel-9-enable-raid1-as-stag2-s390

### DIFF
--- a/pyanaconda/modules/storage/bootloader/zipl.py
+++ b/pyanaconda/modules/storage/bootloader/zipl.py
@@ -18,6 +18,8 @@
 import os
 import re
 
+from blivet.devicelibs import raid
+
 from pyanaconda.modules.storage.bootloader.base import BootLoader, BootLoaderArguments,\
     BootLoaderError
 from pyanaconda.core import util
@@ -38,7 +40,10 @@ class ZIPL(BootLoader):
     packages = ["s390utils-core"]
 
     # stage2 device requirements
-    stage2_device_types = ["partition"]
+    stage2_device_types = ["partition", "mdarray"]
+    stage2_raid_levels = [raid.RAID1]
+    stage2_raid_member_types = ["partition"]
+    stage2_raid_metadata = ["1.2"]
 
     @property
     def stage2_format_types(self):


### PR DESCRIPTION
With s390-tools 2.35.0 the zipl_helper tool gained the ability to
install the bootloader on a raid1 md devices [1]. Make a corresponding
change in the zipl class too.

[1] https://github.com/ibm-s390-linux/s390-tools/commit/3296d85e351a938cd8cea825622e5b602aaded6a

Resolves: [RHEL-21691](https://issues.redhat.com/browse/RHEL-21691)

Backport of https://github.com/rhinstaller/anaconda/pull/6289