### PR TITLE
infra: Template FSF address change on rhel-{9,10}

### DIFF
--- a/dracut/kickstart_version.py.j2
+++ b/dracut/kickstart_version.py.j2
@@ -8,8 +8,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 # Public License for more details.  You should have received a copy of the
 # GNU General Public License along with this program; if not, write to the
+{% if distro_name == "rhel" and distro_release in (9, 10) %}
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+{% else %}
 # Free Software Foundation, Inc., 31 Milk Street #960789 Boston, MA
 # 02196 USA.  Any Red Hat trademarks that are incorporated in the
+{% endif %}
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.

--- a/pyanaconda/core/kickstart/version.py.j2
+++ b/pyanaconda/core/kickstart/version.py.j2
@@ -11,8 +11,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
 # Public License for more details.  You should have received a copy of the
 # GNU General Public License along with this program; if not, write to the
+{% if distro_name == "rhel" and distro_release in (9, 10) %}
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+{% else %}
 # Free Software Foundation, Inc., 31 Milk Street #960789 Boston, MA
 # 02196 USA.  Any Red Hat trademarks that are incorporated in the
+{% endif %}
 # source code or documentation are not subject to the GNU General Public
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.


### PR DESCRIPTION
The address change will not happen now on RHEL-9 and RHEL-10 as this might broke the checks there. So to make it consistent with the rest of the code let's template the address too.

This will resolve our template-check workflow for rhel-10 branch.