### PR TITLE
RHEL-10: Run restorecon after copying logs

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -163,6 +163,6 @@ class Boss(Service):
         :return: a list of installation tasks
         """
         return [
-            SetContextsTask(conf.target.system_root),
-            CopyLogsTask(conf.target.system_root)
+            CopyLogsTask(conf.target.system_root),
+            SetContextsTask(conf.target.system_root)
         ]

--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -50,7 +50,7 @@ class CopyLogsTask(Task):
 
         - Copy logs of all kinds, incl. ks scripts, journal dump, and lorax pkg list
         - Copy input kickstart file
-        - Autorelabel everything in the destination
+        - SELinux contexts are left as is (fixed by SetContextsTask)
         """
         self._copy_kickstart()
         self._copy_logs()
@@ -70,7 +70,6 @@ class CopyLogsTask(Task):
         self._copy_dnf_debugdata()
         self._copy_post_script_logs()
         self._dump_journal()
-        self._relabel_log_files()
 
     def _create_logs_directory(self):
         """Create directory for Anaconda logs on the install target"""
@@ -144,15 +143,6 @@ class CopyLogsTask(Task):
         else:
             log.warning("Input kickstart will not be saved to the installed system due to the "
                         "nosave option.")
-
-    def _relabel_log_files(self):
-        """Relabel the anaconda logs.
-
-        The files we've just copied could be incorrectly labeled, like hawkey.log:
-        https://bugzilla.redhat.com/show_bug.cgi?id=1885772
-        """
-        if not restorecon([TARGET_LOG_DIR], root=self._sysroot, skip_nonexistent=True):
-            log.error("Log file contexts were not restored because restorecon was not installed.")
 
     def _copy_file_to_sysroot(self, src, dest):
         """Copy a file, if it exists, and set its access bits.

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -246,14 +246,14 @@ class BossInterfaceTestCase(unittest.TestCase):
         assert len(task_list) == 2
 
         task_path = task_list[0]
-        task_proxy = check_task_creation(task_path, publisher, SetContextsTask, 0)
-        task = task_proxy.implementation
-        assert task.name == "Set file contexts"
-
-        task_path = task_list[1]
-        task_proxy = check_task_creation(task_path, publisher, CopyLogsTask, 1)
+        task_proxy = check_task_creation(task_path, publisher, CopyLogsTask, 0)
         task = task_proxy.implementation
         assert task.name == "Copy installation logs"
+
+        task_path = task_list[1]
+        task_proxy = check_task_creation(task_path, publisher, SetContextsTask, 1)
+        task = task_proxy.implementation
+        assert task.name == "Set file contexts"
 
     def test_quit(self):
         """Test Quit."""

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_copy_logs_task.py
@@ -23,11 +23,10 @@ from pyanaconda.modules.boss.installation import CopyLogsTask
 class CopyLogsTaskTest(unittest.TestCase):
     @patch("pyanaconda.modules.boss.installation.glob.glob")
     @patch("pyanaconda.modules.boss.installation.execWithRedirect")
-    @patch("pyanaconda.modules.boss.installation.restorecon")
     @patch("pyanaconda.modules.boss.installation.make_directories")
     @patch("pyanaconda.modules.boss.installation.conf")
     @patch("pyanaconda.modules.boss.installation.open_with_perm")
-    def test_run_all(self, open_mock, conf_mock, mkdir_mock, restore_mock, exec_wr_mock,
+    def test_run_all(self, open_mock, conf_mock, mkdir_mock, exec_wr_mock,
                      glob_mock):
         """Test the log copying task."""
         glob_mock.side_effect = [
@@ -76,12 +75,6 @@ class CopyLogsTaskTest(unittest.TestCase):
             ["-b"],
             stdout=log_file,
             log_output=False
-        )
-
-        restore_mock.assert_called_once_with(
-            ["/var/log/anaconda/"],
-            root="/somewhere",
-            skip_nonexistent=True
         )
 
     @patch("pyanaconda.modules.boss.installation.glob.glob")
@@ -214,28 +207,3 @@ class CopyLogsTaskTest(unittest.TestCase):
         exists_mock.assert_called_with("/more/data")
         copytree_mock.assert_not_called()
         chmod_mock.assert_not_called()
-
-    @patch("pyanaconda.core.util.execWithRedirect")
-    @patch("pyanaconda.modules.boss.installation.log")
-    def test_relabel_log_files(self, log_mock, exec_wr_mock):
-        """Test _relabel_log_files"""
-        task = CopyLogsTask("/somewhere")
-
-        exec_wr_mock.return_value = 0
-        task._relabel_log_files()
-        exec_wr_mock.assert_called_with(
-            "restorecon",
-            ["-ir", "/var/log/anaconda/"],
-            root="/somewhere"
-        )
-        log_mock.error.assert_not_called()
-
-        exec_wr_mock.reset_mock()
-        log_mock.reset_mock()
-        log_mock.error.reset_mock()
-
-        exec_wr_mock.side_effect = FileNotFoundError("Testing missing executable")
-        task._relabel_log_files()
-        exec_wr_mock.assert_called()
-        assert "restorecon was not installed" in str(log_mock.error.mock_calls)
-        # implied also: assert that the exception didn't escape


### PR DESCRIPTION
Before this change /var/log and /root/original-ks.cfg were not relabeled, running restorecon last avoid
regressing next time we copy a new file.

Resolves: https://issues.redhat.com/browse/RHEL-86788

(cherry picked from commit c4dca5c79f9b0306cc82dd5213ada5340745232a)

Backport of https://github.com/rhinstaller/anaconda/pull/6340
