### PR TITLE
RHEL-10: Fix vconsole layout doesn't work for ostree

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -30,7 +30,7 @@ from pyanaconda.core.i18n import _
 from pyanaconda.core.path import make_directories, set_system_root
 from pyanaconda.core.util import execProgram, execWithRedirect
 from pyanaconda.modules.common.constants.objects import BOOTLOADER, DEVICE_TREE
-from pyanaconda.modules.common.constants.services import STORAGE
+from pyanaconda.modules.common.constants.services import LOCALIZATION, STORAGE
 from pyanaconda.modules.common.errors.installation import (
     BootloaderInstallationError,
     PayloadInstallationError,
@@ -568,6 +568,7 @@ class ConfigureBootloader(Task):
 
         bootloader = STORAGE.get_proxy(BOOTLOADER)
         device_tree = STORAGE.get_proxy(DEVICE_TREE)
+        localization = LOCALIZATION.get_proxy()
 
         root_name = device_tree.GetRootDevice()
         root_data = DeviceData.from_structure(
@@ -577,6 +578,7 @@ class ConfigureBootloader(Task):
         set_kargs_args = ["admin", "instutil", "set-kargs", "--merge"]
         set_kargs_args.extend(bootloader.GetArguments())
         set_kargs_args.append("root=" + device_tree.GetFstabSpec(root_name))
+        set_kargs_args.append("vconsole.keymap=" + localization.VirtualConsoleKeymap)
 
         if root_data.type == "btrfs subvolume":
             set_kargs_args.append("rootflags=subvol=" + root_name)

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -687,16 +687,20 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.LOCALIZATION")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
-    def test_btrfs_run(self, devdata_mock, storage_mock, symlink_mock, rename_mock, exec_mock):
+    def test_btrfs_run(self, devdata_mock, storage_mock, localization_mock,
+                       symlink_mock, rename_mock, exec_mock):
         """Test OSTree bootloader config task, no BTRFS"""
         exec_mock.return_value = [0, ""]
 
-        proxy_mock = storage_mock.get_proxy()
-        proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
-        proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
-        proxy_mock.GetRootDevice.return_value = "device-name"
+        storage_proxy_mock = storage_mock.get_proxy()
+        storage_proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
+        storage_proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
+        storage_proxy_mock.GetRootDevice.return_value = "device-name"
+        localization_proxy_mock = localization_mock.get_proxy()
+        localization_proxy_mock.VirtualConsoleKeymap = "cs"
         devdata_mock.from_structure.return_value.type = "btrfs subvolume"
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -722,6 +726,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                  "--merge",
                  "BOOTLOADER-ARGS",
                  "root=FSTAB-SPEC",
+                 "vconsole.keymap=cs",
                  "rootflags=subvol=device-name",
                  "rw"
                  ],
@@ -731,16 +736,20 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.LOCALIZATION")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
-    def test_nonbtrfs_run(self, devdata_mock, storage_mock, symlink_mock, rename_mock, exec_mock):
+    def test_nonbtrfs_run(self, devdata_mock, storage_mock, localization_mock,
+                          symlink_mock, rename_mock, exec_mock):
         """Test OSTree bootloader config task, no BTRFS"""
         exec_mock.return_value = [0, ""]
 
-        proxy_mock = storage_mock.get_proxy()
-        proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
-        proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
-        proxy_mock.GetRootDevice.return_value = "device-name"
+        storage_proxy_mock = storage_mock.get_proxy()
+        storage_proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
+        storage_proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
+        storage_proxy_mock.GetRootDevice.return_value = "device-name"
+        localization_proxy_mock = localization_mock.get_proxy()
+        localization_proxy_mock.VirtualConsoleKeymap = "cs"
         devdata_mock.from_structure.return_value.type = "something-non-btrfs-subvolume-ish"
 
         with tempfile.TemporaryDirectory() as sysroot:
@@ -766,6 +775,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                  "--merge",
                  "BOOTLOADER-ARGS",
                  "root=FSTAB-SPEC",
+                 "vconsole.keymap=cs",
                  "rw"
                  ],
                 root=sysroot
