### PR TITLE
infra: Remove systemd dnf swap for ISO build

### DIFF
--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -30,10 +30,6 @@ FROM ${image}
 # see https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
-# Replace standalone systemd package with systemd as these are conflicting
-RUN set -ex; \
-    dnf swap -y systemd-standalone-sysusers systemd
-
 # Prepare environment and install build dependencies
 RUN set -ex; \
   dnf update -y; \


### PR DESCRIPTION
Lorax shouldn't depend on systemd directly so this swap shouldn't be required. Also, the dnf swap is causing failures on some systems.