### PR TITLE
pyanaconda: storage: enforce GPT partition table for ESP on EFI platforms

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -41,6 +41,7 @@ from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.modules.storage.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.modules.storage.platform import (
     PLATFORM_DEVICE_TYPES,
+    PLATFORM_DISK_LABEL_TYPES,
     PLATFORM_FORMAT_TYPES,
     PLATFORM_MAX_END,
     PLATFORM_MOUNT_POINTS,
@@ -553,8 +554,14 @@ class BootLoader:
         if device.protected:
             valid = False
 
+        # Check disklabel - architecture validity via blivet's DiskLabel class
         if not self._is_valid_disklabel(device,
                                         disklabel_types=self.disklabel_types):
+            valid = False
+
+        # Check extra disklabel validity via anaconda's platform constraints
+        if not self._is_valid_disklabel(device,
+                                        disklabel_types=constraints[PLATFORM_DISK_LABEL_TYPES]):
             valid = False
 
         if not self._is_valid_size(device, desc=description):

--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -31,6 +31,7 @@ log = get_module_logger(__name__)
 
 # Names of stage1 constrains.
 PLATFORM_DEVICE_TYPES = "device_types"
+PLATFORM_DISK_LABEL_TYPES = "disklabel_types"
 PLATFORM_FORMAT_TYPES = "format_types"
 PLATFORM_MOUNT_POINTS = "mountpoints"
 PLATFORM_MAX_END = "max_end"
@@ -94,6 +95,7 @@ class Platform:
         """
         return {
             PLATFORM_DEVICE_TYPES: [],
+            PLATFORM_DISK_LABEL_TYPES: [],
             PLATFORM_FORMAT_TYPES: [],
             PLATFORM_MOUNT_POINTS: [],
             PLATFORM_MAX_END: None,
@@ -213,6 +215,7 @@ class EFI(Platform):
         constraints = {
             PLATFORM_FORMAT_TYPES: ["efi"],
             PLATFORM_DEVICE_TYPES: ["partition", "mdarray"],
+            PLATFORM_DISK_LABEL_TYPES: ["gpt"],
             PLATFORM_MOUNT_POINTS: ["/boot/efi"],
             PLATFORM_RAID_LEVELS: [raid.RAID1],
             PLATFORM_RAID_METADATA: ["1.0"],

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
@@ -80,6 +80,7 @@ class PlatformTestCase(unittest.TestCase):
         """Check the platform-specific constraints."""
         all_constraints = {
             "device_types": [],
+            "disklabel_types": [],
             "format_types": [],
             "mountpoints": [],
             "max_end": None,
@@ -233,6 +234,7 @@ class PlatformTestCase(unittest.TestCase):
             constraints={
                 "format_types": ["efi"],
                 "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt"],
                 "mountpoints": ["/boot/efi"],
                 "raid_levels": [raid.RAID1],
                 "raid_metadata": ["1.0"]
@@ -270,6 +272,7 @@ class PlatformTestCase(unittest.TestCase):
             constraints={
                 "format_types": ["efi"],
                 "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt"],
                 "mountpoints": ["/boot/efi"],
                 "raid_levels": [raid.RAID1],
                 "raid_metadata": ["1.0"]
@@ -307,6 +310,7 @@ class PlatformTestCase(unittest.TestCase):
             constraints={
                 "format_types": ["efi"],
                 "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt"],
                 "mountpoints": ["/boot/efi"],
                 "raid_levels": [raid.RAID1],
                 "raid_metadata": ["1.0"]
@@ -344,6 +348,7 @@ class PlatformTestCase(unittest.TestCase):
             constraints={
                 "format_types": ["efi"],
                 "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt"],
                 "mountpoints": ["/boot/efi"],
                 "raid_levels": [raid.RAID1],
                 "raid_metadata": ["1.0"]


### PR DESCRIPTION
Anaconda currently relies on blivet for disk label validation. However,
blivet does not impose any restrictions on using /boot/efi with
MBR formatted disks - a configuration that is technically allowed by the
UEFI specification but is known to cause failures on many real-word scenarios. [1]

This patch introduces a disklabel_types platform constraint and enforces
it during bootloader device validation. For EFI platforms, only the GPT
partitioning scheme is permitted.

This ensures that the EFI System Partition is created on a
compatible disk layout, preventing bootloader installation crashes due
to unsupported MBR setups. [2]

Additionally, this aligns Anaconda’s internal validation logic with its
existing user-facing error message, which already states that a
GPT-formatted disk is required for UEFI installations using /boot/efi. [3]

Finallly, this also aligns with official RHEL documentation related to
UEFI booting [4].

[1] https://wiki.archlinux.org/title/Partitioning#Choosing_between_GPT_and_MBR
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2369747
[3] https://github.com/rhinstaller/anaconda/blob/8d5b4d78ae7ce48b4c8e6b40b9a882c5ee0a34af/pyanaconda/modules/storage/platform.py#L197
[4] https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/installation_guide/sect-uefi-support-drives-x86
