### PR TITLE
Stop using distutils to compare kernel versions

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -100,6 +100,7 @@ Requires: python3-pwquality
 Requires: python3-systemd
 Requires: python3-productmd
 Requires: python3-dasbus >= %{dasbusver}
+Requires: python3-packaging
 Requires: flatpak-libs
 # dependencies for rpm-ostree payload module
 Requires: rpm-ostree >= %{rpmostreever}

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -21,7 +21,7 @@ import functools
 import os
 import stat
 
-from distutils.version import LooseVersion
+from packaging.version import parse as parse_version
 
 from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.util import mkdirChain
@@ -100,6 +100,6 @@ def sort_kernel_version_list(kernel_version_list):
 
 def _compare_versions(v1, v2):
     """Compare two version number strings."""
-    first_version = LooseVersion(v1)
-    second_version = LooseVersion(v2)
+    first_version = parse_version(v1)
+    second_version = parse_version(v2)
     return (first_version > second_version) - (first_version < second_version)


### PR DESCRIPTION
Use packaging instead.

Resolves: [RHEL-87358](https://issues.redhat.com/browse/RHEL-87358)

(cherry picked from commit 25493efeaa5b3845e1b835f08a4729c2ee30d726)