### PR TITLE
anaconda-rpm: Dockerfile: install pocketlint via pip to avoid RPM dependency issues

### DIFF
--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -23,7 +23,7 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # The anaconda.spec.in is in the repository root. This file will be copied automatically here if
 # the build is invoked by Makefile.
-COPY ["anaconda.spec.in", "/root/"]
+COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 
 # Replace standalone systemd package with systemd as these are conflicting
 RUN set -ex; \
@@ -41,9 +41,8 @@ RUN set -ex; \
   'dnf5-command(copr)' \
   git \
   curl \
+  python3-pip \
   python3-polib \
-  # Requirement for translation-canary which is started during RPM build
-  python3-pocketlint \
   /usr/bin/xargs \
   rsync \
   rpm-build \
@@ -64,5 +63,8 @@ RUN set -ex; \
   rpmspec -q --buildrequires /tmp/anaconda.spec | xargs -d '\n' dnf install -y; \
   dnf clean all; \
   mkdir /anaconda
+
+RUN pip install --no-cache-dir --upgrade pip; \
+  pip install --no-cache-dir -r /root/requirements.txt
 
 WORKDIR /anaconda

--- a/dockerfile/anaconda-rpm/requirements.txt
+++ b/dockerfile/anaconda-rpm/requirements.txt
@@ -1,0 +1,11 @@
+# pip package install list
+# storing it as an independent file enables Dependabot to bump versions with noise and attention
+# silent updates of pylint and astroid usually cause breakages
+# for format details see https://pip.pypa.io/en/stable/reference/requirements-file-format/
+
+# unit tests of all kinds
+pocketlint  # translatable strings and translations, used by pylint and glade tests
+
+# pylint and its supporting libs
+pylint == 3.3.7
+astroid == 3.3.10


### PR DESCRIPTION
The python3-pocketlint RPM currently fails to install due to missing Python 3.13 dependencies in Rawhide. To work around this, remove the RPM and install pocketlint via pip instead.