### PR TITLE
bootloader: efi: utilize grub2-common script for handling config file generation

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -90,7 +90,7 @@ class EFIBase(object):
             "-l", self.efi_dir_as_efifs_dir + self._efi_binary,  # pylint: disable=no-member
             root=conf.target.system_root
         )
-        if rc:
+        if rc != 0:
             raise BootLoaderError("Failed to set new efi boot target. This is most "
                                   "likely a kernel or firmware bug.")
 
@@ -178,27 +178,14 @@ class EFIGRUB(EFIBase, GRUB2):
         return "%s/%s" % (self.efi_config_dir, self._config_file)
 
     def write_config(self):
-        config_path = "%s%s" % (conf.target.system_root, self.efi_config_file)
+        rc = util.execWithRedirect(
+            "gen_grub_cfgstub",
+            [self.config_dir, self.efi_config_dir],
+            root=conf.target.system_root,
+        )
 
-        with open(config_path, "w") as fd:
-            grub_dir = self.config_dir
-            if self.stage2_device.format.type != "btrfs":
-                fs_uuid = self.stage2_device.format.uuid
-            else:
-                fs_uuid = self.stage2_device.format.vol_uuid
-
-            if fs_uuid is None:
-                raise BootLoaderError("Could not get stage2 filesystem UUID")
-
-            grub_dir = util.execWithCapture("grub2-mkrelpath", [grub_dir],
-                                            root=conf.target.system_root)
-            if not grub_dir:
-                raise BootLoaderError("Could not get GRUB directory path")
-
-            fd.write("search --no-floppy --fs-uuid --set=dev %s\n" % fs_uuid)
-            fd.write("set prefix=($dev)%s\n" % grub_dir)
-            fd.write("export $prefix\n")
-            fd.write("configfile $prefix/grub.cfg\n")
+        if rc != 0:
+            raise BootLoaderError("gen_grub_cfgstub script failed")
 
         super().write_config()
 


### PR DESCRIPTION
Our backend now executes the grub2-common shared script to generate efi config files.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2327644

Cherry-picked from: 23afdae50107f0a49b2e6ffe335210684fb8288f

Note: I removed the grub2 version requirement from the spec file, the required version is available in RHEL already [1]

[1] https://gitlab.com/redhat/centos-stream/rpms/grub2/-/commit/9d0f911af62979d8f7f928d447bf0683bf8ad3d4

Resolves: RHEL-58830

**Thank you** for your contribution!

Please check that your PR follows these rules:

* [ ] [**Code conventions**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#code-conventions). tl;dr: Follow PEP8, wrap at 100 chars, and provide docstrings.

* [ ] [**Commit message conventions**](https://anaconda-installer.readthedocs.io/en/latest/commit-log.html). tl;dr: Heading, empty line, longer explanations, all wrapped manually. If in doubt, write a longer commit message with more details.

* [ ] **Tests** pass and cover your changes. You can [run tests locally manually](https://anaconda-installer.readthedocs.io/en/latest/testing.html), or have them run as part of the PR. A team member will have to enable tests manually after inspecting the PR.
  *If you don't know how, ask us for help!*

* [ ] [**Release notes**](https://anaconda-installer.readthedocs.io/en/latest/contributing.html#release-notes) and **docs** if the PR adds something major or changes existing behavior.
  *If you don't know how, ask us for help!*

* [ ] **RHEL** rules: If your PR is for a `rhel-*` branch, pay special attention to commit messages. Make sure **all** commit messages include a line linking the commit to a bug, such as `Resolves: RHEL-123456`. For more information, see [the complete rules](https://anaconda-installer.readthedocs.io/en/latest/developer/commit-log.html).
  *If you don't know how, ask us for help!*

Don't forget - *if you don't know how, ask us for help!*

And now that you read this all, you can delete it and type your own description of your changes :-)
