### PR TITLE
RHEL-10: Revert "s390x - enable raid1 as a stage2 device"

### DIFF
--- a/pyanaconda/modules/storage/bootloader/zipl.py
+++ b/pyanaconda/modules/storage/bootloader/zipl.py
@@ -18,8 +18,6 @@
 import os
 import re
 
-from blivet.devicelibs import raid
-
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
@@ -43,10 +41,7 @@ class ZIPL(BootLoader):
     packages = ["s390utils-core"]
 
     # stage2 device requirements
-    stage2_device_types = ["partition", "mdarray"]
-    stage2_raid_levels = [raid.RAID1]
-    stage2_raid_member_types = ["partition"]
-    stage2_raid_metadata = ["1.2"]
+    stage2_device_types = ["partition"]
 
     @property
     def stage2_format_types(self):


### PR DESCRIPTION
This reverts commit 6c26a56f533a720e3b508b3d7b38ecc9cbf72fd8.

After some testing we discovered that there are constrains for S390 ZIPL on partitions which are making this feature in Anaconda quite fragile.

The most problematic is requirement of having all partitions used by raid for /boot with the same offset. That is hard to achieve as Anaconda doesn't allow offset configuration right now.

Reverts: [RHEL-83924](https://issues.redhat.com/browse/RHEL-83924)