### PR TITLE
infra: Replace dnf swap with --allowerasing

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -31,7 +31,7 @@ COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 
 # Replace standalone systemd package with systemd as these are conflicting
 RUN set -ex; \
-    dnf swap -y systemd-standalone-sysusers systemd
+    dnf install -y systemd --allowerasing
 
 # Prepare environment and install build dependencies
 RUN set -ex; \


### PR DESCRIPTION
The anaconda-ci container have a dnf swap but this may fail on some places using --allowerasing seems like a more robust way to handle this.