### PR TITLE
infra: trigger-webui: we need to run the workflow on Fedora container

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
     environment: gh-cockpituous
+    container: registry.fedoraproject.org/fedora:rawhide
     # this polls for a COPR build, which can take long
     timeout-minutes: 120
 
@@ -41,6 +42,11 @@ jobs:
       # an unpredictable SHA; so instead, wait until COPR has a build which is
       # newer than the PR push time. This assumes that this workflow always runs earlier
       # than the COPR srpm build finishes.
+
+      - name: Install dependencies
+        run: |
+          dnf install -y git-core dnf-plugins-core gh
+
       - name: Wait for packit COPR build
         run: |
           set -ex

--- a/.github/workflows/trigger-webui.yml.j2
+++ b/.github/workflows/trigger-webui.yml.j2
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-24.04
     # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
     environment: gh-cockpituous
+    container: registry.fedoraproject.org/fedora:{$ distro_release $}
     # this polls for a COPR build, which can take long
     timeout-minutes: 120
 
@@ -35,6 +36,11 @@ jobs:
       # an unpredictable SHA; so instead, wait until COPR has a build which is
       # newer than the PR push time. This assumes that this workflow always runs earlier
       # than the COPR srpm build finishes.
+
+      - name: Install dependencies
+        run: |
+          dnf install -y git-core dnf-plugins-core gh
+
       - name: Wait for packit COPR build
         run: |
           set -ex


### PR DESCRIPTION
Because of the DNF dependency. This partially reverts 483801520bd5e6f567a6ffec19435097e642120f.
Install extra the gh command that we wanted to use.

