### PR TITLE
storage: Fix AttributeError and protect installation media in bootloader partition removal

### DIFF
--- a/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/automatic/automatic_partitioning.py
@@ -142,7 +142,7 @@ class AutomaticPartitioningTask(NonInteractivePartitioningTask):
             return False
         part_type = bootloader_parts[0].fstype
 
-        partition_table_types = {disk.format.parted_disk.type for disk in storage.disks}
+        partition_table_types = {disk.format.parted_disk.type for disk in storage.disks if disk.partitioned and not disk.protected}
         devices = []
 
         for device in storage.devices:


### PR DESCRIPTION
The _remove_bootloader_partitions method was accessing parted_disk.type on all disks in storage.disks without proper filtering. This caused an AttributeError when CD/DVD/ISO devices were present, as these devices don't have partition tables and thus lack the parted_disk attribute.

The fix adds two conditions when building the set of partition table types:
1. disk.partitioned - ensures the disk has a partition table before accessing parted_disk
2. not disk.protected - prevents operating on installation media and other protected devices

This issue likely wasn't encountered before because it only arises when both regular disks and optical media are selected as installation targets during automatic partitioning — a scenario that's uncommon. Typically, installation media (like the ISO on optical media) is not among the selected target disks.

Fixes: rhbz#2383145
