### PR TITLE
packit: Add bruno-fs to allowed PR authors/committers/builders

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -88,12 +88,14 @@ jobs:
       - rvykydal
       - jkonecny
       - packit
+      - bruno-fs
     allowed_pr_authors:
       - m4rtink
       - kkoukiou
       - rvykydal
       - jkonecny
       - packit
+      - bruno-fs
 
   - job: bodhi_update
     trigger: koji_build
@@ -109,3 +111,4 @@ jobs:
       - rvykydal
       - jkonecny
       - packit
+      - bruno-fs

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -132,12 +132,14 @@ jobs:
       - rvykydal
       - jkonecny
       - packit
+      - bruno-fs
     allowed_pr_authors:
       - m4rtink
       - kkoukiou
       - rvykydal
       - jkonecny
       - packit
+      - bruno-fs
 
   - job: bodhi_update
     trigger: koji_build
@@ -153,4 +155,5 @@ jobs:
       - rvykydal
       - jkonecny
       - packit
+      - bruno-fs
 {% endif %}


### PR DESCRIPTION
Adding a new maintainer to packit allowed commiters, PR authors and builders lists.