### PR TITLE
Don't pass --sm-disable to gnome-kiosk

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -226,8 +226,7 @@ def do_startup_wl_actions(timeout, headless=False, headless_resolution=None):
         argv.extend(["--vt", "6"])
 
     # add the generic GNOME Kiosk invocation
-    argv.extend(["gnome-kiosk", "--sm-disable",
-                 "--wayland", "--no-x11",
+    argv.extend(["gnome-kiosk", "--wayland", "--no-x11",
                  "--wayland-display", constants.WAYLAND_SOCKET_NAME])
 
     # remote access needs gnome-kiosk to start in headless mode


### PR DESCRIPTION
See https://github.com/fedora-eln/eln/issues/251 . I'm pretty sure this argument has done nothing for a long time. It has only existed at all for the last several years if mutter is built with its X11 backend, and we specifically use the Wayland backend.

Anyhow, the argument was removed entirely from mutter in https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4438 , so this will break startup whenever Rawhide gets a mutter with that change. Startup is already broken on ELN because we started building mutter without the X11 backend on ELN, so the argument already doesn't exist there.