### PR TITLE
infra: Build F43 containers & run F43 tests on main branch PRs

### DIFF
--- a/.branch-variables.yml
+++ b/.branch-variables.yml
@@ -18,3 +18,12 @@ supported_branches:
     variant: "rhel"
   - rhel-10:
     variant: "rhel"
+  - fedora-43:
+    variant: "fedora"
+
+# List of all the branches which should get translation updates
+translation_branches:
+  - rhel-9:
+    variant: "rhel"
+  - rhel-10:
+    variant: "rhel"

--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', 'rhel-9', 'rhel-10']
+        branch: ['main', 'rhel-9', 'rhel-10', 'fedora-43']
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
     uses: ./.github/workflows/container-rebuild-action.yml

--- a/.github/workflows/l10n-po-update.yml.j2
+++ b/.github/workflows/l10n-po-update.yml.j2
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        branch: ['main'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
+        branch: ['main'{% for branch in translation_branches %}, '{$ branch|first $}'{% endfor %}]
 
     steps:
       - name: Set up dependencies

--- a/.github/workflows/tests-daily.yml
+++ b/.github/workflows/tests-daily.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['main', 'rhel-9', 'rhel-10']
+        release: ['main', 'rhel-9', 'rhel-10', 'fedora-43']
         include:
           - release: 'main'
             target_branch: 'main'
@@ -58,6 +58,9 @@ jobs:
           - release: 'rhel-10'
             target_branch: 'rhel-10'
             ci_tag: 'rhel-10'
+          - release: 'fedora-43'
+            target_branch: 'fedora-43'
+            ci_tag: 'fedora-43'
 
     env:
       CI_TAG: '${{ matrix.ci_tag }}'
@@ -90,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['main', 'rhel-9', 'rhel-10']
+        release: ['main', 'rhel-9', 'rhel-10', 'fedora-43']
         include:
           - release: 'main'
             target_branch: 'main'
@@ -101,6 +104,9 @@ jobs:
           - release: 'rhel-10'
             target_branch: 'rhel-10'
             ci_tag: 'rhel-10'
+          - release: 'fedora-43'
+            target_branch: 'fedora-43'
+            ci_tag: 'fedora-43'
 
     env:
       CI_TAG: '${{ matrix.ci_tag }}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['']
+        release: ['', 'branched_fedora']
         include:
           - release: ''
             target_branch: 'main'
             ci_tag: 'main'
+          - release: 'branched_fedora'
+            target_branch: 'main'
+            ci_tag: 'fedora-43'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
           #  target_branch: 'main'
@@ -93,11 +96,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: ['']
+        release: ['', 'branched_fedora']
         include:
           - release: ''
             target_branch: 'main'
             ci_tag: 'main'
+          - release: 'branched_fedora'
+            target_branch: 'main'
+            ci_tag: 'fedora-43'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
           #  target_branch: 'main'

--- a/.github/workflows/tests.yml.j2
+++ b/.github/workflows/tests.yml.j2
@@ -24,12 +24,15 @@ jobs:
         # * This is still a matrix because we might re-enable ELN one day and then we will need
         #   a matrix here.
         #}
-        release: ['']
+        release: ['', 'branched_fedora']
         include:
         {% if distro_name == "fedora" and distro_release == "rawhide" %}
           - release: ''
             target_branch: 'main'
             ci_tag: 'main'
+          - release: 'branched_fedora'
+            target_branch: 'main'
+            ci_tag: 'fedora-43'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
           #  target_branch: 'main'
@@ -106,11 +109,14 @@ jobs:
       matrix:
         {# For matrix details, see comments for the unit tests above. #}
         {% if distro_name == "fedora" and distro_release == "rawhide" %}
-        release: ['']
+        release: ['', 'branched_fedora']
         include:
           - release: ''
             target_branch: 'main'
             ci_tag: 'main'
+          - release: 'branched_fedora'
+            target_branch: 'main'
+            ci_tag: 'fedora-43'
           ## add to  release: [...]  also eln if re-enabled by uncommenting the below
           #- release: eln
           #  target_branch: 'main'

--- a/.github/workflows/try-release-daily.yml
+++ b/.github/workflows/try-release-daily.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', 'rhel-9', 'rhel-10']
+        branch: ['main', 'rhel-9', 'rhel-10', 'fedora-43']
 
     steps:
       - name: Check out repo


### PR DESCRIPTION
Looks like we will need the Fedora 43 containers at least for running Fedora 43 tests on main branch PRs and quite likely also for other things (release tarball building ?).

Also we want to try not having per-Fedora 43 translation folder, so lets change the template to track that separately. That way we can keep the "main" translation folder for both Rawhide and Fedora 43.