### PR TITLE
infra: Add hint when kickstart test CI fails for empty test selection

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -300,9 +300,10 @@ jobs:
       - name: Run kickstart tests in container
         working-directory: ./permian
         run: |
+          PERMIAN_LOG=permian.log
           sudo --preserve-env=TEST_JOBS \
           PYTHONPATH=${PYTHONPATH:-}:${{ github.workspace }}/tplib \
-          ./run_subset --debug-log permian.log \
+          ./run_subset --debug-log ${PERMIAN_LOG} \
             --settings settings.ini \
             --override workflows.dry_run=False \
             --testcase-query '${{ steps.generate_query.outputs.query }}' \
@@ -317,10 +318,13 @@ jobs:
             }'
 
           # Permian hides the exit code of launcher, so error out this step manually based on logs
-          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
+          rc=$( awk '/Runner return code: /{ print $4 }' ${PERMIAN_LOG})
           if [ -n "$rc" ]; then
             exit $rc
           else
+            if grep -q "All execution and reporting is done" ${PERMIAN_LOG}; then
+              echo "0 tests were run. It can be caused by using a wrong parameter or by the test(s) being disabled for the os variant."
+            fi
             exit 111
           fi
 

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -294,9 +294,10 @@ jobs:
       - name: Run kickstart tests in container
         working-directory: ./permian
         run: |
+          PERMIAN_LOG=permian.log
           sudo --preserve-env=TEST_JOBS \
           PYTHONPATH=${PYTHONPATH:-}:${{ github.workspace }}/tplib \
-          ./run_subset --debug-log permian.log \
+          ./run_subset --debug-log ${PERMIAN_LOG} \
             --settings settings.ini \
             --override workflows.dry_run=False \
             --testcase-query '${{ steps.generate_query.outputs.query }}' \
@@ -311,10 +312,13 @@ jobs:
             }'
 
           # Permian hides the exit code of launcher, so error out this step manually based on logs
-          rc=$( awk '/Runner return code: /{ print $4 }' permian.log)
+          rc=$( awk '/Runner return code: /{ print $4 }' ${PERMIAN_LOG})
           if [ -n "$rc" ]; then
             exit $rc
           else
+            if grep -q "All execution and reporting is done" ${PERMIAN_LOG}; then
+              echo "0 tests were run. It can be caused by using a wrong parameter or by the test(s) being disabled for the os variant."
+            fi
             exit 111
           fi
 


### PR DESCRIPTION
In this workflow empty selection will still result in failure, but now it should be clear why, from the log inspeciton. Noticing that a test was not run (due to wrong test specification) is more important then failing also in case all the tests are disabled (and even in this case the submitter probably wants to know).

Example of the case:
https://github.com/rhinstaller/anaconda/pull/6475#issuecomment-2996635801