### PR TITLE
infra: Remove support for Fedora 42

### DIFF
--- a/.branch-variables.yml
+++ b/.branch-variables.yml
@@ -14,8 +14,6 @@ rawhide_fedora_version: 43 # number without quotation marks, or nothing if CI sh
 
 # List of all the branches which are currently supported and CI should be executed on these.
 supported_branches:
-  - fedora-42:
-    variant: "fedora"
   - rhel-9:
     variant: "rhel"
   - rhel-10:

--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', 'fedora-42', 'rhel-9', 'rhel-10']
+        branch: ['main', 'rhel-9', 'rhel-10']
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
     uses: ./.github/workflows/container-rebuild-action.yml

--- a/.github/workflows/l10n-po-update.yml
+++ b/.github/workflows/l10n-po-update.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        branch: ['main', 'fedora-42', 'rhel-9', 'rhel-10']
+        branch: ['main', 'rhel-9', 'rhel-10']
 
     steps:
       - name: Set up dependencies

--- a/.github/workflows/tests-daily.yml
+++ b/.github/workflows/tests-daily.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['main', 'fedora-42', 'rhel-9', 'rhel-10']
+        release: ['main', 'rhel-9', 'rhel-10']
         include:
           - release: 'main'
             target_branch: 'main'
@@ -52,9 +52,6 @@ jobs:
           #  target_branch: 'main'
           #  ci_tag: 'eln'
           #  build-args: '--build-arg=image=quay.io/fedoraci/fedora:eln-x86_64'
-          - release: 'fedora-42'
-            target_branch: 'fedora-42'
-            ci_tag: 'fedora-42'
           - release: 'rhel-9'
             target_branch: 'rhel-9'
             ci_tag: 'rhel-9'
@@ -93,14 +90,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['main', 'fedora-42', 'rhel-9', 'rhel-10']
+        release: ['main', 'rhel-9', 'rhel-10']
         include:
           - release: 'main'
             target_branch: 'main'
             ci_tag: 'main'
-          - release: 'fedora-42'
-            target_branch: 'fedora-42'
-            ci_tag: 'fedora-42'
           - release: 'rhel-9'
             target_branch: 'rhel-9'
             ci_tag: 'rhel-9'

--- a/.github/workflows/try-release-daily.yml
+++ b/.github/workflows/try-release-daily.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', 'fedora-42', 'rhel-9', 'rhel-10']
+        branch: ['main', 'rhel-9', 'rhel-10']
 
     steps:
       - name: Check out repo


### PR DESCRIPTION
It was already released some time ago so we can remove the support.

Also our try-release-daily workflow started to fail on this branch.