### PR TITLE
RHEL-9: Remove tmpfs on /var/tmp for ISO builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -352,8 +352,6 @@ container-iso-build:
 	sudo $(CONTAINER_ENGINE) run \
 	--rm \
 	--privileged \
-	$(shell test $(shell grep MemTotal /proc/meminfo | awk '{print $$2}') -gt 11000000 && \
-	  echo --tmpfs /var/tmp:rw,mode=1777) \
 	-v $(srcdir)/result/build/01-rpm-build:/anaconda-rpms:ro \
 	-v $(srcdir)/result/iso:/images:z \
 	$(CONTAINER_ADD_ARGS) \


### PR DESCRIPTION
We are facing an issue that the symlinks are not created correctly when Dracut is building initrd which was breaking boot of the ISO image.

Removing tmpfs for /var/tmp helps to resolve the issue. This line was there to improve ISO build times by moving the build process to memory but it seems to be breaking symlink creation now for some reason.

Backport of https://github.com/rhinstaller/anaconda/pull/6467