### PR TITLE
Don't pass --no-x11 to gnome-kiosk

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -226,8 +226,7 @@ def do_startup_wl_actions(timeout, headless=False, headless_resolution=None):
         argv.extend(["--vt", "6"])
 
     # add the generic GNOME Kiosk invocation
-    argv.extend(["gnome-kiosk", "--wayland", "--no-x11",
-                 "--wayland-display", constants.WAYLAND_SOCKET_NAME])
+    argv.extend(["gnome-kiosk", "--wayland", "--wayland-display", constants.WAYLAND_SOCKET_NAME])
 
     # remote access needs gnome-kiosk to start in headless mode
     if headless:


### PR DESCRIPTION
This is also gone when mutter is built without X11 support, as is now the case in Rawhide and ELN, and probably soon in EL 10. Don't backport this to earlier branches.