### PR TITLE
Retrieve DEVICE_TYPES from blivet.

### DIFF
--- a/pyanaconda/core/configuration/storage_constraints.py
+++ b/pyanaconda/core/configuration/storage_constraints.py
@@ -17,11 +17,11 @@
 #
 #
 
-# Use blive DEVICE_TYPES because we don't want to allow UNSUPPORTED here.
-from blivet.devicefactory import DEVICE_TYPES
-
 from pyanaconda.core.configuration.base import Section
-from pyanaconda.core.storage import Size
+
+# Use the blivet idea of DeviceTypes instead of pyanaconda.core.storage.DEVICE_TYPES because
+# we are using it for validation here so we don't want to allow the UNSUPPORTED type.
+from pyanaconda.core.storage import DeviceTypes, Size
 
 
 class StorageConstraints(Section):
@@ -76,12 +76,9 @@ class StorageConstraints(Section):
 
         Valid values:
 
-          0  LVM        Allow LVM.
-          1  MD         Allow RAID.
-          2  PARTITION  Allow standard partitions.
-          3  BTRFS      Allow Btrfs.
-          4  DISK       Allow disks.
-          5  LVM_THINP  Allow LVM Thin Provisioning.
+            The set of device types listed in blivet's DeviceTypes enum.
+            This currently includes devices that we do not support for
+            all usecases (2025-07-09).
 
         :return: a set of device types
         """
@@ -95,7 +92,7 @@ class StorageConstraints(Section):
         bad_names = []
         for name in device_names:
             try:
-                device_codes.add(getattr(DEVICE_TYPES, name).value)
+                device_codes.add(getattr(DeviceTypes, name).value)
             except AttributeError:
                 bad_names.append(name)
 

--- a/pyanaconda/core/configuration/storage_constraints.py
+++ b/pyanaconda/core/configuration/storage_constraints.py
@@ -19,25 +19,17 @@
 from enum import Enum
 
 from pyanaconda.core.configuration.base import Section
-from pyanaconda.core.storage import (
-    DEVICE_TYPE_BTRFS,
-    DEVICE_TYPE_DISK,
-    DEVICE_TYPE_LVM,
-    DEVICE_TYPE_LVM_THINP,
-    DEVICE_TYPE_MD,
-    DEVICE_TYPE_PARTITION,
-    Size,
-)
+from pyanaconda.core.storage import DEVICE_TYPES, Size
 
 
 class DeviceType(Enum):
     """Type of a device."""
-    LVM = DEVICE_TYPE_LVM
-    MD = DEVICE_TYPE_MD
-    PARTITION = DEVICE_TYPE_PARTITION
-    BTRFS = DEVICE_TYPE_BTRFS
-    DISK = DEVICE_TYPE_DISK
-    LVM_THINP = DEVICE_TYPE_LVM_THINP
+    LVM = DEVICE_TYPES.LVM
+    MD = DEVICE_TYPES.MD
+    PARTITION = DEVICE_TYPES.PARTITION
+    BTRFS = DEVICE_TYPES.BTRFS
+    DISK = DEVICE_TYPES.DISK
+    LVM_THINP = DEVICE_TYPES.LVM_THINP
 
     @classmethod
     def from_name(cls, value):

--- a/pyanaconda/core/storage.py
+++ b/pyanaconda/core/storage.py
@@ -20,7 +20,24 @@ from decimal import Decimal
 from enum import IntEnum
 
 from blivet import udev
-from blivet.devicefactory import DEVICE_TYPES as blivet_dts
+
+try:
+    from blivet.devicefactory import DeviceTypes
+except ImportError:
+    # Compatibility with older versions of blivet which do not have
+    # DeviceTypes.  Get rid of this code once we have a new enough blivet
+    # everywhere.
+    DeviceTypes = IntEnum('DeviceTypes', [
+        ('LVM', 0),
+        ('MD', 1),
+        ('PARTITION', 2),
+        ('BTRFS', 3),
+        ('DISK', 4),
+        ('LVM_THINP', 5),
+        ('LVM_VDO', 6),
+        ('STRATIS', 7),
+    ])
+
 from blivet.size import Size
 from blivet.util import total_memory
 from pykickstart.constants import (
@@ -43,7 +60,8 @@ SIZE_POLICY_AUTO = 0
 
 # Use blivet values plus Unsupported which contains info about devices without
 # a supported type.
-DEVICE_TYPES = IntEnum([(dt.name, dt.value) for dt in blivet_dts] + [('UNSUPPORTED', -1)])
+DEVICE_TYPES = IntEnum('DEVICE_TYPES',
+                       [(dt.name, dt.value) for dt in DeviceTypes] + [('UNSUPPORTED', -1)])
 
 # Backwards compat, make DEVICE_TYPE_* constants that mirror the contents of
 # the Enum.

--- a/pyanaconda/modules/storage/partitioning/interactive/add_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/add_device.py
@@ -21,7 +21,7 @@ from blivet.size import Size
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
-from pyanaconda.core.storage import PARTITION_ONLY_FORMAT_TYPES
+from pyanaconda.core.storage import DEVICE_TYPES, PARTITION_ONLY_FORMAT_TYPES
 from pyanaconda.core.string import lower_ascii
 from pyanaconda.modules.common.errors.configuration import StorageConfigurationError
 from pyanaconda.modules.common.structures.device_factory import DeviceFactoryRequest
@@ -114,16 +114,16 @@ class AddDeviceTask(Task):
         # These devices should never be encrypted.
         if (request.mount_point.startswith("/boot") or
                 request.format_type in PARTITION_ONLY_FORMAT_TYPES):
-            request.device_type = devicefactory.DEVICE_TYPES.PARTITION
+            request.device_type = DEVICE_TYPES.PARTITION
             request.device_encrypted = False
 
         # We shouldn't create swap on a thinly provisioned volume.
         if (request.format_type == "swap" and
-                request.device_type == devicefactory.DEVICE_TYPES.LVM_THINP):
-            request.device_type = devicefactory.DEVICE_TYPES.LVM
+                request.device_type == DEVICE_TYPES.LVM_THINP):
+            request.device_type = DEVICE_TYPES.LVM
 
         # Encryption of thinly provisioned volumes isn't supported.
-        if request.device_type == devicefactory.DEVICE_TYPES.LVM_THINP:
+        if request.device_type == DEVICE_TYPES.LVM_THINP:
             request.device_encrypted = False
 
     def _add_device(self, storage, request: DeviceFactoryRequest, use_existing_container=False):

--- a/pyanaconda/modules/storage/partitioning/interactive/add_device.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/add_device.py
@@ -114,16 +114,16 @@ class AddDeviceTask(Task):
         # These devices should never be encrypted.
         if (request.mount_point.startswith("/boot") or
                 request.format_type in PARTITION_ONLY_FORMAT_TYPES):
-            request.device_type = devicefactory.DEVICE_TYPE_PARTITION
+            request.device_type = devicefactory.DEVICE_TYPES.PARTITION
             request.device_encrypted = False
 
         # We shouldn't create swap on a thinly provisioned volume.
         if (request.format_type == "swap" and
-                request.device_type == devicefactory.DEVICE_TYPE_LVM_THINP):
-            request.device_type = devicefactory.DEVICE_TYPE_LVM
+                request.device_type == devicefactory.DEVICE_TYPES.LVM_THINP):
+            request.device_type = devicefactory.DEVICE_TYPES.LVM
 
         # Encryption of thinly provisioned volumes isn't supported.
-        if request.device_type == devicefactory.DEVICE_TYPE_LVM_THINP:
+        if request.device_type == devicefactory.DEVICE_TYPES.LVM_THINP:
             request.device_encrypted = False
 
     def _add_device(self, storage, request: DeviceFactoryRequest, use_existing_container=False):

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -415,19 +415,19 @@ def validate_device_factory_request(storage, request: DeviceFactoryRequest):
         if error:
             return error
 
-    supported_types = (devicefactory.DEVICE_TYPE_PARTITION, devicefactory.DEVICE_TYPE_MD)
+    supported_types = (devicefactory.DEVICE_TYPES.PARTITION, devicefactory.DEVICE_TYPES.MD)
 
     if mount_point == "/boot/efi" and device_type not in supported_types:
         return _("/boot/efi must be on a device of type {type} or {another}").format(
-            type=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPE_PARTITION]),
-            another=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPE_MD])
+            type=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPES.PARTITION]),
+            another=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPES.MD])
         )
 
-    if device_type != devicefactory.DEVICE_TYPE_PARTITION and \
+    if device_type != devicefactory.DEVICE_TYPES.PARTITION and \
             fs_type in PARTITION_ONLY_FORMAT_TYPES:
         return _("{fs} must be on a device of type {type}").format(
             fs=fs_type,
-            type=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPE_PARTITION])
+            type=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPES.PARTITION])
         )
 
     if mount_point and encrypted and mount_point.startswith("/boot"):
@@ -439,7 +439,7 @@ def validate_device_factory_request(storage, request: DeviceFactoryRequest):
     if mount_point == "/" and device.format.exists and not reformat:
         return _("You must create a new file system on the root device.")
 
-    if (raid_level is not None or device_type == devicefactory.DEVICE_TYPE_MD) and \
+    if (raid_level is not None or device_type == devicefactory.DEVICE_TYPES.MD) and \
             raid_level not in get_supported_raid_levels(device_type):
         return _("Device does not support RAID level selection {}.").format(raid_level)
 
@@ -760,7 +760,7 @@ def collect_device_types(device):
     """
     # Collect the supported device types.
     supported_types = set(SUPPORTED_DEVICE_TYPES)
