### PR TITLE
Use os.get_terminal_size rather than ioctl magic

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -19,12 +19,8 @@
 DESCRIPTION = "Anaconda is the installation program used by Fedora, " \
               "Red Hat Enterprise Linux and some other distributions."
 
-import fcntl
 import itertools
 import os
-import struct
-import sys
-import termios
 from argparse import (
     SUPPRESS,
     Action,
@@ -65,9 +61,8 @@ def get_help_width():
         return DEFAULT_HELP_WIDTH
 
     try:
-        data = fcntl.ioctl(sys.stdout, termios.TIOCGWINSZ, '1234')
-        columns = int(struct.unpack('hh', data)[1])
-    except (OSError, ValueError) as e:
+        columns = os.get_terminal_size().columns
+    except OSError as e:
         log.info("Unable to determine terminal width: %s", e)
         print("terminal size detection failed, using default width")
         return DEFAULT_HELP_WIDTH


### PR DESCRIPTION
This is an alternate fix to https://github.com/rhinstaller/anaconda/pull/6447

On Python 3.14+, the previous version raised SystemError:

    >>> from pyanaconda.argument_parsing import get_help_width
    ...
    >>> get_help_width()
    Traceback (most recent call last):
      File "<python-input-1>", line 1, in <module>
        get_help_width()
        ~~~~~~~~~~~~~~^^
      File "/usr/lib64/python3.14/site-packages/pyanaconda/argument_parsing.py", line 68, in get_help_width
        data = fcntl.ioctl(sys.stdout, termios.TIOCGWINSZ, '1234')
    SystemError: buffer overflow

See https://github.com/python/cpython/commit/c2eaeee3dc3306ca486b0377b07b1a957584b691

Fixes https://bugzilla.redhat.com/2370944

Rather than the suggested shutil.get_terminal_size I use to lower-level function from os to support the original problem reporting.

**Thank you** for your contribution!

Please check that your PR follows these rules:

* [x] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.

* [x] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.

* [ ] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.
  *If you don't know how, ask us for help!*

* [ ] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
  *If you don't know how, ask us for help!*

---

Unlike https://github.com/rhinstaller/anaconda/pull/6447 this was not tested.