### PR TITLE
tests/network: reorder filterwarnings to fix warning handling in test_sync_call_glib_in_thread

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/network/test_module_network_nm_client.py
@@ -1104,8 +1104,8 @@ class NMClientTestCase(unittest.TestCase):
         mainctx.pop_thread_default()
 
     # Promote all warnings to errors (rhbz#1931389)
-    @pytest.mark.filterwarnings("error")  # Promote all warnings to errors
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")  # But ignore DeprecationWarning
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")  # Ignore DeprecationWarning
+    @pytest.mark.filterwarnings("error")  # but fail on other warnings
     def test_sync_call_glib_in_thread(self):
         thread = threading.Thread(target = self.test_sync_call_glib)
         thread.start()


### PR DESCRIPTION
Since decorators apply bottom-up, placing "ignore::DeprecationWarning" before "error" ensures deprecation warnings are ignored while other warnings still cause test failures.

Note: docs can be found at https://docs.pytest.org/en/stable/how-to/capture-warnings.html#pytest-mark-filterwarnings
