### PR TITLE
bootloader: efi: utilize grub2-common script for handling config file generation

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -131,6 +131,10 @@ Requires: python3-pid
 Requires: crypto-policies
 Requires: crypto-policies-scripts
 
+%ifnarch s390 s390x
+Requires: grub2-common
+%endif
+
 # required because of the rescue mode and VNC question
 Requires: anaconda-tui = %{version}-%{release}
 

--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -77,7 +77,7 @@ class EFIBase(object):
             "-l", self.efi_dir_as_efifs_dir + self._efi_binary,  # pylint: disable=no-member
             root=conf.target.system_root
         )
-        if rc:
+        if rc != 0:
             raise BootLoaderError("Failed to set new efi boot target. This is most "
                                   "likely a kernel or firmware bug.")
 
@@ -170,27 +170,14 @@ class EFIGRUB(EFIBase, GRUB2):
         return "%s/%s" % (self.efi_config_dir, self._config_file)
 
     def write_config(self):
-        config_path = "%s%s" % (conf.target.system_root, self.efi_config_file)
+        rc = util.execWithRedirect(
+            "gen_grub_cfgstub",
+            [self.config_dir, self.efi_config_dir],
+            root=conf.target.system_root,
+        )
 
-        with open(config_path, "w") as fd:
-            grub_dir = self.config_dir
-            if self.stage2_device.format.type != "btrfs":
-                fs_uuid = self.stage2_device.format.uuid
-            else:
-                fs_uuid = self.stage2_device.format.vol_uuid
-
-            if fs_uuid is None:
-                raise BootLoaderError("Could not get stage2 filesystem UUID")
-
-            grub_dir = util.execWithCapture("grub2-mkrelpath", [grub_dir],
-                                            root=conf.target.system_root)
-            if not grub_dir:
-                raise BootLoaderError("Could not get GRUB directory path")
-
-            fd.write("search --no-floppy --fs-uuid --set=dev %s\n" % fs_uuid)
-            fd.write("set prefix=($dev)%s\n" % grub_dir)
-            fd.write("export $prefix\n")
-            fd.write("configfile $prefix/grub.cfg\n")
+        if rc != 0:
+            raise BootLoaderError("gen_grub_cfgstub script failed")
 
         super().write_config()
 


### PR DESCRIPTION
Our backend now executes the grub2-common shared script to generate efi config files.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2327644

Cherry-picked from: 23afdae50107f0a49b2e6ffe335210684fb8288f

Note: I removed the grub2 version requirement from the spec file, the required version is available in RHEL already [1]

[1] https://gitlab.com/redhat/centos-stream/rpms/grub2/-/commit/f63b7984e5919d4c2d0bf90e4ed39783d33ad3f9

Resolves: RHEL-36187