### PR TITLE
infra: Better name for kickstart test run log bundles

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -331,11 +331,19 @@ jobs:
         run:
           sudo chown -R github:github .
 
+      - name: Construct image description
+        id: kstest_run_description
+        run: |
+          set -eux
+          pr_num="${{ github.event.issue.number }}"
+          timestamp=$(date +'%Y-%m-%d_%H:%M:%S')
+          echo "image_description=pr$pr_num-$timestamp-${{ needs.pr-info.outputs.sha }}" >> $GITHUB_OUTPUT
+
       - name: Collect logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: 'logs'
+          name: kstest_logs_${{ steps.kstest_run_description.outputs.image_description }}
           # skip the /anaconda subdirectories, too large
           path: |
             kickstart-tests/data/logs/kstest*.log

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -325,11 +325,19 @@ jobs:
         run:
           sudo chown -R github:github .
 
+      - name: Construct image description
+        id: kstest_run_description
+        run: |
+          set -eux
+          pr_num="${{ github.event.issue.number }}"
+          timestamp=$(date +'%Y-%m-%d_%H:%M:%S')
+          echo "image_description=pr$pr_num-$timestamp-${{ needs.pr-info.outputs.sha }}" >> $GITHUB_OUTPUT
+
       - name: Collect logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: 'logs'
+          name: kstest_logs_${{ steps.kstest_run_description.outputs.image_description }}
           # skip the /anaconda subdirectories, too large
           path: |
             kickstart-tests/data/logs/kstest*.log


### PR DESCRIPTION
Instead of just "logs.zip", lets name the log bundles based on the PR number, timestamp and branch SHA.

This way it should be much easier to make sense of downloaded log bundles from kickstart test runs on various PRs.