### PR TITLE
RHEL-9: tests: Fix outdated bootupd_run test

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -715,7 +715,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                 ),
                 call(
                     "ostree",
-                    ["admin", "instutil", "set-kargs", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
+                    ["admin", "instutil", "set-kargs", "--merge", "BOOTLOADER-ARGS", "root=FSTAB-SPEC", "rw"],
                     root=sysroot
                 )
             ])


### PR DESCRIPTION
This test was introduced by recent merge of https://github.com/rhinstaller/anaconda/pull/5760

where it was green, however, the test run on that PR was old and code has changed since then. New test introduced by the PR wasn't expecting that other commit ecf50659b0a953703828d4dc882f834e21f8f63e has changed call checked by this test.

This is just a test fix not changing code in any way.

Related: RHEL-40897