### PR TITLE
infra: Run branched Fedora tests on all main branch PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['']
+        release: ['', 'branched_fedora']
         include:
           - release: ''
             target_branch: 'main'
             ci_tag: 'main'
+          - release: 'branched_fedora'
+            target_branch: 'main'
+            ci_tag: 'branched_fedora'
+            build-args: '--build-arg=image=quay.io/fedora/fedora:42-x86_64'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
           #  target_branch: 'main'
@@ -93,11 +97,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['']
+        release: ['', 'branched_fedora']
         include:
           - release: ''
             target_branch: 'main'
             ci_tag: 'main'
+          - release: 'branched_fedora'
+            target_branch: 'main'
+            ci_tag: 'branched_fedora'
+            build-args: '--build-arg=image=quay.io/fedora/fedora:42-x86_64'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
           #  target_branch: 'main'

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -24,12 +24,16 @@ jobs:
         # * This is still a matrix because we might re-enable ELN one day and then we will need
         #   a matrix here.
         #}
-        release: ['']
+        release: ['', 'branched_fedora']
         include:
         {% if distro_name == "fedora" and distro_release == "rawhide" %}
           - release: ''
             target_branch: 'main'
             ci_tag: 'main'
+          - release: 'branched_fedora'
+            target_branch: 'main'
+            ci_tag: 'branched_fedora'
+            build-args: '--build-arg=image=quay.io/fedora/fedora:42-x86_64'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
           #  target_branch: 'main'
@@ -106,11 +110,15 @@ jobs:
       matrix:
         {# For matrix details, see comments for the unit tests above. #}
         {% if distro_name == "fedora" and distro_release == "rawhide" %}
-        release: ['']
+        release: ['', 'branched_fedora']
         include:
           - release: ''
             target_branch: 'main'
             ci_tag: 'main'
+          - release: 'branched_fedora'
+            target_branch: 'main'
+            ci_tag: 'branched_fedora'
+            build-args: '--build-arg=image=quay.io/fedora/fedora:42-x86_64'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
           #  target_branch: 'main'


### PR DESCRIPTION
As Fedora 43 has not been branched yet, lets use Fedora 42 for now so that the container is different from Rawhide.

Related: INSTALLER-4237