### PR TITLE
RHEL-9: Sort RPM versions via rpm.labelCompare() and not via packaging.version.LegacyVersion()

### DIFF
--- a/pyanaconda/core/payload.py
+++ b/pyanaconda/core/payload.py
@@ -15,11 +15,17 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from functools import cmp_to_key
 from urllib.parse import quote, unquote
+
+import rpm
 
 from pyanaconda.core.i18n import _
 from pyanaconda.core.regexes import URL_PARSE
 from pyanaconda.core.util import ensure_str
+
+
+rpm_version_key = cmp_to_key(rpm.labelCompare)
 
 
 def parse_nfs_url(nfs_url):

--- a/pyanaconda/modules/payloads/base/utils.py
+++ b/pyanaconda/modules/payloads/base/utils.py
@@ -17,16 +17,14 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
-import functools
 import os
 import stat
-
-from distutils.version import LooseVersion
 
 from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.util import mkdirChain
 
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.payload import rpm_version_key
 log = get_module_logger(__name__)
 
 
@@ -95,11 +93,4 @@ def get_dir_size(directory):
 
 def sort_kernel_version_list(kernel_version_list):
     """Sort the given kernel version list."""
-    kernel_version_list.sort(key=functools.cmp_to_key(_compare_versions))
-
-
-def _compare_versions(v1, v2):
-    """Compare two version number strings."""
-    first_version = LooseVersion(v1)
-    second_version = LooseVersion(v2)
-    return (first_version > second_version) - (first_version < second_version)
+    kernel_version_list.sort(key=rpm_version_key)

--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -20,7 +20,6 @@ gi.require_version("BlockDev", "2.0")
 from gi.repository import BlockDev as blockdev
 
 from collections import defaultdict
-from distutils.version import LooseVersion
 
 from blivet import arch, util
 from blivet.devicefactory import get_device_type
@@ -34,6 +33,7 @@ from pyanaconda.core.constants import productName, STORAGE_REFORMAT_BLOCKLIST, \
     STORAGE_LUKS2_MIN_RAM, STORAGE_ROOT_DEVICE_TYPES, STORAGE_REQ_PARTITION_SIZES, \
     STORAGE_MUST_NOT_BE_ON_ROOT
 from pyanaconda.core.i18n import _
+from pyanaconda.core.payload import rpm_version_key
 from pyanaconda.core.storage import DEVICE_TEXT_MAP
 from pyanaconda.modules.storage.platform import platform
 
@@ -259,7 +259,7 @@ def _check_opal_firmware_kernel_version(detected_version, required_version):
     """
     try:
         if detected_version and required_version:
-            return LooseVersion(detected_version) >= LooseVersion(required_version)
+            return rpm_version_key(detected_version) >= rpm_version_key(required_version)
     except Exception as e:  # pylint: disable=broad-except
         log.warning("Couldn't check the firmware kernel version: %s", str(e))
 


### PR DESCRIPTION
Packaging 22+ removed the long-deprecated packaging.version.LegacyVersion class. The packaging.version library is intended to parse Python (PEP 440) versions, not arbitrary versions and definitively not RPM versions.

Even if LegacyVersion was still available, it may produce incorrect results if the version contains ~, ^ or other characters with special meaning in RPM.

This assumes the Python rpm module is always available. If that assumption is wrong
the logic from rpm.labelCompare() needs to be reimplemented instead.

(cherry picked from commit 1742188518c9af7e3cd060a26f3a3b1e4cb61e91)

Resolves: [RHEL-87358](https://issues.redhat.com/browse/RHEL-87358)