### PR TITLE
pyanaconda: localization: adjust existing keyboard API to fetch all available keyboard

### DIFF
--- a/pyanaconda/modules/common/structures/keyboard_layout.py
+++ b/pyanaconda/modules/common/structures/keyboard_layout.py
@@ -29,6 +29,7 @@ class KeyboardLayout(DBusData):
     def __init__(self):
         self._layout_id = ""
         self._description = ""
+        self._is_common = False
         self._langs = []
 
     @property
@@ -48,6 +49,15 @@ class KeyboardLayout(DBusData):
     @description.setter
     def description(self, value: Str):
         self._description = value
+
+    @property
+    def is_common(self) -> bool:
+        """Return whether the layout is common."""
+        return self._is_common
+
+    @is_common.setter
+    def is_common(self, value: bool):
+        self._is_common = value
 
     @property
     def langs(self) -> List[Str]:

--- a/pyanaconda/modules/localization/localization_interface.py
+++ b/pyanaconda/modules/localization/localization_interface.py
@@ -107,24 +107,16 @@ class LocalizationInterface(KickstartModuleInterface):
         locale_data = self.implementation.get_locale_data(locale_id)
         return LocaleData.to_structure(locale_data)
 
-    def GetLocaleKeyboardLayouts(self, lang: Str) -> List[Structure]:
-        """Get keyboard layouts for the specified language.
+    def GetKeyboardLayouts(self) -> List[Structure]:
+        """Get keyboard layouts.
 
-        Returns a list of keyboard layouts available for the given language.
+        Returns a list of all available keyboard layouts.
         Each layout is represented as a `KeyboardLayout` structure.
 
-        Example output:
-        [
-            KeyboardLayout(layout_id="us", description="English (US)", langs=["English"]),
-            KeyboardLayout(layout_id="cz", description="Czech", langs=["Czech"]),
-            KeyboardLayout(layout_id="cz (qwerty)", description="Czech (QWERTY)", langs=["Czech"])
-        ]
-
-        :param lang: Language code string (e.g., "en_US.UTF-8")
         :return: List of `KeyboardLayout` structures
         """
         return KeyboardLayout.to_structure_list(
-            self.implementation.get_locale_keyboard_layouts(lang)
+            self.implementation.get_keyboard_layouts()
         )
 
     @property

--- a/tests/unit_tests/pyanaconda_tests/test_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/test_localization.py
@@ -85,7 +85,7 @@ class LangcodeLocaleParsingTests(unittest.TestCase):
         assert localization.get_locale_keyboards("en_US") == ["us"]
         assert localization.get_locale_keyboards("en_GB") == ["gb"]
 
-    def test_common_keyboard_layouts(self):
+    def test_keyboard_layouts(self):
         layouts = localization.get_common_keyboard_layouts()
         assert "us" in layouts
         assert "fr(oss)" in layouts


### PR DESCRIPTION
Previously, keyboard layouts were tied to the selected language. Users should be able to choose any available keyboard layout, regardless of language choice. Adjust the API to return all.

