### PR TITLE
flatpak: Fix Flatpak source generation from DNF

### DIFF
--- a/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
+++ b/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
@@ -232,6 +232,7 @@ class FlatpakManager:
             return
 
         try:
+            # pylint: disable=assignment-from-none
             self._collection_location = self.get_source().download(self._flatpak_refs,
                                                                    self._download_location,
                                                                    progress)


### PR DESCRIPTION
Currently, the Flatpak source generation is using RepositorySourceMixin, however, this mixin class is not used everywhere and this code is failing for offline installation. The offline installation is using RepoPathSourceModule which don't have `repository` property, however, it is able to generate this structure with other API.

Use this API specifically for this type of source.

Forwardport of fix from https://github.com/rhinstaller/anaconda/pull/6440 back to Fedora.