### PR TITLE
Revert "Allow to use an existing unlocked LUKS in one special case (#1772902)"

### DIFF
--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -416,7 +416,6 @@ def verify_unlocked_devices_have_key(storage, constraints, report_error, report_
         and d.format.exists
         and not d.format.has_key
         and d.children
-        and any(c.name == d.format.map_name for c in d.children)
     ]
 
     for dev in devices:


### PR DESCRIPTION
This reverts commit 1ba1c37546c4e1f22d7954692a267bf279a7f320.

The blivet bug which this feature relied on was fixed in 3.5: storaged-project/blivet#991