-    supported_types.add(devicefactory.DEVICE_TYPE_MD)
+    supported_types.add(devicefactory.DEVICE_TYPES.MD)
 
     # Include the type of the given device.
     supported_types.add(devicefactory.get_device_type(device))
@@ -771,7 +771,7 @@ def collect_device_types(device):
     if fmt.supported \
             and fmt.formattable \
             and device.raw_device.format.type not in PARTITION_ONLY_FORMAT_TYPES + ("swap",):
-        supported_types.add(devicefactory.DEVICE_TYPE_BTRFS)
+        supported_types.add(devicefactory.DEVICE_TYPES.BTRFS)
 
     return sorted(filter(devicefactory.is_supported_device_type, supported_types))
 
@@ -973,7 +973,7 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
         device.resizable or (
                 not device.exists
                 and request.device_type not in {
-                    devicefactory.DEVICE_TYPE_BTRFS
+                    devicefactory.DEVICE_TYPES.BTRFS
                 }
         )
 
@@ -985,14 +985,14 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
     permissions.format_type = \
         request.reformat \
         and request.device_type not in {
-            devicefactory.DEVICE_TYPE_BTRFS
+            devicefactory.DEVICE_TYPES.BTRFS
         }
 
     permissions.device_encrypted = \
         request.reformat \
         and not request.container_encrypted \
         and request.device_type not in {
-            devicefactory.DEVICE_TYPE_BTRFS
+            devicefactory.DEVICE_TYPES.BTRFS
         } \
         and not any(
             a.format.type == "luks" and a.format.exists
@@ -1100,7 +1100,7 @@ def _destroy_device(storage, device):
         device_type = devicefactory.get_device_type(device)
     elif hasattr(device, "volume"):
         container = device.volume
-        device_type = devicefactory.DEVICE_TYPE_BTRFS
+        device_type = devicefactory.DEVICE_TYPES.BTRFS
     else:
         container = None
         device_type = None
@@ -1199,7 +1199,7 @@ def get_default_container_raid_level_name(device_type):
     :param int device_type: a device_type
     :return str: a name of the default RAID level or an empty string
     """
-    if device_type == devicefactory.DEVICE_TYPE_BTRFS:
+    if device_type == devicefactory.DEVICE_TYPES.BTRFS:
         return "single"
 
     return ""
@@ -1212,7 +1212,7 @@ def collect_containers(storage, device_type):
     :param device_type: a device type
     :return: a list of container devices
     """
-    if device_type == devicefactory.DEVICE_TYPE_BTRFS:
+    if device_type == devicefactory.DEVICE_TYPES.BTRFS:
         return storage.btrfs_volumes
     else:
         return storage.vgs

--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -33,6 +33,7 @@ from pyanaconda.core.product import get_product_name, get_product_version
 from pyanaconda.core.storage import (
     CONTAINER_DEVICE_TYPES,
     DEVICE_TEXT_MAP,
+    DEVICE_TYPES,
     NAMED_DEVICE_TYPES,
     PARTITION_ONLY_FORMAT_TYPES,
     SUPPORTED_DEVICE_TYPES,
@@ -415,19 +416,19 @@ def validate_device_factory_request(storage, request: DeviceFactoryRequest):
         if error:
             return error
 
-    supported_types = (devicefactory.DEVICE_TYPES.PARTITION, devicefactory.DEVICE_TYPES.MD)
+    supported_types = (DEVICE_TYPES.PARTITION, DEVICE_TYPES.MD)
 
     if mount_point == "/boot/efi" and device_type not in supported_types:
         return _("/boot/efi must be on a device of type {type} or {another}").format(
-            type=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPES.PARTITION]),
-            another=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPES.MD])
+            type=_(DEVICE_TEXT_MAP[DEVICE_TYPES.PARTITION]),
+            another=_(DEVICE_TEXT_MAP[DEVICE_TYPES.MD])
         )
 
