### PR TITLE
Avoid the multiprocessing forkserver method with dnf

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -652,9 +652,12 @@ class DNFManager:
         :param timeout: a time out of a failed process in seconds
         :raise PayloadInstallationError: if the installation fails
         """
-        queue = multiprocessing.Queue()
+        # SwigPyObjects are not picklable, so force the fork method
+        # On Python 3.14+, forkserver is the default (and it pickles)
+        context = multiprocessing.get_context(method="fork")
+        queue = context.Queue()
         display = TransactionProgress(queue)
-        process = multiprocessing.Process(
+        process = context.Process(
             target=self._run_transaction,
             args=(self._base, display)
         )


### PR DESCRIPTION
Fixes:

    Traceback (most recent call last):
      File "/usr/lib64/python3.14/site-packages/pyanaconda/core/threads.py", line 281, in run
        threading.Thread.run(self)
        ~~~~~~~~~~~~~~~~~~~~^^^^^^
      File "/usr/lib64/python3.14/threading.py", line 1023, in run
        self._target(*self._args, **self._kwargs)
        ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.14/site-packages/pyanaconda/modules/common/task/task.py", line 97, in _thread_run_callback
        self._task_run_callback()
        ~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/usr/lib64/python3.14/site-packages/pyanaconda/modules/common/task/task.py", line 110, in _task_run_callback
        self._set_result(self.run())
                         ~~~~~~~~^^
      File "/usr/lib64/python3.14/site-packages/pyanaconda/modules/payloads/payload/dnf/installation.py", line 281, in run
        self._dnf_manager.install_packages(self.report_progress)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.14/site-packages/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py", line 664, in install_packages
        process.start()
        ~~~~~~~~~~~~~^^
      File "/usr/lib64/python3.14/multiprocessing/process.py", line 121, in start
        self._popen = self._Popen(self)
                      ~~~~~~~~~~~^^^^^^
      File "/usr/lib64/python3.14/multiprocessing/context.py", line 224, in _Popen
        return _default_context.get_context().Process._Popen(process_obj)
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
      File "/usr/lib64/python3.14/multiprocessing/context.py", line 300, in _Popen
        return Popen(process_obj)
      File "/usr/lib64/python3.14/multiprocessing/popen_forkserver.py", line 35, in __init__
        super().__init__(process_obj)
        ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
      File "/usr/lib64/python3.14/multiprocessing/popen_fork.py", line 20, in __init__
        self._launch(process_obj)
        ~~~~~~~~~~~~^^^^^^^^^^^^^
      File "/usr/lib64/python3.14/multiprocessing/popen_forkserver.py", line 47, in _launch
        reduction.dump(process_obj, buf)
        ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.14/multiprocessing/reduction.py", line 60, in dump
        ForkingPickler(file, protocol).dump(obj)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
    TypeError: cannot pickle 'SwigPyObject' object

**Thank you** for your contribution!

Please check that your PR follows these rules:

* [x] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.

* [x] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.

* [ ] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.
  *If you don't know how, ask us for help!*

* [ ] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
  *If you don't know how, ask us for help!*
