### PR TITLE
Fix a pair of error messages.

### DIFF
--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -539,9 +539,9 @@ def verify_lvm_destruction(storage, constraints, report_error, report_warning):
         if vg_name not in destroyed_vg_names:
             report_error(_(
                 "Selected disks {} contain volume group '{}' that also uses further unselected "
-                "disks. You must select or de-select all these disks as a set."
+                "disks. You must select or de-select all these disks as a set.")
                 .format(", ".join(disks), vg_name)
-            ))
+            )
 
 
 class StorageCheckerReport:

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -135,7 +135,8 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         bootloader_parts = [part for part in platform.partitions
                             if part.fstype in bootloader_types]
         if len(bootloader_parts) > 1:
-            raise StorageError(_("Multiple boot loader partitions required: %s"), bootloader_parts)
+            raise StorageError(_("Multiple boot loader partitions required: %s") %
+                               bootloader_parts)
         if not bootloader_parts:
             log.debug("No bootloader partition required")
             return False


### PR DESCRIPTION
The StorageError raised from _remove_bootloader_partitions() was not listing the partitions which were required.

Translation of the error message to select all or none of the disks in a particular volume group in verify_lvm_destruction() was not being substituted for the error message.  Fixed by substituting variables into the format string after the translation is looked up.

Resolves: INSTALLER-4142