-    if device_type != devicefactory.DEVICE_TYPES.PARTITION and \
+    if device_type != DEVICE_TYPES.PARTITION and \
             fs_type in PARTITION_ONLY_FORMAT_TYPES:
         return _("{fs} must be on a device of type {type}").format(
             fs=fs_type,
-            type=_(DEVICE_TEXT_MAP[devicefactory.DEVICE_TYPES.PARTITION])
+            type=_(DEVICE_TEXT_MAP[DEVICE_TYPES.PARTITION])
         )
 
     if mount_point and encrypted and mount_point.startswith("/boot"):
@@ -439,7 +440,7 @@ def validate_device_factory_request(storage, request: DeviceFactoryRequest):
     if mount_point == "/" and device.format.exists and not reformat:
         return _("You must create a new file system on the root device.")
 
-    if (raid_level is not None or device_type == devicefactory.DEVICE_TYPES.MD) and \
+    if (raid_level is not None or device_type == DEVICE_TYPES.MD) and \
             raid_level not in get_supported_raid_levels(device_type):
         return _("Device does not support RAID level selection {}.").format(raid_level)
 
@@ -760,7 +761,7 @@ def collect_device_types(device):
     """
     # Collect the supported device types.
     supported_types = set(SUPPORTED_DEVICE_TYPES)
-    supported_types.add(devicefactory.DEVICE_TYPES.MD)
+    supported_types.add(DEVICE_TYPES.MD)
 
     # Include the type of the given device.
     supported_types.add(devicefactory.get_device_type(device))
@@ -771,7 +772,7 @@ def collect_device_types(device):
     if fmt.supported \
             and fmt.formattable \
             and device.raw_device.format.type not in PARTITION_ONLY_FORMAT_TYPES + ("swap",):
-        supported_types.add(devicefactory.DEVICE_TYPES.BTRFS)
+        supported_types.add(DEVICE_TYPES.BTRFS)
 
     return sorted(filter(devicefactory.is_supported_device_type, supported_types))
 
@@ -973,7 +974,7 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
         device.resizable or (
                 not device.exists
                 and request.device_type not in {
-                    devicefactory.DEVICE_TYPES.BTRFS
+                    DEVICE_TYPES.BTRFS
                 }
         )
 
@@ -985,14 +986,14 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
     permissions.format_type = \
         request.reformat \
         and request.device_type not in {
-            devicefactory.DEVICE_TYPES.BTRFS
+            DEVICE_TYPES.BTRFS
         }
 
     permissions.device_encrypted = \
         request.reformat \
         and not request.container_encrypted \
         and request.device_type not in {
-            devicefactory.DEVICE_TYPES.BTRFS
+            DEVICE_TYPES.BTRFS
         } \
         and not any(
             a.format.type == "luks" and a.format.exists
@@ -1100,7 +1101,7 @@ def _destroy_device(storage, device):
         device_type = devicefactory.get_device_type(device)
     elif hasattr(device, "volume"):
         container = device.volume
-        device_type = devicefactory.DEVICE_TYPES.BTRFS
+        device_type = DEVICE_TYPES.BTRFS
     else:
         container = None
         device_type = None
@@ -1199,7 +1200,7 @@ def get_default_container_raid_level_name(device_type):
     :param int device_type: a device_type
     :return str: a name of the default RAID level or an empty string
     """
