### PR TITLE
RHEL-10: infra: Update ubuntu-runners to 24.04

### DIFF
--- a/.github/workflows/autolabel.yml
+++ b/.github/workflows/autolabel.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   add-label:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Add labels
         uses: actions/labeler@v5

--- a/.github/workflows/build-image.yml.j2
+++ b/.github/workflows/build-image.yml.j2
@@ -6,7 +6,7 @@
 # --live
 # --updates.img
 #
-# If none of these is present, --boot-iso is assumed.
+# If none of these is present, --boot.iso is assumed.
 # If more are present at once, all variants are built.
 #
 # To use webui on boot.iso, add also:

--- a/.github/workflows/container-rebuild-action.yml.j2
+++ b/.github/workflows/container-rebuild-action.yml.j2
@@ -42,7 +42,7 @@ permissions:
 jobs:
   refresh-container:
     name: Refresh anaconda container
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: quay.io
     strategy:
       fail-fast: false

--- a/.github/workflows/infra-check.yml
+++ b/.github/workflows/infra-check.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   commit-message-check:
     if: contains(github.event.pull_request.labels.*.name, 'infrastructure') && github.event.pull_request.merged != 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Infra tags in commit messages
 
     steps:

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -192,7 +192,7 @@ jobs:
         working-directory: ./kickstart-tests
         run: |
           LAUNCH_ARGS=$(scripts/generate-launch-args.py ${{ needs.pr-info.outputs.comment_args }} \
-             --branch ${{ needs.pr-info.outputs.target_branch }} ) || RC=$?
+             --branch ${{ needs.pr-info.outputs.target_branch }} --anaconda-pr ) || RC=$?
           if [ -z ${RC} ] || [ ${RC} == 0 ]; then
             echo "Generated launch arguments: $LAUNCH_ARGS"
           else

--- a/.github/workflows/push-tests.yml.j2
+++ b/.github/workflows/push-tests.yml.j2
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Clone repository

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release-note-check:
     if: contains(github.event.pull_request.labels.*.name, 'release note required')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Release notes present
 
     steps:

--- a/.github/workflows/template-check.yml
+++ b/.github/workflows/template-check.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   infra-reload-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Templates match results
 
     steps:
@@ -61,7 +61,7 @@ jobs:
           done
 
   infra-template-master-match-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Compare templates files with master branch
     if: github.event.pull_request.base.ref != 'main'
 

--- a/.github/workflows/tests-daily.yml
+++ b/.github/workflows/tests-daily.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
@@ -80,7 +80,7 @@ jobs:
           path: test-logs/*
 
   rpm-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'

--- a/.github/workflows/tests-daily.yml.j2
+++ b/.github/workflows/tests-daily.yml.j2
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
@@ -83,7 +83,7 @@ jobs:
           path: test-logs/*
 
   rpm-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   rpm-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -99,7 +99,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   rpm-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -1,4 +1,4 @@
-{% if distro_release == "rawhide" %}
+{% if distro_name == "fedora" %}
 # This workflow checks if the PR affects Anaconda (changes to pyanaconda folder),
 # polls the packit COPR until it has the current PR version
 # available, and then test-triggers an "anaconda PR" scenario.
@@ -19,11 +19,11 @@ on:
       - 'data/conf.d/**/'
       - 'data/profile.d/**'
       - 'po/l10n-config.mk'
-    branches:
-      - 'main'
+    branches: [ main, fedora-* ]
+
 jobs:
   trigger:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
     environment: gh-cockpituous
     container: registry.fedoraproject.org/fedora:40
@@ -50,8 +50,8 @@ jobs:
           COPR_NAME="${{ github.event.pull_request.base.user.login }}-${{ github.event.pull_request.base.repo.name }}-${{ github.event.number }}"
           for _ in $(seq 60); do
               sleep 60;
-              if dnf copr enable -y packit/$COPR_NAME fedora-rawhide-x86_64 &&
-                 out=$(dnf info --refresh --repo='copr:*anaconda*' --releasever=rawhide anaconda) &&
+              if dnf copr enable -y packit/$COPR_NAME {$ distro_name $}-{$ distro_release $}-x86_64 &&
+                 out=$(dnf info --refresh --repo='copr:*anaconda*' --releasever={$ distro_release $} anaconda) &&
                  stamp=$(echo "$out" | awk '/^Release/ { split($3, v, "."); print substr(v[2], 0, 14)}' | head -1) &&
                  [ "$stamp" -gt "$PUSH_TIME" ]; then
                   exit 0
@@ -64,5 +64,7 @@ jobs:
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
-          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
+          TEST_OS="{$ distro_name $}-{$ distro_release $}-boot"
+          bots/tests-trigger --force --repo ${{ github.repository }} ${{ github.event.number }} $TEST_OS/anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
+          bots/tests-trigger --force --repo ${{ github.repository }} ${{ github.event.number }} $TEST_OS/efi-anaconda-pr-${{ github.event.number }}@rhinstaller/anaconda-webui
 {% endif %}

--- a/.packit.yml
+++ b/.packit.yml
@@ -13,6 +13,7 @@ downstream_package_name: anaconda
 
 files_to_sync:
   - rpmlint.toml
