### PR TITLE
infra: Update ubuntu-runners to 24.04

### DIFF
--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   infra-check:
     if: contains(github.event.pull_request.labels.*.name, 'infrastructure')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Infra tags in commit messages
 
     steps:
@@ -74,7 +74,7 @@ jobs:
           fi
 
   infra-reload-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Templates match results
 
     steps:

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   infra-reload-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Templates match results
 
     steps:
@@ -61,7 +61,7 @@ jobs:
           done
 
   infra-template-master-match-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Compare templates files with master branch
     if: github.event.pull_request.base.ref != 'main'
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Configuration of the documentation build process
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.9"
 


### PR DESCRIPTION
The Ubuntu 20.04 was retired on 2025-04-15 so these workflows don't work now.