### PR TITLE
Change formatting on some error messages.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Please check that your PR follows these rules:
 * [ ] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
   *If you don't know how, ask us for help!*
 
-* [ ] **RHEL** rules: If your PR is for a `rhel-*` branch, pay special attention to commit messages. Make sure **all** commit messages include a line linking the commit to a bug, such as `Resolves: RHEL-123456`. For more information, see [the complete rules](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html).
+* [ ] **RHEL** rules: If your PR is for a `rhel-*` branch, pay special attention to commit messages. Make sure **all** commit messages include a line linking the commit to a bug, such as `Resolves: RHEL-123456`. For more information, see [the complete rules](https://anaconda-installer.readthedocs.io/en/latest/developer/commit-log.html).
   *If you don't know how, ask us for help!*
 
 Don't forget - *if you don't know how, ask us for help!*

--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -58,8 +58,8 @@ def verify_root(storage, constraints, report_error, report_warning):
 
     if not root:
         report_error(_("You have not defined a root partition (/), "
-                       "which is required for installation of %s"
-                       " to continue.") % (get_product_name(),))
+                       "which is required for installation of %(prod_name)s "
+                       "to continue.") % {"prod_name": get_product_name()})
 
     if root and root.format.exists and root.format.mountable and root.format.mountpoint == "/" \
        and not root.format.is_empty:
@@ -349,7 +349,7 @@ def verify_swap_uuid(storage, constraints, report_error, report_warning):
                          "will be referred to by device path in "
                          "/etc/fstab, which is not ideal since device "
                          "paths can change under a variety of "
-                         "circumstances. "))
+                         "circumstances."))
 
 
 def verify_mountpoints_on_root(storage, constraints, report_error, report_warning):
@@ -538,9 +538,9 @@ def verify_lvm_destruction(storage, constraints, report_error, report_warning):
     for vg_name, disks in all_touched_disks_by_vg.items():
         if vg_name not in destroyed_vg_names:
             report_error(_(
-                "Selected disks {} contain volume group '{}' that also uses further unselected "
-                "disks. You must select or de-select all these disks as a set.")
-                .format(", ".join(disks), vg_name)
+                "Selected disks {disks} contain volume group '{vg}' that also uses further "
+                "unselected disks. You must select or de-select all these disks as a set.")
+                .format(disks=", ".join(disks), vg=vg_name)
             )
 
 

--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -135,8 +135,8 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
         bootloader_parts = [part for part in platform.partitions
                             if part.fstype in bootloader_types]
         if len(bootloader_parts) > 1:
-            raise StorageError(_("Multiple boot loader partitions required: %s") %
-                               bootloader_parts)
+            raise StorageError(_("Multiple boot loader partitions required: %(bootparts)s") %
+                               {"bootparts": bootloader_parts})
         if not bootloader_parts:
             log.debug("No bootloader partition required")
             return False


### PR DESCRIPTION
Push trailing whitepsaces on multi-line strings to the last line.

Remove a space at the end of a string.

Convert variable interpolation on these strings from ordered to
mapping to be friendlier to translations.

Update link to commit message conventions.  The page moved under a /developer/ subdirectory in the documentation.

This PR should be merged after https://github.com/rhinstaller/anaconda/pull/6469

Note: This PR contains string changes so it will break translations.