### PR TITLE
pyanaconda: storage: enforce GPT partition table for ESP on EFI x86 platforms

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -41,6 +41,7 @@ from pyanaconda.modules.common.util import is_module_available
 from pyanaconda.modules.storage.bootloader.image import LinuxBootLoaderImage
 from pyanaconda.modules.storage.platform import (
     PLATFORM_DEVICE_TYPES,
+    PLATFORM_DISK_LABEL_TYPES,
     PLATFORM_FORMAT_TYPES,
     PLATFORM_MAX_END,
     PLATFORM_MOUNT_POINTS,
@@ -553,8 +554,14 @@ class BootLoader:
         if device.protected:
             valid = False
 
+        # Check disklabel - architecture validity via blivet's DiskLabel class
         if not self._is_valid_disklabel(device,
                                         disklabel_types=self.disklabel_types):
+            valid = False
+
+        # Check extra disklabel validity via anaconda's platform constraints
+        if not self._is_valid_disklabel(device,
+                                        disklabel_types=constraints[PLATFORM_DISK_LABEL_TYPES]):
             valid = False
 
         if not self._is_valid_size(device, desc=description):

--- a/pyanaconda/modules/storage/bootloader/factory.py
+++ b/pyanaconda/modules/storage/bootloader/factory.py
@@ -122,7 +122,7 @@ class BootLoaderFactory:
             from pyanaconda.modules.storage.bootloader.grub2 import GRUB2
             return GRUB2
 
-        if platform_class is platform.EFI:
+        if platform_class is platform.EFI or platform_class is platform.X86EFI:
             from pyanaconda.modules.storage.bootloader.efi import EFIGRUB
             return EFIGRUB
 

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
@@ -80,6 +80,7 @@ class PlatformTestCase(unittest.TestCase):
         """Check the platform-specific constraints."""
         all_constraints = {
             "device_types": [],
+            "disklabel_types": [],
             "format_types": [],
             "mountpoints": [],
             "max_end": None,
@@ -233,6 +234,40 @@ class PlatformTestCase(unittest.TestCase):
             constraints={
                 "format_types": ["efi"],
                 "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt", "msdos"],
+                "mountpoints": ["/boot/efi"],
+                "raid_levels": [raid.RAID1],
+                "raid_metadata": ["1.0"]
+            },
+            descriptions={
+                "partition": "EFI System Partition",
+                "mdarray": "RAID Device"
+            },
+            error_message=str(
+                "For a UEFI installation, you must include "
+                "an EFI System Partition on a GPT-formatted "
+                "disk, mounted at /boot/efi."
+            )
+        )
+
+    @patch("pyanaconda.modules.storage.platform.arch")
+    def test_x86_efi(self, arch):
+        """Test the x86 EFI platform."""
+        self._reset_arch(arch)
+        arch.is_efi.return_value = True
+        arch.is_x86.return_value = True
+
+        self._check_partitions(
+            PartSpec(mountpoint="/boot/efi", fstype="efi", grow=True,
+                     size=Size("500MiB"), max_size=Size("600MiB")),
+            PartSpec(mountpoint="/boot", size=Size("1GiB"))
+        )
+
+        self._check_constraints(
+            constraints={
+                "format_types": ["efi"],
+                "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt"],
                 "mountpoints": ["/boot/efi"],
                 "raid_levels": [raid.RAID1],
                 "raid_metadata": ["1.0"]
@@ -270,6 +305,7 @@ class PlatformTestCase(unittest.TestCase):
             constraints={
                 "format_types": ["efi"],
                 "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt", "msdos"],
                 "mountpoints": ["/boot/efi"],
                 "raid_levels": [raid.RAID1],
                 "raid_metadata": ["1.0"]
@@ -307,6 +343,7 @@ class PlatformTestCase(unittest.TestCase):
             constraints={
                 "format_types": ["efi"],
                 "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt", "msdos"],
                 "mountpoints": ["/boot/efi"],
                 "raid_levels": [raid.RAID1],
                 "raid_metadata": ["1.0"]
@@ -344,6 +381,7 @@ class PlatformTestCase(unittest.TestCase):
             constraints={
                 "format_types": ["efi"],
                 "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt", "msdos"],
                 "mountpoints": ["/boot/efi"],
                 "raid_levels": [raid.RAID1],
                 "raid_metadata": ["1.0"]


### PR DESCRIPTION
Anaconda currently relies on blivet for disk label validation. However, blivet does not impose restrictions on using /boot/efi with MBR (msdos) formatted disks — a configuration that is technically allowed by the UEFI specification but known to cause failures on many real-world x86 systems [1].

This patch introduces a `disklabel_types` constraint in platform definitions and enforces it during bootloader device validation. For the x86 EFI platform, only GPT is permitted. Other EFI-capable platforms (e.g., Aarch64, Arm, RISCV64) are unaffected and may continue using MBR where appropriate - such as in cloud or embedded environments where MBR UEFI booting is still used.

This change will help us avoid bootloader crashes caused by firmware failures when MBR is used [2].

Additionally, this aligns:
- Internal validation with the user-facing error message that already requires GPT for UEFI installs [3].
- Anaconda’s behavior with Red Hat and Fedora documentation recommendations [4].

[1] https://wiki.archlinux.org/title/Partitioning#Choosing_between_GPT_and_MBR
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2369747
[3] https://github.com/rhinstaller/anaconda/blob/8d5b4d78ae7ce48b4c8e6b40b9a882c5ee0a34af/pyanaconda/modules/storage/platform.py#L197
[4] https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/installation_guide/sect-uefi-support-drives-x86


Note:
--------
This is alternative to https://github.com/rhinstaller/anaconda/pull/6484 but limits this constraint to x86 platform.