@@ -776,21 +786,24 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.LOCALIZATION")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
-    def test_bootupd_run(self, devdata_mock, storage_mock, symlink_mock, rename_mock, exec_mock,
-                         exec_redirect_mock, have_bootupd_mock):
+    def test_bootupd_run(self, devdata_mock, storage_mock, localization_mock, symlink_mock,
+                         rename_mock, exec_mock, exec_redirect_mock, have_bootupd_mock):
         """Test OSTree bootloader config task, bootupd"""
         exec_mock.return_value = [0, ""]
         exec_redirect_mock.return_value = 0
         have_bootupd_mock.return_value = True
 
-        proxy_mock = storage_mock.get_proxy()
-        proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
-        proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
-        proxy_mock.GetRootDevice.return_value = "device-name"
-        proxy_mock.Drive = "btldr-drv"
-        proxy_mock.KeepBootOrder = False
+        storage_proxy_mock = storage_mock.get_proxy()
+        storage_proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
+        storage_proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
+        storage_proxy_mock.GetRootDevice.return_value = "device-name"
+        storage_proxy_mock.Drive = "btldr-drv"
+        storage_proxy_mock.KeepBootOrder = False
+        localization_proxy_mock = localization_mock.get_proxy()
+        localization_proxy_mock.VirtualConsoleKeymap = "cs"
         devdata_mock.from_structure.return_value.type = "something-non-btrfs-subvolume-ish"
         devdata_mock.from_structure.return_value.path = "/dev/btldr-drv"
 
@@ -819,6 +832,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                      "--merge",
                      "BOOTLOADER-ARGS",
                      "root=FSTAB-SPEC",
+                     "vconsole.keymap=cs",
                      "rw"
                      ],
                     root=sysroot
@@ -830,21 +844,25 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.execProgram")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.rename")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.os.symlink")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.LOCALIZATION")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.STORAGE")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.DeviceData")
-    def test_bootupd_run_with_leavebootorder(self, devdata_mock, storage_mock, symlink_mock,
-                                             rename_mock, exec_mock,  exec_redirect_mock, have_bootupd_mock):
+    def test_bootupd_run_with_leavebootorder(self, devdata_mock, storage_mock, localization_mock,
+                                             symlink_mock, rename_mock, exec_mock, exec_redirect_mock,
+                                             have_bootupd_mock):
         """Test OSTree bootloader config task, bootupd"""
         exec_mock.return_value = [0, ""]
         exec_redirect_mock.return_value = 0
         have_bootupd_mock.return_value = True
 
-        proxy_mock = storage_mock.get_proxy()
-        proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
-        proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
-        proxy_mock.GetRootDevice.return_value = "device-name"
-        proxy_mock.Drive = "btldr-drv"
-        proxy_mock.KeepBootOrder = True
+        storage_proxy_mock = storage_mock.get_proxy()
+        storage_proxy_mock.GetArguments.return_value = ["BOOTLOADER-ARGS"]
+        storage_proxy_mock.GetFstabSpec.return_value = "FSTAB-SPEC"
+        storage_proxy_mock.GetRootDevice.return_value = "device-name"
+        storage_proxy_mock.Drive = "btldr-drv"
+        storage_proxy_mock.KeepBootOrder = True
+        localization_proxy_mock = localization_mock.get_proxy()
+        localization_proxy_mock.VirtualConsoleKeymap = "cs"
         devdata_mock.from_structure.return_value.type = "something-non-btrfs-subvolume-ish"
         devdata_mock.from_structure.return_value.path = "/dev/btldr-drv"
 
@@ -873,6 +891,7 @@ class ConfigureBootloaderTaskTestCase(unittest.TestCase):
                      "--merge",
                      "BOOTLOADER-ARGS",
                      "root=FSTAB-SPEC",
+                     "vconsole.keymap=cs",
                      "rw"
                      ],
                     root=sysroot


### PR DESCRIPTION
Seems that ostree currently doesn't work with localed as standard system so to overcome this issue and allow users to open LUKS devices during boot let's use vconsole.keymap kernel argument. It seems that this kernel boot argument was already used in the past but the solution changed, however, we cane use this as a hotfix specifically for ostree.

See more info in https://bugzilla.redhat.com/show_bug.cgi?id=1035316

Resolves: [RHEL-101058](https://issues.redhat.com/browse/RHEL-101058)
Backport of https://github.com/rhinstaller/anaconda/pull/5952

Kickstart test coverage: https://github.com/rhinstaller/kickstart-tests/pull/1446