### PR TITLE
infra: Fix kickstart test log bundle time stamp

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -336,7 +336,7 @@ jobs:
         run: |
           set -eux
           pr_num="${{ github.event.issue.number }}"
-          timestamp=$(date +'%Y-%m-%d_%H:%M:%S')
+          timestamp=$(date +'%Y-%m-%d_%H-%M-%S')
           echo "image_description=pr$pr_num-$timestamp-${{ needs.pr-info.outputs.sha }}" >> $GITHUB_OUTPUT
 
       - name: Collect logs

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -330,7 +330,7 @@ jobs:
         run: |
           set -eux
           pr_num="${{ github.event.issue.number }}"
-          timestamp=$(date +'%Y-%m-%d_%H:%M:%S')
+          timestamp=$(date +'%Y-%m-%d_%H-%M-%S')
           echo "image_description=pr$pr_num-$timestamp-${{ needs.pr-info.outputs.sha }}" >> $GITHUB_OUTPUT
 
       - name: Collect logs


### PR DESCRIPTION
Looks like GitHub does not like : so use -.