+  - .packit.yml
 
 srpm_build_deps:
   - automake

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -6,6 +6,7 @@ downstream_package_name: anaconda
 
 files_to_sync:
   - rpmlint.toml
+  - .packit.yml
 
 srpm_build_deps:
   - automake
@@ -46,7 +47,8 @@ jobs:
   - job: propose_downstream
     trigger: release
     packages: [anaconda-fedora]
-    dist_git_branches: main
+    dist_git_branches:
+      - main
 
   - job: tests
     trigger: pull_request
@@ -77,9 +79,16 @@ jobs:
   - job: propose_downstream
     trigger: release
     packages: [anaconda-fedora]
-    dist_git_branches: f{$ distro_release $}
+    dist_git_branches:
+      - f{$ distro_release $}
 
   - job: tests
+    trigger: pull_request
+    packages: [anaconda-fedora]
+    targets:
+      - fedora-{$ distro_release $}
+
+  - job: copr_build
     trigger: pull_request
     packages: [anaconda-fedora]
     targets:
@@ -92,7 +101,7 @@ jobs:
       - fedora-{$ distro_release $}
     branch: fedora-{$ distro_release $}
     owner: "@rhinstaller"
-    project: Anaconda-devel
+    project: Anaconda
     preserve_project: True
     additional_repos:
       - "copr://@storage/blivet-daily"
@@ -109,4 +118,39 @@ jobs:
     packages: [anaconda-centos]
     dist_git_branches: c{$ distro_release $}s
 
+{% endif %}
+{% if distro_name == "fedora" %}
+  - job: koji_build
+    trigger: commit
+    packages: [anaconda-fedora]
+    sidetag_group: anaconda-releases
+    dist_git_branches:
+      - fedora-development
+    allowed_committers:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+      - packit
+    allowed_pr_authors:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+      - packit
+
+  - job: bodhi_update
+    trigger: koji_build
+    packages: [anaconda-fedora]
+    sidetag_group: anaconda-releases
+    dependencies:
+      - anaconda-webui
+    dist_git_branches:
+      - fedora-development
+    allowed_builders:
+      - m4rtink
+      - kkoukiou
+      - rvykydal
+      - jkonecny
+      - packit
 {% endif %}

--- a/branch-config.mk.j2
+++ b/branch-config.mk.j2
@@ -31,7 +31,6 @@ L10N_DIR ?= main
 BASE_CONTAINER ?= registry.fedoraproject.org/fedora:rawhide
 
 # COPR repo for use in container builds.
-# Can be @rhinstaller/Anaconda for main, or @rhinstaller/Anaconda-devel for branched Fedora.
 COPR_REPO ?= \@rhinstaller/Anaconda
 
 {% elif distro_name == "fedora" %}
@@ -39,7 +38,7 @@ COPR_REPO ?= \@rhinstaller/Anaconda
 GIT_BRANCH ?= fedora-{$ distro_release $}
 L10N_DIR ?= f{$ distro_release $}
 BASE_CONTAINER ?= registry.fedoraproject.org/fedora:{$ distro_release $}
-COPR_REPO ?= \@rhinstaller/Anaconda-devel
+COPR_REPO ?= \@rhinstaller/Anaconda
 
 {% elif distro_name == "rhel" and distro_release != 10 %}
 

--- a/dockerfile/anaconda-iso-creator/lorax-build.j2
+++ b/dockerfile/anaconda-iso-creator/lorax-build.j2
@@ -38,7 +38,7 @@ lorax -p Fedora -v "$VERSION_ID" -r "$VERSION_ID" \
 {% if distro_release == "rawhide" %}
       --volid Fedora-S-dvd-x86_64-rawh \
 {% else %}
-      --volid Fedora-S-dvd-x86_64-f{$ distro_release $} \
+      --volid Fedora-S-dvd-x86_64-{$ distro_release $} \
 {% endif %}
       -s http://dl.fedoraproject.org/pub/fedora/linux/development/{$ distro_release $}/Everything/x86_64/os/ \
 {% elif distro_name == "rhel" and distro_release == 10 %}

--- a/dracut/kickstart_version.py.j2
+++ b/dracut/kickstart_version.py.j2
@@ -8,8 +8,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 # Public License for more details.  You should have received a copy of the
 # GNU General Public License along with this program; if not, write to the
+{% if distro_name == "rhel" and distro_release in (9, 10) %}
 # Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+{% else %}
+# Free Software Foundation, Inc., 31 Milk Street #960789 Boston, MA
+# 02196 USA.  Any Red Hat trademarks that are incorporated in the
+{% endif %}
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.

--- a/pyanaconda/core/kickstart/version.py.j2
+++ b/pyanaconda/core/kickstart/version.py.j2
@@ -11,8 +11,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 # Public License for more details.  You should have received a copy of the
 # GNU General Public License along with this program; if not, write to the
+{% if distro_name == "rhel" and distro_release in (9, 10) %}
 # Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+{% else %}
+# Free Software Foundation, Inc., 31 Milk Street #960789 Boston, MA
+# 02196 USA.  Any Red Hat trademarks that are incorporated in the
+{% endif %}
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.


### PR DESCRIPTION
The Ubuntu 20.04 was retired on 2025-04-15 so these workflows don't work now.