### PR TITLE
Make sure the pre_install queue is run (#2378660)

### DIFF
--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -663,6 +663,8 @@ class RunInstallationTask(InstallationTask):
             certificates_task = certificates_proxy.PreInstallWithTask(payload_proxy.Type)
             pre_install.append_dbus_tasks(SECURITY, [certificates_task])
 
+        installation_queue.append(pre_install)
+
         payload_install = TaskQueue(
             "Payload installation",
             _("Installing the software"),


### PR DESCRIPTION
Looks like we might have dropped this invocation unintentionally during recent modularization work. Should be fixed now & the affected tasks should now be running again as expected. :)

Resolves: rhbz#2378660