-    if device_type == devicefactory.DEVICE_TYPES.BTRFS:
+    if device_type == DEVICE_TYPES.BTRFS:
         return "single"
 
     return ""
@@ -1212,7 +1213,7 @@ def collect_containers(storage, device_type):
     :param device_type: a device type
     :return: a list of container devices
     """
-    if device_type == devicefactory.DEVICE_TYPES.BTRFS:
+    if device_type == DEVICE_TYPES.BTRFS:
         return storage.btrfs_volumes
     else:
         return storage.vgs

--- a/pyanaconda/ui/gui/spokes/custom_storage.py
+++ b/pyanaconda/ui/gui/spokes/custom_storage.py
@@ -42,9 +42,7 @@ from pyanaconda.core.product import get_product_name, get_product_version
 from pyanaconda.core.storage import (
     CONTAINER_DEVICE_TYPES,
     DEVICE_TEXT_MAP,
-    DEVICE_TYPE_BTRFS,
-    DEVICE_TYPE_MD,
-    DEVICE_TYPE_UNSUPPORTED,
+    DEVICE_TYPES,
     MOUNTPOINT_DESCRIPTIONS,
     NAMED_DEVICE_TYPES,
     PROTECTED_FORMAT_TYPES,
@@ -715,7 +713,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             return None
 
         device_type = self._typeStore[itr][1]
-        if device_type == DEVICE_TYPE_UNSUPPORTED:
+        if device_type == DEVICE_TYPES.UNSUPPORTED:
             return None
 
         return device_type
@@ -747,12 +745,12 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         """Set up device type combo."""
         # Include md only if there are two or more disks.
         if len(self._selected_disks) <= 1:
-            device_types.remove(DEVICE_TYPE_MD)
+            device_types.remove(DEVICE_TYPES.MD)
 
         # For existing unsupported device add the information in the UI.
         if device_type not in device_types:
             log.debug("Existing device with unsupported type %s found.", device_type)
-            device_type = DEVICE_TYPE_UNSUPPORTED
+            device_type = DEVICE_TYPES.UNSUPPORTED
             device_types.append(device_type)
 
         # Add values.
@@ -1215,7 +1213,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
 
         self.reset_state()
 
-        is_md = self._get_current_device_type() == DEVICE_TYPE_MD
+        is_md = self._get_current_device_type() == DEVICE_TYPES.MD
 
         dialog = DisksDialog(
             self.data,
@@ -1675,7 +1673,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
             Preconditions are:
             * the filesystem combo contains at least the default filesystem
             * the default filesystem is not the same as btrfs
-            * if device_type is DEVICE_TYPE_BTRFS, btrfs is supported
+            * if device_type is DEVICE_TYPES.BTRFS, btrfs is supported
 
             This method is idempotent, and must remain so.
         """
@@ -1684,7 +1682,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         btrfs_iter = ((idx, row) for idx, row in enumerate(model) if row[1] == "btrfs")
         btrfs_idx, btrfs_row = next(btrfs_iter, (None, None))
 
