### PR TITLE
Avoid buffer overflow with TIOCGWINSZ

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -65,8 +65,8 @@ def get_help_width():
         return DEFAULT_HELP_WIDTH
 
     try:
-        data = fcntl.ioctl(sys.stdout, termios.TIOCGWINSZ, '1234')
-        columns = int(struct.unpack('hh', data)[1])
+        data = fcntl.ioctl(sys.stdout, termios.TIOCGWINSZ, '12345678')
+        columns = int(struct.unpack('hhhh', data)[1])
     except (OSError, ValueError) as e:
         log.info("Unable to determine terminal width: %s", e)
         print("terminal size detection failed, using default width")


### PR DESCRIPTION
It has 4 bytes, not 2.

On Python 3.14+, the previous version raised SystemError:

    >>> from pyanaconda.argument_parsing import get_help_width
    ...
    >>> get_help_width()
    Traceback (most recent call last):
      File "<python-input-1>", line 1, in <module>
        get_help_width()
        ~~~~~~~~~~~~~~^^
      File "/usr/lib64/python3.14/site-packages/pyanaconda/argument_parsing.py", line 68, in get_help_width
        data = fcntl.ioctl(sys.stdout, termios.TIOCGWINSZ, '1234')
    SystemError: buffer overflow

See https://github.com/python/cpython/commit/c2eaeee3dc3306ca486b0377b07b1a957584b691

Fixes https://bugzilla.redhat.com/2370944

**Thank you** for your contribution!

Please check that your PR follows these rules:

* [x] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.

* [x] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.

* [ ] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.
  *If you don't know how, ask us for help!*

* [ ] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
  *If you don't know how, ask us for help!*
