### PR TITLE
 bootloader: efi: utilize grub2-common script for handling config file generation

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -143,6 +143,10 @@ Requires: python3-pid
 Requires: crypto-policies
 Requires: crypto-policies-scripts
 
+%ifnarch s390 s390x
+Requires: grub2-common >= 2.12-37
+%endif
+
 # required because of the rescue mode and RDP question
 Requires: anaconda-tui = %{version}-%{release}
 

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -103,7 +103,7 @@ class EFIBase:
             "-l", self.efi_dir_as_efifs_dir + self._efi_binary,  # pylint: disable=no-member
             root=conf.target.system_root
         )
-        if rc:
+        if rc != 0:
             raise BootLoaderError("Failed to set new efi boot target. This is most "
                                   "likely a kernel or firmware bug.")
 
@@ -191,27 +191,14 @@ class EFIGRUB(EFIBase, GRUB2):
         return "%s/%s" % (self.efi_config_dir, self._config_file)
 
     def write_config(self):
-        config_path = "%s%s" % (conf.target.system_root, self.efi_config_file)
+        rc = util.execWithRedirect(
+            "gen_grub_cfgstub",
+            [self.config_dir, self.efi_config_dir],
+            root=conf.target.system_root,
+        )
 
-        with open(config_path, "w") as fd:
-            grub_dir = self.config_dir
-            if self.stage2_device.format.type != "btrfs":
-                fs_uuid = self.stage2_device.format.uuid
-            else:
-                fs_uuid = self.stage2_device.format.vol_uuid
-
-            if fs_uuid is None:
-                raise BootLoaderError("Could not get stage2 filesystem UUID")
-
-            grub_dir = util.execWithCapture("grub2-mkrelpath", [grub_dir],
-                                            root=conf.target.system_root)
-            if not grub_dir:
-                raise BootLoaderError("Could not get GRUB directory path")
-
-            fd.write("search --no-floppy --fs-uuid --set=dev %s\n" % fs_uuid)
-            fd.write("set prefix=($dev)%s\n" % grub_dir)
-            fd.write("export $prefix\n")
-            fd.write("configfile $prefix/grub.cfg\n")
+        if rc != 0:
+            raise BootLoaderError("gen_grub_cfgstub script failed")
 
         super().write_config()
 


### PR DESCRIPTION
Our backend now executes the grub2-common shared script to generate
efi config files.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2327644