### PR TITLE
Remove code related to backend_ready file

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -18,8 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-BACKEND_READY_FLAG=/run/anaconda/backend_ready
-
 WAYLAND_DISPLAY_SOCKET=/tmp/anaconda-wldisplay
 ATSPI_BUSADDR=/tmp/anaconda-atspibusaddr
 
@@ -223,12 +221,6 @@ if [ -n "$UPDATES" ]; then
 fi
 
 start_anaconda_web_ui() {
-    # remove flag file about initialized backend it shouldn't exists
-    # if the file existed before it might be a broken cleanup
-    if [ -e "$BACKEND_READY_FLAG" ]; then
-        echo "Anaconda backend flag file still exists! Probably a problem with cleanup. Removing now!" >&2
-        rm -f "$BACKEND_READY_FLAG" 2>/dev/null
-    fi
     # early execution of Firefox to reduce starting time
     mkdir -p /run/anaconda
     /usr/libexec/anaconda/webui-desktop -t live /cockpit/@localhost/anaconda-webui/index.html &

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -69,9 +69,6 @@ ANACONDA_CONFIG_TMP = "/run/anaconda/anaconda.conf"
 
 # file to store pid of the web viewer app to show Anaconda locally
 WEBUI_VIEWER_PID_FILE = "/run/anaconda/webui_script.pid"
-# flag file for Web UI to signalize that Anaconda backend is ready to be used
-# FIXME: Web UI should monitor the initialization itself
-BACKEND_READY_FLAG_FILE = "/run/anaconda/backend_ready"
 
 # NOTE: this should be LANG_TERRITORY.CODESET, e.g. en_US.UTF-8
 DEFAULT_LANG = "en_US.UTF-8"


### PR DESCRIPTION
The backend_ready file was originally used by the WebUI to signal when the backend is ready.
Instead of relying on this file, we now check for the presence of the bus address file.

Depends on: https://github.com/rhinstaller/anaconda-webui/pull/898 
