### PR TITLE
infra: Temporary override for COPR use in containers

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -44,6 +44,10 @@ RUN set -ex; \
   # Enable COPR repositories
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     CI_TAG="${ci_tag}"; \
+    # FIXME: remove after Fedora COPR can build Fedora 43 packages
+    if [ $CI_TAG == "fedora-43" ]; then \
+      CI_TAG="fedora-rawhide"; \
+    fi; \
     dnf copr enable -y ${copr_repo} ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/blivet-daily ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/udisks-daily ${CI_TAG}-x86_64; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -49,6 +49,10 @@ RUN set -ex; \
   rpmlint; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     CI_TAG=${ci_tag}; \
+    # FIXME: remove after Fedora COPR can build Fedora 43 packages
+    if [ $CI_TAG == "fedora-43" ]; then \
+      CI_TAG="fedora-rawhide"; \
+    fi; \
     dnf copr enable -y ${copr_repo} ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/blivet-daily ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/udisks-daily ${CI_TAG}-x86_64; \


### PR DESCRIPTION
We need to use Rawhide COPR for Fedora 43 builds until COPR gets a Fedora 43 target after branching.

Otherwise we are not able verify our branched Fedora test runs until after Fedora 43 branches.