-        if device_type == DEVICE_TYPE_BTRFS:
+        if device_type == DEVICE_TYPES.BTRFS:
             # If no btrfs entry, add one, and select the new entry
             if btrfs_idx is None:
                 fmt = DeviceFormatData.from_structure(
@@ -1719,7 +1717,7 @@ class CustomPartitioningSpoke(NormalSpoke, StorageCheckHandler):
         self._fsCombo.set_active(active_index)
         fancy_set_sensitive(
             self._fsCombo,
-            self._reformatCheckbox.get_active() and device_type != DEVICE_TYPE_BTRFS
+            self._reformatCheckbox.get_active() and device_type != DEVICE_TYPES.BTRFS
         )
 
     def on_device_type_changed(self, combo):

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.py
@@ -23,10 +23,7 @@ from dasbus.structure import get_fields
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import C_, CN_, N_, _
 from pyanaconda.core.storage import (
-    DEVICE_TYPE_BTRFS,
-    DEVICE_TYPE_LVM,
-    DEVICE_TYPE_LVM_THINP,
-    DEVICE_TYPE_MD,
+    DEVICE_TYPES,
     PROTECTED_FORMAT_TYPES,
     SIZE_POLICY_AUTO,
     SIZE_POLICY_MAX,
@@ -86,13 +83,13 @@ DESIRED_CAPACITY_ERROR = DESIRED_CAPACITY_HINT
 ContainerType = namedtuple("ContainerType", ["name", "label"])
 
 CONTAINER_TYPES = {
-    DEVICE_TYPE_LVM: ContainerType(
+    DEVICE_TYPES.LVM: ContainerType(
         N_("Volume Group"),
         CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume Group:")),
-    DEVICE_TYPE_LVM_THINP: ContainerType(
+    DEVICE_TYPES.LVM_THINP: ContainerType(
         N_("Volume Group"),
         CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume Group:")),
-    DEVICE_TYPE_BTRFS: ContainerType(
+    DEVICE_TYPES.BTRFS: ContainerType(
         N_("Volume"),
         CN_("GUI|Custom Partitioning|Configure|Devices", "_Volume:"))
 }
@@ -190,7 +187,7 @@ def get_default_raid_level(device_type):
     :param int device_type: an int representing the device_type
     :return str: the default RAID level for this device type or an empty string
     """
-    if device_type == DEVICE_TYPE_MD:
+    if device_type == DEVICE_TYPES.MD:
         return "raid1"
 
     return ""
@@ -203,7 +200,7 @@ def get_supported_device_raid_levels(device_tree, device_type):
     supports for the given device type.
 
     Since anaconda only ever allows the user to choose RAID levels for
-    device type DEVICE_TYPE_MD, hiding the RAID menu for all other device
+    device type DEVICE_TYPES.MD, hiding the RAID menu for all other device
     types, the function only returns a non-empty set for this device type.
     If this changes, then so should this function, but at this time it
     is not clear what RAID levels should be offered for other device types.
@@ -213,9 +210,9 @@ def get_supported_device_raid_levels(device_tree, device_type):
     :return: a set of supported raid levels
     :rtype: a set of strings
     """
-    if device_type == DEVICE_TYPE_MD:
+    if device_type == DEVICE_TYPES.MD:
         supported = {"raid0", "raid1", "raid4", "raid5", "raid6", "raid10"}
-        levels = set(device_tree.GetSupportedRaidLevels(DEVICE_TYPE_MD))
+        levels = set(device_tree.GetSupportedRaidLevels(DEVICE_TYPES.MD))
         return levels.intersection(supported)
 
     return set()
@@ -231,14 +228,14 @@ def get_supported_container_raid_levels(device_tree, device_type):
     :return: a set of supported raid levels
     :rtype: a set of strings
     """
-    if device_type in (DEVICE_TYPE_LVM, DEVICE_TYPE_LVM_THINP):
+    if device_type in (DEVICE_TYPES.LVM, DEVICE_TYPES.LVM_THINP):
         supported = {"raid0", "raid1", "raid4", "raid5", "raid6", "raid10"}
-        levels = set(device_tree.GetSupportedRaidLevels(DEVICE_TYPE_MD))
+        levels = set(device_tree.GetSupportedRaidLevels(DEVICE_TYPES.MD))
         return levels.intersection(supported).union({""})
 
-    if device_type == DEVICE_TYPE_BTRFS:
+    if device_type == DEVICE_TYPES.BTRFS:
         supported = {"raid0", "raid1", "raid10", "single"}
-        levels = set(device_tree.GetSupportedRaidLevels(DEVICE_TYPE_BTRFS))
+        levels = set(device_tree.GetSupportedRaidLevels(DEVICE_TYPES.BTRFS))
         return levels.intersection(supported)
 
     return set()

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
@@ -174,7 +174,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, ""),
             "label": get_variant(Str, ""),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPE_DISK),
+            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.DISK),
             "device-name": get_variant(Str, "dev2"),
             "device-size": get_variant(UInt64, 0),
             "device-encrypted": get_variant(Bool, False),
@@ -202,7 +202,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, "ext4"),
             "label": get_variant(Str, "root"),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPE_PARTITION),
+            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.PARTITION),
             "device-name": get_variant(Str, "dev3"),
             "device-size": get_variant(UInt64, Size("5 GiB").get_bytes()),
             "device-encrypted": get_variant(Bool, False),
@@ -249,7 +249,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, "xfs"),
             "label": get_variant(Str, ""),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPE_LVM),
+            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.LVM),
             "device-name": get_variant(Str, "testlv"),
             "device-size": get_variant(UInt64, Size("508 MiB").get_bytes()),
             "device-encrypted": get_variant(Bool, False),
@@ -286,7 +286,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, ""),
             "label": get_variant(Str, ""),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPE_MD),
+            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.MD),
             "device-name": get_variant(Str, "dev3"),
             "device-size": get_variant(UInt64, 0),
             "device-encrypted": get_variant(Bool, False),
@@ -326,7 +326,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, "btrfs"),
             "label": get_variant(Str, ""),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPE_BTRFS),
+            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.BTRFS),
             "device-name": get_variant(Str, dev3.name),
             "device-size": get_variant(UInt64, Size("10 GiB").get_bytes()),
             "device-encrypted": get_variant(Bool, False),
@@ -353,7 +353,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         request.device_spec = "dev3"
         request.disks = ["dev1", "dev2"]
         request.device_name = "dev3"
-        request.device_type = devicefactory.DEVICE_TYPE_LVM_THINP
+        request.device_type = devicefactory.DEVICE_TYPES.LVM_THINP
         request.device_size = Size("10 GiB").get_bytes()
         request.mount_point = "/"
         request.format_type = "xfs"
@@ -365,7 +365,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         assert utils.get_device_factory_arguments(self.storage, request) == {
             "device": dev3,
             "disks": [dev1, dev2],
-            "device_type": devicefactory.DEVICE_TYPE_LVM_THINP,
+            "device_type": devicefactory.DEVICE_TYPES.LVM_THINP,
             "device_name": "dev3",
             "size": Size("10 GiB"),
             "mountpoint": "/",
@@ -392,7 +392,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         assert utils.get_device_factory_arguments(self.storage, request) == {
             "device": dev3,
             "disks": [dev1, dev2],
-            "device_type": devicefactory.DEVICE_TYPE_LVM,
+            "device_type": devicefactory.DEVICE_TYPES.LVM,
             "device_name": "dev3",
             "size": None,
             "mountpoint": None,

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_interactive.py
@@ -38,6 +38,7 @@ from blivet.size import Size
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.core.constants import PARTITIONING_METHOD_INTERACTIVE
+from pyanaconda.core.storage import DEVICE_TYPES
 from pyanaconda.modules.common.containers import DeviceTreeContainer
 from pyanaconda.modules.common.errors.storage import UnsupportedDeviceError
 from pyanaconda.modules.common.structures.device_factory import DeviceFactoryRequest
@@ -174,7 +175,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, ""),
             "label": get_variant(Str, ""),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.DISK),
+            "device-type": get_variant(Int, DEVICE_TYPES.DISK),
             "device-name": get_variant(Str, "dev2"),
             "device-size": get_variant(UInt64, 0),
             "device-encrypted": get_variant(Bool, False),
@@ -202,7 +203,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, "ext4"),
             "label": get_variant(Str, "root"),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.PARTITION),
+            "device-type": get_variant(Int, DEVICE_TYPES.PARTITION),
             "device-name": get_variant(Str, "dev3"),
             "device-size": get_variant(UInt64, Size("5 GiB").get_bytes()),
             "device-encrypted": get_variant(Bool, False),
@@ -249,7 +250,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, "xfs"),
             "label": get_variant(Str, ""),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.LVM),
+            "device-type": get_variant(Int, DEVICE_TYPES.LVM),
             "device-name": get_variant(Str, "testlv"),
             "device-size": get_variant(UInt64, Size("508 MiB").get_bytes()),
             "device-encrypted": get_variant(Bool, False),
@@ -286,7 +287,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, ""),
             "label": get_variant(Str, ""),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.MD),
+            "device-type": get_variant(Int, DEVICE_TYPES.MD),
             "device-name": get_variant(Str, "dev3"),
             "device-size": get_variant(UInt64, 0),
             "device-encrypted": get_variant(Bool, False),
@@ -326,7 +327,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
             "format-type": get_variant(Str, "btrfs"),
             "label": get_variant(Str, ""),
             "luks-version": get_variant(Str, ""),
-            "device-type": get_variant(Int, devicefactory.DEVICE_TYPES.BTRFS),
+            "device-type": get_variant(Int, DEVICE_TYPES.BTRFS),
             "device-name": get_variant(Str, dev3.name),
             "device-size": get_variant(UInt64, Size("10 GiB").get_bytes()),
             "device-encrypted": get_variant(Bool, False),
@@ -353,7 +354,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         request.device_spec = "dev3"
         request.disks = ["dev1", "dev2"]
         request.device_name = "dev3"
-        request.device_type = devicefactory.DEVICE_TYPES.LVM_THINP
+        request.device_type = DEVICE_TYPES.LVM_THINP
         request.device_size = Size("10 GiB").get_bytes()
         request.mount_point = "/"
         request.format_type = "xfs"
@@ -365,7 +366,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         assert utils.get_device_factory_arguments(self.storage, request) == {
             "device": dev3,
             "disks": [dev1, dev2],
-            "device_type": devicefactory.DEVICE_TYPES.LVM_THINP,
+            "device_type": DEVICE_TYPES.LVM_THINP,
             "device_name": "dev3",
             "size": Size("10 GiB"),
             "mountpoint": "/",
@@ -392,7 +393,7 @@ class InteractiveUtilsTestCase(unittest.TestCase):
         assert utils.get_device_factory_arguments(self.storage, request) == {
             "device": dev3,
             "disks": [dev1, dev2],
-            "device_type": devicefactory.DEVICE_TYPES.LVM,
+            "device_type": DEVICE_TYPES.LVM,
             "device_name": "dev3",
             "size": None,
             "mountpoint": None,

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -23,7 +23,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 from blivet.devicefactory import (
-    DEVICE_TYPES,
     SIZE_POLICY_AUTO,
 )
 from blivet.devices import (
@@ -44,6 +43,7 @@ from dasbus.structure import compare_data
 from dasbus.typing import get_native
 from pykickstart.constants import AUTOPART_TYPE_PLAIN
 
+from pyanaconda.core.storage import DEVICE_TYPES
 from pyanaconda.modules.common.errors.configuration import StorageConfigurationError
 from pyanaconda.modules.common.structures.device_factory import DeviceFactoryRequest
 from pyanaconda.modules.common.structures.partitioning import PartitioningRequest

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -23,12 +23,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from blivet.devicefactory import (
-    DEVICE_TYPE_BTRFS,
-    DEVICE_TYPE_DISK,
-    DEVICE_TYPE_LVM,
-    DEVICE_TYPE_LVM_THINP,
-    DEVICE_TYPE_MD,
-    DEVICE_TYPE_PARTITION,
+    DEVICE_TYPES,
     SIZE_POLICY_AUTO,
 )
 from blivet.devices import (
@@ -189,7 +184,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
 
     def test_get_supported_raid_levels(self):
         """Test GetSupportedRaidLevels."""
-        assert self.interface.GetSupportedRaidLevels(DEVICE_TYPE_MD) == \
+        assert self.interface.GetSupportedRaidLevels(DEVICE_TYPES.MD) == \
             ['linear', 'raid0', 'raid1', 'raid10', 'raid4', 'raid5', 'raid6']
 
     @patch('pyanaconda.modules.storage.partitioning.interactive.utils.get_format')
@@ -264,7 +259,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         ))
 
         request = DeviceFactoryRequest()
-        request.device_type = DEVICE_TYPE_LVM
+        request.device_type = DEVICE_TYPES.LVM
         request.mount_point = "/home"
         request.size = Size("5 GiB")
         request.disks = ["dev1"]
@@ -291,7 +286,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         original_request = self.module.generate_device_factory_request("dev2")
         request = copy.deepcopy(original_request)
 
-        request.device_type = DEVICE_TYPE_LVM
+        request.device_type = DEVICE_TYPES.LVM
         request.mount_point = "/home"
         request.size = Size("4 GiB")
         request.label = "home"
@@ -352,7 +347,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
             'format-type': 'ext4',
             'label': 'root',
             'luks-version': '',
-            'device-type': DEVICE_TYPE_PARTITION,
+            'device-type': DEVICE_TYPES.PARTITION,
             'device-name': 'dev2',
             'device-size': Size("5 GiB").get_bytes(),
             'device-encrypted': False,
@@ -403,11 +398,11 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         """Test GetDeviceTypesForDevice."""
         self._add_device(DiskDevice("dev1"))
         assert self.interface.GetDeviceTypesForDevice("dev1") == [
-            DEVICE_TYPE_LVM,
-            DEVICE_TYPE_MD,
-            DEVICE_TYPE_PARTITION,
-            DEVICE_TYPE_DISK,
-            DEVICE_TYPE_LVM_THINP,
+            DEVICE_TYPES.LVM,
+            DEVICE_TYPES.MD,
+            DEVICE_TYPES.PARTITION,
+            DEVICE_TYPES.DISK,
+            DEVICE_TYPES.LVM_THINP,
         ]
 
     def test_validate_device_factory_request(self):
@@ -429,7 +424,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev3)
 
         request = self.module.generate_device_factory_request("dev3")
-        request.device_type = DEVICE_TYPE_LVM
+        request.device_type = DEVICE_TYPES.LVM
         request.disks = ["dev1", "dev2"]
         request.format_type = "ext4"
         request.mount_point = "/boot"
@@ -778,8 +773,8 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(dev1)
         self._add_device(dev2)
 
-        assert self.interface.CollectContainers(DEVICE_TYPE_BTRFS) == [dev2.device_id]
-        assert self.interface.CollectContainers(DEVICE_TYPE_LVM) == []
+        assert self.interface.CollectContainers(DEVICE_TYPES.BTRFS) == [dev2.device_id]
+        assert self.interface.CollectContainers(DEVICE_TYPES.LVM) == []
 
     def test_get_container_free_space(self):
         """Test GetContainerFreeSpace."""
@@ -859,7 +854,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         request = DeviceFactoryRequest()
         request.device_spec = lv.device_id
 
-        request.device_type = DEVICE_TYPE_LVM
+        request.device_type = DEVICE_TYPES.LVM
         request = DeviceFactoryRequest.from_structure(
             self.interface.GenerateContainerData(
                 DeviceFactoryRequest.to_structure(request)
@@ -872,7 +867,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         assert request.container_raid_level == ""
         assert request.container_size_policy == Size("1.5 GiB").get_bytes()
 
-        request.device_type = DEVICE_TYPE_BTRFS
+        request.device_type = DEVICE_TYPES.BTRFS
         request = DeviceFactoryRequest.from_structure(
             self.interface.GenerateContainerData(
                 DeviceFactoryRequest.to_structure(request)
@@ -885,7 +880,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         assert request.container_raid_level == "single"
         assert request.container_size_policy == 0
 
-        request.device_type = DEVICE_TYPE_PARTITION
+        request.device_type = DEVICE_TYPES.PARTITION
         request = DeviceFactoryRequest.from_structure(
             self.interface.GenerateContainerData(
                 DeviceFactoryRequest.to_structure(request)
@@ -920,7 +915,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         self._add_device(vg)
 
         request = DeviceFactoryRequest()
-        request.device_type = DEVICE_TYPE_PARTITION
+        request.device_type = DEVICE_TYPES.PARTITION
 
         with pytest.raises(StorageError):
             self.interface.UpdateContainerData(
@@ -928,7 +923,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
                     "anaconda"
             )
 
-        request.device_type = DEVICE_TYPE_BTRFS
+        request.device_type = DEVICE_TYPES.BTRFS
         request = DeviceFactoryRequest.from_structure(
             self.interface.UpdateContainerData(
                 DeviceFactoryRequest.to_structure(request),
@@ -943,7 +938,7 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         assert request.container_size_policy == 0
         assert request.disks == []
 
-        request.device_type = DEVICE_TYPE_LVM
+        request.device_type = DEVICE_TYPES.LVM
         request = DeviceFactoryRequest.from_structure(
             self.interface.UpdateContainerData(
                 DeviceFactoryRequest.to_structure(request),

--- a/tests/unit_tests/pyanaconda_tests/ui/test_ui_custom_spoke.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_ui_custom_spoke.py
@@ -19,9 +19,9 @@ import copy
 import unittest
 from textwrap import dedent
 
-from blivet import devicefactory
 from blivet.size import Size
 
+from pyanaconda.core.storage import DEVICE_TYPES
 from pyanaconda.modules.common.structures.device_factory import DeviceFactoryRequest
 from pyanaconda.ui.gui.spokes.lib.custom_storage_helpers import (
     generate_request_description,
@@ -37,7 +37,7 @@ class CustomStorageHelpersTestCase(unittest.TestCase):
         request.device_spec = "dev3"
         request.disks = ["dev1", "dev2"]
         request.device_name = "dev3"
-        request.device_type = devicefactory.DEVICE_TYPES.LVM_THINP
+        request.device_type = DEVICE_TYPES.LVM_THINP
         request.device_size = Size("10 GiB").get_bytes()
         request.mount_point = "/"
         request.format_type = "xfs"
@@ -58,7 +58,7 @@ class CustomStorageHelpersTestCase(unittest.TestCase):
         device-raid-level = 'raid1'
         device-size = 10737418240
         device-spec = 'dev3'
-        device-type = 5
+        device-type = <DEVICE_TYPES.LVM_THINP: 5>
         disks = ['dev1', 'dev2']
         format-type = 'xfs'
         label = 'root'
@@ -89,7 +89,7 @@ class CustomStorageHelpersTestCase(unittest.TestCase):
         device-raid-level = 'raid1'
         device-size = 10737418240
         device-spec = 'dev3'
-        device-type = 5
+        device-type = <DEVICE_TYPES.LVM_THINP: 5>
         disks = ['dev1', 'dev2'] -> ['dev1']
         format-type = 'xfs'
         label = 'root'

--- a/tests/unit_tests/pyanaconda_tests/ui/test_ui_custom_spoke.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_ui_custom_spoke.py
@@ -37,7 +37,7 @@ class CustomStorageHelpersTestCase(unittest.TestCase):
         request.device_spec = "dev3"
         request.disks = ["dev1", "dev2"]
         request.device_name = "dev3"
-        request.device_type = devicefactory.DEVICE_TYPE_LVM_THINP
+        request.device_type = devicefactory.DEVICE_TYPES.LVM_THINP
         request.device_size = Size("10 GiB").get_bytes()
         request.mount_point = "/"
         request.format_type = "xfs"


### PR DESCRIPTION
Before this, we were copying the device types from blivet code into our own.  If we failed to sync the codes, we could eventually cause tracebacks because we didn't recognize the code blivet was sending us.  With this change, we import the codes that blivet uses from the blivet library.  This way we will stay in sync with them.

Note that this does not implement support for all of the other types that blivet supports; it just means we will not crash if we encounter them.

Resolves: INSTALLER-4090

Note: This requires that blivet accept https://github.com/storaged-project/blivet/pull/1397 first.  I will update this code to work with any changes made to the blivet PR.