### PR TITLE
infra: Remove tmpfs from Live ISO build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -404,8 +404,6 @@ container-live-iso-build:
 	--rm \
 	--tty \
 	--privileged \
-	$(shell test $(shell grep MemTotal /proc/meminfo | awk '{print $$2}') -gt 15000000 && \
-	  echo --tmpfs /var/tmp:rw,mode=1777) \
 	--device /dev/kvm \
 	-v $(srcdir)/result/build/01-rpm-build:/anaconda-rpms:ro \
 	-v $(srcdir)/result/iso:/images:z \


### PR DESCRIPTION
This is a fix for issue we have had with the standard ISO builds fixed by commit 6414d7e36ef2e1b0b41aaca5ae6a95eb89d4554a .

Potential reason of this bug might be that extended attributes are not supported on tmpfs. This worked before because there was a bug in kernel code which allowed this.