### PR TITLE
payload/rpm-ostree: Include program output in exception

### DIFF
--- a/pyanaconda/core/util.py
+++ b/pyanaconda/core/util.py
@@ -281,6 +281,26 @@ def execWithCapture(command, argv, stdin=None, root='/', env_prune=None, env_add
     return _run_program(argv, stdin=stdin, root=root, log_output=log_output, env_prune=env_prune,
                         env_add=env_add, filter_stderr=filter_stderr, do_preexec=do_preexec)[1]
 
+def execProgram(command, argv, stdin=None, root='/', env_prune=None, env_add=None,
+                log_output=True, filter_stderr=False, do_preexec=True):
+    """ Run an external program and capture standard out and err as well as the return code.
+
+        :param command: The command to run
+        :param argv: The argument list
+        :param stdin: The file object to read stdin from.
+        :param root: The directory to chroot to before running command.
+        :param env_prune: environment variable to remove before execution
+        :param env_add: environment variables added for the execution
+        :param log_output: Whether to log the output of command
+        :param filter_stderr: Whether stderr should be excluded from the returned output
+        :param do_preexec: whether to use the preexec function
+        :return: Tuple of the return code and the output of the command
+    """
+    argv = [command] + argv
+
+    return _run_program(argv, stdin=stdin, root=root, log_output=log_output, env_prune=env_prune,
+                        env_add=env_add, filter_stderr=filter_stderr, do_preexec=do_preexec)
+
 
 def execWithCaptureAsLiveUser(command, argv, stdin=None, root='/', log_output=True,
                               filter_stderr=False, do_preexec=True):

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -28,7 +28,7 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.glib import GError, Variant, create_new_context, format_size_full
 from pyanaconda.core.i18n import _
 from pyanaconda.core.path import make_directories, set_system_root
-from pyanaconda.core.util import execWithRedirect
+from pyanaconda.core.util import execProgram, execWithRedirect
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, DEVICE_TREE
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.installation import (
@@ -47,16 +47,17 @@ from gi.repository import Gio, OSTree, RpmOstree
 log = get_module_logger(__name__)
 
 
-def safe_exec_with_redirect(cmd, argv, successful_return_codes=(0,), **kwargs):
-    """Like util.execWithRedirect, but treat errors as fatal.
+def safe_exec_program(cmd, argv, successful_return_codes=(0,), **kwargs):
+    """Like util.execProgram, but treat errors as fatal.
 
     :raise: PayloadInstallationError if the call fails for any reason
     """
-    rc = execWithRedirect(cmd, argv, **kwargs)
+    rc, output = execProgram(cmd, argv, **kwargs)
 
     if rc not in successful_return_codes:
         raise PayloadInstallationError(
-            "The command '{}' exited with the code {}.".format(" ".join([cmd] + argv), rc)
+            "The command '{}' exited with the code {}:\n{}".format(" ".join([cmd] + argv), rc,
+            output)
         )
 
 
@@ -170,8 +171,8 @@ class PrepareOSTreeMountTargetsTask(Task):
         dest = os.path.realpath(dest)
 
         if bind_ro:
-            safe_exec_with_redirect("mount", ["--bind", src, src])
-            safe_exec_with_redirect("mount", ["--bind", "-o", "remount,ro", src, src])
+            safe_exec_program("mount", ["--bind", src, src])
+            safe_exec_program("mount", ["--bind", "-o", "remount,ro", src, src])
         else:
             # Create missing directories for user defined mount points
             if not os.path.exists(dest):
@@ -183,7 +184,7 @@ class PrepareOSTreeMountTargetsTask(Task):
                 bindopt = '--rbind'
             else:
                 bindopt = '--bind'
-            safe_exec_with_redirect("mount", [bindopt, src, dest])
+            safe_exec_program("mount", [bindopt, src, dest])
 
         self._internal_mounts.append(src if bind_ro else dest)
 
@@ -240,7 +241,7 @@ class PrepareOSTreeMountTargetsTask(Task):
         # Therefore we ignore error 65, since this is coming from
         # the payload itself and the actual execution of it was fine
 
-        safe_exec_with_redirect(
+        safe_exec_program(
             "systemd-tmpfiles", [
                 "--create",
                 "--boot",
@@ -377,7 +378,7 @@ class CopyBootloaderDataTask(Task):
             # doesn't, we're not on a UEFI system, so we don't want to copy the data.
             if not fname == 'efi' or is_efi and os.path.isdir(os.path.join(physboot, fname)):
                 log.info("Copying bootloader data: %s", fname)
-                safe_exec_with_redirect('cp', ['-r', '-p', srcpath, physboot])
+                safe_exec_program('cp', ['-r', '-p', srcpath, physboot])
 
             # Unfortunate hack, see https://github.com/rhinstaller/anaconda/issues/1188
             efi_grubenv_link = physboot + '/grub2/grubenv'
@@ -405,7 +406,7 @@ class InitOSTreeFsAndRepoTask(Task):
 
         This will create the repository as well.
         """
-        safe_exec_with_redirect(
+        safe_exec_program(
             "ostree",
             ["admin",
              "--sysroot=" + self._physroot,
@@ -582,12 +583,12 @@ class ConfigureBootloader(Task):
 
         set_kargs_args.append("rw")
 
-        safe_exec_with_redirect("ostree", set_kargs_args, root=self._sysroot)
+        safe_exec_program("ostree", set_kargs_args, root=self._sysroot)
 
         if arch.is_s390():
             # Deployment was done. Enable ostree's zipl support; this is how things are currently done in e.g.
             # https://github.com/coreos/coreos-assembler/blob/7d6fa376fc9f73625487adbb9386785bb09f1bb2/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml#L261
-            safe_exec_with_redirect(
+            safe_exec_program(
                 "ostree",
                 ["config",
                  "--repo=" + self._sysroot + "/ostree/repo",
@@ -607,7 +608,7 @@ class ConfigureBootloader(Task):
                 break
 
             # pylint: disable=possibly-used-before-assignment
-            safe_exec_with_redirect(
+            safe_exec_program(
                 "zipl",
                 ["-V",
                  "-i",
@@ -646,14 +647,14 @@ class DeployOSTreeTask(Task):
         if arch.is_s390():
             # Disable ostree's builtin zipl support; this is how things are currently done in e.g.
             # https://github.com/coreos/coreos-assembler/blob/7d6fa376fc9f73625487adbb9386785bb09f1bb2/src/osbuild-manifests/coreos.osbuild.s390x.mpp.yaml#L168
-            safe_exec_with_redirect(
+            safe_exec_program(
                 "ostree",
                 ["config",
                  "--repo=" + self._physroot + "/ostree/repo",
                  "set", "sysroot.bootloader", "none"]
             )
 
-        safe_exec_with_redirect(
+        safe_exec_program(
             "ostree",
             ["admin",
              "--sysroot=" + self._physroot,
@@ -675,13 +676,13 @@ class DeployOSTreeTask(Task):
             if not self._data.signature_verification_enabled:
                 args.append("--no-signature-verification")
 
-            safe_exec_with_redirect(
+            safe_exec_program(
                 "ostree",
                 args
             )
         else:
             log.info("ostree admin deploy starting")
-            safe_exec_with_redirect(
+            safe_exec_program(
                 "ostree",
                 ["admin",
                  "--sysroot=" + self._physroot,
@@ -692,7 +693,7 @@ class DeployOSTreeTask(Task):
 
         log.info("ostree config set sysroot.readonly true")
 
-        safe_exec_with_redirect(
+        safe_exec_program(
             "ostree",
             ["config",
              "--repo=" + self._physroot + "/ostree/repo",

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -74,10 +74,10 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
 
     @patch("os.path.exists")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.make_directories")
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     def test_setup_internal_bindmount(self, exec_mock, mkdir_mock, exists_mock):
         """Test OSTree mount target prepare task _setup_internal_bindmount"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
         exists_mock.return_value = True
 
         data = _make_config_data()
@@ -87,10 +87,10 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
 
     @patch("os.path.exists")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.make_directories")
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     def test_container_setup_internal_bindmount(self, exec_mock, mkdir_mock, exists_mock):
         """Test OSTree mount target prepare task _setup_internal_bindmount with ostreecontainer"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
         exists_mock.return_value = True
 
         data = _make_container_config_data()
@@ -154,24 +154,24 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         exec_mock.reset_mock()
         exists_mock.return_value = True
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.make_directories")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("os.path.exists", returns=True)
     def test_run_with_var(self, exist_mock, storage_mock, mkdir_mock, exec_mock):
         """Test OSTree mount target prepare task run() with /var"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         data = _make_config_data()
         self._check_run_with_var(data, exist_mock, storage_mock, mkdir_mock, exec_mock)
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.make_directories")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("os.path.exists", returns=True)
     def test_container_run_with_var(self, exist_mock, storage_mock, mkdir_mock, exec_mock):
         """Test OSTree mount target prepare task run() with /var with ostreecontainer"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         data = _make_container_config_data()
         self._check_run_with_var(data, exist_mock, storage_mock, mkdir_mock, exec_mock)
@@ -222,24 +222,24 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         assert len(exec_mock.mock_calls) == 19
         mkdir_mock.assert_called_once_with("/sysroot/var/lib")
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.make_directories")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("os.path.exists", returns=True)
     def test_run_without_var(self, exists_mock, storage_mock, mkdir_mock, exec_mock):
         """Test OSTree mount target prepare task run() without /var"""
-        exec_mock.side_effect = [0] * 7 + [0, 65] * 4 + [0] + [0] * 3
+        exec_mock.side_effect = [(0, "")] * 7 + [(0, ""), (65, "")] * 4 + [(0, "")] + [(0, "")] * 3
 
         data = _make_config_data()
         self._check_run_without_var(data, exists_mock, storage_mock, mkdir_mock, exec_mock)
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.make_directories")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("os.path.exists", returns=True)
     def test_container_run_without_var(self, exists_mock, storage_mock, mkdir_mock, exec_mock):
         """Test OSTree mount target prepare task run() without /var with ostreecontainer"""
-        exec_mock.side_effect = [0] * 7 + [0, 65] * 4 + [0] + [0] * 3
+        exec_mock.side_effect = [(0, "")] * 7 + [(0, ""), (65, "")] * 4 + [(0, "")] + [(0, "")] * 3
 
         data = _make_container_config_data()
         self._check_run_without_var(data, exists_mock, storage_mock, mkdir_mock, exec_mock)
@@ -289,22 +289,22 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         assert len(exec_mock.mock_calls) == 19
         mkdir_mock.assert_called_once_with("/sysroot/var/lib")
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.make_directories")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     def test_run_failed(self, storage_mock, mkdir_mock, exec_mock):
         """Test the failed OSTree mount target prepare task."""
-        exec_mock.return_value = 1
+        exec_mock.return_value = [1, ""]
 
         data = _make_config_data()
         self._check_run_failed(data, storage_mock, mkdir_mock, exec_mock)
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.make_directories")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     def test_container_run_failed(self, storage_mock, mkdir_mock, exec_mock):
         """Test the failed OSTree mount target prepare task with ostreecontainer."""
-        exec_mock.return_value = 1
+        exec_mock.return_value = [1, ""]
 
         data = _make_container_config_data()
         self._check_run_failed(data, storage_mock, mkdir_mock, exec_mock)
@@ -320,7 +320,7 @@ class PrepareOSTreeMountTargetsTaskTestCase(unittest.TestCase):
         with pytest.raises(PayloadInstallationError) as cm:
             task.run()
 
-        msg = "The command 'mount --bind /sysroot/usr /sysroot/usr' exited with the code 1."
+        msg = "The command 'mount --bind /sysroot/usr /sysroot/usr' exited with the code 1:\n"
         assert str(cm.value) == msg
 
 
@@ -392,13 +392,13 @@ class CopyBootloaderDataTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.isdir")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.listdir")
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.islink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.unlink")
     def test_run_noefi_noefidir_nolink(
             self, unlink_mock, islink_mock, exec_mock, listdir_mock, isdir_mock, storage_mock):
         """Test OSTree bootloader copy task run() with no EFI, no efi dir, and no links"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         bootloader_mock = storage_mock.get_proxy()
         bootloader_mock.IsEFI.return_value = False
@@ -418,13 +418,13 @@ class CopyBootloaderDataTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.isdir")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.listdir")
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.islink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.unlink")
     def test_run_noefi_efidir_link(
             self, unlink_mock, islink_mock, exec_mock, listdir_mock, isdir_mock, storage_mock):
         """Test OSTree bootloader copy task run() with no EFI but efi dir and link"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         bootloader_mock = storage_mock.get_proxy()
         bootloader_mock.IsEFI.return_value = False
@@ -444,13 +444,13 @@ class CopyBootloaderDataTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.isdir")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.listdir")
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.islink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.unlink")
     def test_run_efi_nolink(
             self, unlink_mock, islink_mock, exec_mock, listdir_mock, isdir_mock, storage_mock):
         """Test OSTree bootloader copy task run() with EFI, efi dir, and no links"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         bootloader_mock = storage_mock.get_proxy()
         bootloader_mock.IsEFI.return_value = True
@@ -471,13 +471,13 @@ class CopyBootloaderDataTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.isdir")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.listdir")
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.path.islink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.unlink")
     def test_run_noefi_notadir(
             self, unlink_mock, islink_mock, exec_mock, listdir_mock, isdir_mock, storage_mock):
         """Test OSTree bootloader copy task run() with non-directory source of data"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         bootloader_mock = storage_mock.get_proxy()
         bootloader_mock.IsEFI.return_value = False
@@ -496,10 +496,10 @@ class CopyBootloaderDataTaskTestCase(unittest.TestCase):
 
 
 class InitOSTreeFsAndRepoTaskTestCase(unittest.TestCase):
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     def test_run(self, exec_mock):
         """Test OSTree fs and repo init task"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         task = InitOSTreeFsAndRepoTask("/physroot")
         task.run()
@@ -684,14 +684,14 @@ class ChangeOSTreeRemoteTaskTestCase(unittest.TestCase):
 
 
 class ConfigureBootloaderTaskTestCase(unittest.TestCase):
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
     def test_btrfs_run(self, devdata_mock, storage_mock, symlink_mock, rename_mock, exec_mock):
         """Test OSTree bootloader config task, no BTRFS"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         proxy_mock = storage_mock.get_proxy()
         proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
@@ -728,14 +728,14 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                 root=sysroot
             )
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
     def test_nonbtrfs_run(self, devdata_mock, storage_mock, symlink_mock, rename_mock, exec_mock):
         """Test OSTree bootloader config task, no BTRFS"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
 
         proxy_mock = storage_mock.get_proxy()
         proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
@@ -773,14 +773,16 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.have_bootupd")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
     def test_bootupd_run(self, devdata_mock, storage_mock, symlink_mock, rename_mock, exec_mock,
-                         have_bootupd_mock):
+                         exec_redirect_mock, have_bootupd_mock):
         """Test OSTree bootloader config task, bootupd"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
+        exec_redirect_mock.return_value = 0
         have_bootupd_mock.return_value = True
 
         proxy_mock = storage_mock.get_proxy()
@@ -798,14 +800,17 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
 
             rename_mock.assert_not_called()
             symlink_mock.assert_not_called()
-            assert exec_mock.call_count == 2
-            exec_mock.assert_has_calls([
+            assert exec_redirect_mock.call_count == 1
+            exec_redirect_mock.assert_has_calls([
                 call(
                     "bootupctl",
                     ["backend", "install", "--auto", "--write-uuid", "--update-firmware",
                      "--device", "/dev/btldr-drv", "/"],
                     root=sysroot
-                ),
+                )
+            ])
+            assert exec_mock.call_count == 1
+            exec_mock.assert_has_calls([
                 call(
                     "ostree",
                     ["admin",
@@ -822,14 +827,16 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
 
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.have_bootupd")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
     def test_bootupd_run_with_leavebootorder(self, devdata_mock, storage_mock, symlink_mock,
-                                             rename_mock, exec_mock, have_bootupd_mock):
+                                             rename_mock, exec_mock,  exec_redirect_mock, have_bootupd_mock):
         """Test OSTree bootloader config task, bootupd"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
+        exec_redirect_mock.return_value = 0
         have_bootupd_mock.return_value = True
 
         proxy_mock = storage_mock.get_proxy()
@@ -847,14 +854,17 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
 
             rename_mock.assert_not_called()
             symlink_mock.assert_not_called()
-            assert exec_mock.call_count == 2
-            exec_mock.assert_has_calls([
+            assert exec_redirect_mock.call_count == 1
+            exec_redirect_mock.assert_has_calls([
                 call(
                     "bootupctl",
                     ["backend", "install", "--auto", "--write-uuid",
                      "--device", "/dev/btldr-drv", "/"],
                     root=sysroot
-                ),
+                )
+            ])
+            assert exec_mock.call_count == 1
+            exec_mock.assert_has_calls([
                 call(
                     "ostree",
                     ["admin",
@@ -869,13 +879,13 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                 )
             ])
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.conf")
     def test_dir_run(self, conf_mock, symlink_mock, rename_mock, exec_mock):
         """Test OSTree bootloader config task, dirinstall"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
         conf_mock.target.is_directory = True
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -897,10 +907,10 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
 
 
 class DeployOSTreeTaskTestCase(unittest.TestCase):
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     def test_run(self, exec_mock):
         """Test OSTree deploy task"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
         data = _make_config_data()
 
         task = DeployOSTreeTask(data=data, physroot="/sysroot")
@@ -914,10 +924,10 @@ class DeployOSTreeTaskTestCase(unittest.TestCase):
         ])
         # no need to mock RpmOstree.varsubst_basearch(), since "ref" won't change
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     def test_container_run(self, exec_mock):
         """Test OSTree deploy task ostreecontainer"""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
         data = _make_container_config_data()
 
         task = DeployOSTreeTask(data=data, physroot="/sysroot")
@@ -935,10 +945,10 @@ class DeployOSTreeTaskTestCase(unittest.TestCase):
         ])
         # no need to mock RpmOstree.varsubst_basearch(), since "ref" won't change
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     def test_container_run_with_no_stateroot(self, exec_mock):
         """Test OSTree deploy task ostreecontainer without stateroot."""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
         data = _make_container_config_data()
         data.stateroot = None
 
@@ -955,10 +965,10 @@ class DeployOSTreeTaskTestCase(unittest.TestCase):
                             "set", "sysroot.readonly", "true"])
         ])
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     def test_container_run_with_no_transport(self, exec_mock):
         """Test OSTree deploy task ostreecontainer without transport."""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
         data = _make_container_config_data()
         data.transport = None
 
@@ -975,10 +985,10 @@ class DeployOSTreeTaskTestCase(unittest.TestCase):
                             "set", "sysroot.readonly", "true"])
         ])
 
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execWithRedirect")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     def test_container_run_with_no_verification(self, exec_mock):
         """Test OSTree deploy task ostreecontainer without signature verification."""
-        exec_mock.return_value = 0
+        exec_mock.return_value = [0, ""]
         data = _make_container_config_data()
         data.signature_verification_enabled = False
 


### PR DESCRIPTION
The rpm-ostree container deployment path can fail for many reasons from networking to details in mount setup.

What we really want is a proper API with progress out of bootc/ostree; I will work on that at some point.

In the meantime though, just capture stderr on failure and include it in the payload installation error so people don't have to dig into `program.log` which is very obscure.

Signed-off-by: Colin Walters <walters@verbum.org>

Cherry-picked from: 7d40d850a3d6f717167995c8969c6b5999b0dfc0

Resolves: RHEL-83926

