### PR TITLE
Revert "Default to GTK UI when available, fallback to Web UI otherwise"

### DIFF
--- a/data/liveinst/liveinst
+++ b/data/liveinst/liveinst
@@ -236,10 +236,8 @@ start_anaconda_web_ui() {
 }
 
 start_anaconda() {
-    # Start the Anaconda Web UI early to display the loading screen.
-    # This is done only if 'anaconda-webui' is installed and 'anaconda-gui' is not.
-    # Note: 'anaconda-gui' takes precedence over 'anaconda-webui'.
-    if [ -e "/usr/share/cockpit/anaconda-webui" ] && [ ! -d "/usr/share/anaconda/ui/spokes" ]; then
+    # start Firefox to use Anaconda Web UI if it is installed
+    if [ -e "/usr/share/cockpit/anaconda-webui" ]; then
         start_anaconda_web_ui
     fi
     # start Anaconda main process

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -158,11 +158,6 @@ class Anaconda:
         "Report if webui package is installed"
         return os.path.exists("/usr/share/cockpit/anaconda-webui")
 
-    @property
-    def is_gtk_ui_supported(self):
-        """Report if anaconda-gui package is installed."""
-        return os.path.exists("/usr/share/anaconda/ui/spokes")
-
     def log_display_mode(self):
         if not self.display_mode:
             log.error("Display mode is not set!")
@@ -217,17 +212,7 @@ class Anaconda:
         if self._intf:
             raise RuntimeError("Second attempt to initialize the InstallInterface")
 
-        if self.gui_mode and self.is_gtk_ui_supported:
-            from pyanaconda.ui.gui import GraphicalUserInterface
-            # Run the GUI in non-fullscreen mode, so live installs can still
-            # use the window manager
-            self._intf = GraphicalUserInterface(None, self.payload,
-                                                gui_lock=self.gui_initialized,
-                                                fullscreen=False)
-
-            # needs to be refreshed now we know if gui or tui will take place
-            addon_paths = collect_addon_ui_paths(ADDON_PATHS, "gui")
-        elif self.gui_mode and self.is_webui_supported:
+        if self.gui_mode and self.is_webui_supported:
             from pyanaconda.ui.webui import CockpitUserInterface
             self._intf = CockpitUserInterface(
                 None,
@@ -238,6 +223,16 @@ class Anaconda:
             # needs to be refreshed now we know if gui or tui will take place
             # FIXME - what about Cockpit based addons ?
             addon_paths = []
+        elif self.gui_mode:
+            from pyanaconda.ui.gui import GraphicalUserInterface
+            # Run the GUI in non-fullscreen mode, so live installs can still
+            # use the window manager
+            self._intf = GraphicalUserInterface(None, self.payload,
+                                                gui_lock=self.gui_initialized,
+                                                fullscreen=False)
+
+            # needs to be refreshed now we know if gui or tui will take place
+            addon_paths = collect_addon_ui_paths(ADDON_PATHS, "gui")
         elif self.tui_mode:
             # TUI and noninteractive TUI are the same in this regard
             from pyanaconda.ui.tui import TextUserInterface

--- a/pyanaconda/startup_utils.py
+++ b/pyanaconda/startup_utils.py
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 import os
+import pkgutil
 import sys
 import time
 
@@ -212,11 +213,15 @@ def fallback_to_tui_if_gtk_ui_is_not_available(anaconda):
 
     Also take into account Web UI.
     """
-    if anaconda.gui_mode and not anaconda.is_webui_supported and not anaconda.is_gtk_ui_supported:
-        stdout_log.warning("Graphical user interface not available, falling back to text mode")
-        anaconda.display_mode = DisplayModes.TUI
-        flags.use_rd = False
-        flags.rd_question = False
+    if anaconda.gui_mode and not anaconda.is_webui_supported:
+        import pyanaconda.ui
+
+        mods = (tup[1] for tup in pkgutil.iter_modules(pyanaconda.ui.__path__, "pyanaconda.ui."))
+        if "pyanaconda.ui.gui" not in mods:
+            stdout_log.warning("Graphical user interface not available, falling back to text mode")
+            anaconda.display_mode = DisplayModes.TUI
+            flags.use_rd = False
+            flags.rd_question = False
 
 
 def setup_logging_from_options(options):

--- a/tests/unit_tests/pyanaconda_tests/core/test_startup_utils.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_startup_utils.py
@@ -317,8 +317,9 @@ class StartupUtilsGeolocApplyTestCase(unittest.TestCase):
 
 class TestUIHelpers(unittest.TestCase):
 
+    @patch("pyanaconda.startup_utils.pkgutil")
     @patch("pyanaconda.startup_utils.flags")
-    def test_fallback_tui_when_gtk_ui_not_available(self, mocked_flags):
+    def test_fallback_tui_when_gtk_ui_not_available(self, mocked_flags, mocked_pkgutil):
         mocked_anaconda = Mock()
 
         def check_method(gui_mode,
@@ -328,12 +329,16 @@ class TestUIHelpers(unittest.TestCase):
                          expected_rd_output):
             mocked_anaconda.gui_mode = gui_mode
             mocked_anaconda.is_webui_supported = webui_supported
-            mocked_anaconda.is_gtk_ui_supported = gtk_available
 
             # prefilled values
             mocked_anaconda.display_mode = ""
             mocked_flags.use_rd = None
             mocked_flags.rd_question = None
+
+            if gtk_available:
+                mocked_pkgutil.iter_modules.return_value = [(None, "pyanaconda.ui.gui")]
+            else:
+                mocked_pkgutil.iter_modules.return_value = [(None, "pyanaconda.ui.webui")]
 
             fallback_to_tui_if_gtk_ui_is_not_available(mocked_anaconda)
 


### PR DESCRIPTION
This reverts commit 488e49327d49cd554e0d973f412a6e44a1fb1b82.

Note:
`anaconda-gui` is pulled in by main anaconda package. See https://github.com/rhinstaller/anaconda/pull/6538 When this is resolved we can consider reverting this.

