### PR TITLE
tui: print newline after waiting

### DIFF
--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -78,7 +78,7 @@ class SummaryHub(TUIHub):
                 sys.stdout.flush()
                 time.sleep(1)
 
-            print('')
+            print('\n')
 
         return True
 


### PR DESCRIPTION
How to reproduce:

1. Choose text mode by putting `text` as first line in a kickstart file.
2. Observe two lines which are joined:

```
Starting automated install.Saving storage configuration...
```

It should look like this:

```
Starting automated install.
Saving storage configuration...
```
