### PR TITLE
RHEL-9: bootloader: drop write_config_console, just preserve console=

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -148,7 +148,7 @@ preserved_arguments =
     speakup_synth apic noapic apm ide noht acpi video
     pci nodmraid nompath nomodeset noiswmd fips selinux
     biosdevname ipv6.disable net.ifnames net.ifnames.prefix
-    nosmt rd.net.dns rd.net.dns-resolve-mode rd.net.dns-backend
+    nosmt rd.net.dns rd.net.dns-resolve-mode rd.net.dns-backend console
 
 
 [Storage]

--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -975,17 +975,12 @@ class BootLoader(object):
 
         log.debug("Console is set to %s with options '%s'", self.console, self.console_options)
 
-    def write_config_console(self, config):
-        """Write console-related configuration lines."""
-        pass
-
     def write_config_password(self, config):
         """Write password-related configuration lines."""
         pass
 
     def write_config_header(self, config):
         """Write global configuration lines."""
-        self.write_config_console(config)
         self.write_config_password(config)
 
     def write_config_images(self, config):

--- a/pyanaconda/modules/storage/bootloader/extlinux.py
+++ b/pyanaconda/modules/storage/bootloader/extlinux.py
@@ -58,17 +58,7 @@ class EXTLINUX(BootLoader):
 
         return prefix
 
-    def write_config_console(self, config):
-        if not self.console:
-            return
-
-        console_arg = "console=%s" % self.console
-        if self.console_options:
-            console_arg += ",%s" % self.console_options
-        self.boot_args.add(console_arg)
-
     def write_config_images(self, config):
-        self.write_config_console(config)
         for image in self.images:
             args = BootLoaderArguments()
             args.update(["root=%s" % image.device.fstab_spec, "ro"])

--- a/pyanaconda/modules/storage/bootloader/grub2.py
+++ b/pyanaconda/modules/storage/bootloader/grub2.py
@@ -214,15 +214,6 @@ class GRUB2(BootLoader):
             name += ")"
         return name
 
-    def write_config_console(self, config):
-        if not self.console:
-            return
-
-        console_arg = "console=%s" % self.console
-        if self.console_options:
-            console_arg += ",%s" % self.console_options
-        self.boot_args.add(console_arg)
-
     def write_device_map(self):
         """Write out a device map containing all supported devices."""
         map_path = os.path.normpath(conf.target.system_root + self.device_map_file)
@@ -318,7 +309,6 @@ class GRUB2(BootLoader):
         header.close()
 
     def write_config(self):
-        self.write_config_console(None)
         # See if we have a password and if so update the boot args before we
         # write out the defaults file.
         if self.password or self.encrypted_password:


### PR DESCRIPTION
The name of this method has been a lie ever since the GRUB class was removed in 2019, because that's the only implementation of it that ever wrote anything into a config file (as well as effectively passing through the console= command line argument to the installed system). Every other implementation since has been functionally identical and has done nothing besides pass through the console= argument (if present). But we already have a perfectly good mechanism for preserving command line arguments, so let's just use that instead of repeating this now-wrongly-named method in every bootloader class. This will also fix it so the argument gets passed through in ostree installs - see:

https://issues.redhat.com/browse/RHEL-79961

Note we cannot remove _set_console(), which *parses* the console= argument, because the variables it parses to are used for various things in the GRUB2 class.

Backport of https://github.com/rhinstaller/anaconda/pull/6457.

Resolves: [RHEL-98670](https://issues.redhat.com/browse/RHEL-98670)