### PR TITLE
infra: update container update workflows to use release-specific CI tags

### DIFF
--- a/.github/workflows/container-autoupdate.yml
+++ b/.github/workflows/container-autoupdate.yml
@@ -20,11 +20,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main', 'rhel-9', 'rhel-10', 'fedora-43']
+        release: ['main', 'rhel-9', 'rhel-10', 'fedora-43']
+        include:
+          - release: 'main'
+            target_branch: 'main'
+            ci_tag: 'fedora-rawhide'
+          - release: 'rhel-9'
+            target_branch: 'rhel-9'
+            ci_tag: 'rhel-9'
+          - release: 'rhel-10'
+            target_branch: 'rhel-10'
+            ci_tag: 'rhel-10'
+          - release: 'fedora-43'
+            target_branch: 'fedora-43'
+            ci_tag: 'fedora-43'
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
     uses: ./.github/workflows/container-rebuild-action.yml
     secrets: inherit
     with:
-      container-tag: ${{ matrix.branch }}
-      branch: ${{ matrix.branch }}
+      container-tag: ${{ matrix.ci_tag }}
+      branch: ${{ matrix.target_branch }}

--- a/.github/workflows/container-autoupdate.yml.j2
+++ b/.github/workflows/container-autoupdate.yml.j2
@@ -13,11 +13,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['main'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
+        release: ['main'{% for branch in supported_branches %}, '{$ branch|first $}'{% endfor %}]
+        include:
+          - release: 'main'
+            target_branch: 'main'
+            ci_tag: 'fedora-rawhide'
+        {% for branch in supported_branches %}
+          - release: '{$ branch|first $}'
+            target_branch: '{$ branch|first $}'
+            ci_tag: '{$ branch|first $}'
+        {% endfor %}
     # Don't run scheduled workflows on forks.
     if: github.event_name != 'schedule' || github.repository == 'rhinstaller/anaconda'
     uses: ./.github/workflows/container-rebuild-action.yml
     secrets: inherit
     with:
-      container-tag: ${{ matrix.branch }}
-      branch: ${{ matrix.branch }}
+      container-tag: ${{ matrix.ci_tag }}
+      branch: ${{ matrix.target_branch }}

--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -95,8 +95,8 @@ jobs:
         run: podman login -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
 
         # we can hardcode the path to the image here because this will be executed only for main image
-      - name: Add latest tag for main container
-        if: ${{ inputs.container-tag == 'main' }}
+      - name: Add latest tag for fedora-rawhide container
+        if: ${{ inputs.container-tag == 'fedora-rawhide' }}
         run: |
           podman tag quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:main quay.io/rhinstaller/anaconda-${{ matrix.container-type }}:latest
           CI_TAG=latest make -f Makefile.am anaconda-${{ matrix.container-type }}-push


### PR DESCRIPTION
Update GitHub workflows to use CI_TAG for container builds. This is follow up for 767333961ac6ef4e93d14ff144f2ac0c86e3173e.

