### PR TITLE
build: decouple BASE_CONTAINER from branch configuration

### DIFF
--- a/.github/workflows/container-autoupdate-eln.yml
+++ b/.github/workflows/container-autoupdate-eln.yml
@@ -26,4 +26,3 @@ jobs:
     with:
       container-tag: eln
       branch: main
-      base-container: 'quay.io/fedoraci/fedora:eln-x86_64'

--- a/.github/workflows/container-autoupdate-eln.yml.j2
+++ b/.github/workflows/container-autoupdate-eln.yml.j2
@@ -20,5 +20,4 @@ jobs:
     with:
       container-tag: eln
       branch: main
-      base-container: 'quay.io/fedoraci/fedora:eln-x86_64'
 {% endif %}

--- a/.github/workflows/container-rebuild-action.yml
+++ b/.github/workflows/container-rebuild-action.yml
@@ -36,9 +36,6 @@ on:
       branch:
         required: true
         type: string
-      base-container:
-        required: false
-        type: string
     # secrets consumed: QUAY_USERNAME, QUAY_PASSWORD
     # these are provided by using the quay.io environment below
 
@@ -65,8 +62,7 @@ jobs:
 
       - name: Build anaconda-${{ matrix.container-type }} container
         run: |
-          BASE_CONTAINER=${{ inputs.base-container }}
-          make -f Makefile.am anaconda-${{ matrix.container-type }}-build ${BASE_CONTAINER:+BASE_CONTAINER=}${BASE_CONTAINER:-}
+          make -f Makefile.am anaconda-${{ matrix.container-type }}-build
 
       - name: Run tests in anaconda-ci container
         if: matrix.container-type == 'ci'

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,6 +74,22 @@ TEST_INST_BUILD_DIR = $(BUILD_RESULT_DIR)/02-test-install
 # Program for rendering infra Jinja2 templates
 TEMPLATE_RENDERER = scripts/jinja-render
 
+# Parse CI_TAG into distro and version (e.g., "fedora-41" or "rhel-9")
+CI_TAG_DISTRO := $(word 1,$(subst -, ,$(CI_TAG)))
+CI_TAG_VERSION := $(word 2,$(subst -, ,$(CI_TAG)))
+
+# Compute BASE_CONTAINER based on CI_TAG
+BASE_CONTAINER = $(strip \
+  $(if $(filter eln,$(CI_TAG)), \
+      $(ELN_CONTAINER_REGISTRY)/fedoraci/fedora:eln-x86_64, \
+      $(if $(filter fedora,$(CI_TAG_DISTRO)), \
+          $(FEDORA_CONTAINER_REGISTRY)/$(CI_TAG_DISTRO):$(CI_TAG_VERSION), \
+          $(if $(filter rhel,$(CI_TAG_DISTRO)), \
+              $(CENTOS_CONTAINER_REGISTRY)/centos/centos:stream$(CI_TAG_VERSION)-development, \
+          ) \
+      ) \
+  ))
+
 # Helper target to print CI_TAG for workflows
 print-CI_TAG:
 	@echo $(CI_TAG)

--- a/branch-config.mk
+++ b/branch-config.mk
@@ -25,6 +25,10 @@
 # Store a branch specific configuration here to avoid dealing with
 # conflicts on multiple places.
 
+FEDORA_CONTAINER_REGISTRY = registry.fedoraproject.org
+CENTOS_CONTAINER_REGISTRY = quay.io
+ELN_CONTAINER_REGISTRY = quay.io
+
 
 # Name of the expected current git branch.
 # This could be main, fedora-XX, rhel-X ...
@@ -33,9 +37,6 @@ CI_TAG ?= fedora-rawhide
 
 # Directory for this anaconda branch in anaconda-l10n repository. This could be main, fXX, rhel-8 etc.
 L10N_DIR ?= main
-
-# Base container for our containers.
-BASE_CONTAINER ?= registry.fedoraproject.org/fedora:rawhide
 
 # COPR repo for use in container builds.
 COPR_REPO ?= \@rhinstaller/Anaconda

--- a/branch-config.mk.j2
+++ b/branch-config.mk.j2
@@ -18,6 +18,10 @@
 # Store a branch specific configuration here to avoid dealing with
 # conflicts on multiple places.
 
+FEDORA_CONTAINER_REGISTRY = registry.fedoraproject.org
+CENTOS_CONTAINER_REGISTRY = quay.io
+ELN_CONTAINER_REGISTRY = quay.io
+
 {% if distro_name == "fedora" and distro_release == "rawhide" %}
 
 # Name of the expected current git branch.
@@ -28,9 +32,6 @@ CI_TAG ?= fedora-rawhide
 # Directory for this anaconda branch in anaconda-l10n repository. This could be main, fXX, rhel-8 etc.
 L10N_DIR ?= main
 
-# Base container for our containers.
-BASE_CONTAINER ?= registry.fedoraproject.org/fedora:rawhide
-
 # COPR repo for use in container builds.
 COPR_REPO ?= \@rhinstaller/Anaconda
 
@@ -38,21 +39,21 @@ COPR_REPO ?= \@rhinstaller/Anaconda
 
 GIT_BRANCH ?= fedora-{$ distro_release $}
 L10N_DIR ?= f{$ distro_release $}
-BASE_CONTAINER ?= registry.fedoraproject.org/fedora:{$ distro_release $}
+
 COPR_REPO ?= \@rhinstaller/Anaconda
 
 {% elif distro_name == "rhel" and distro_release != 10 %}
 
 GIT_BRANCH ?= rhel-{$ distro_release $}
 L10N_DIR ?= rhel-{$ distro_release $}
-BASE_CONTAINER ?= quay.io/centos/centos:stream9
+
 COPR_REPO ?= rhinstaller-group/Anaconda
 
 {% elif distro_name == "rhel" and distro_release == 10 %}
 
 GIT_BRANCH ?= rhel-{$ distro_release $}
 L10N_DIR ?= rhel-{$ distro_release $}
-BASE_CONTAINER ?= quay.io/centos/centos:stream10-development
+
 COPR_REPO ?= rhinstaller-group/Anaconda
 
 {% endif %}


### PR DESCRIPTION
Replace branch-specific BASE_CONTAINER definitions with dynamic construction from CI_TAG. This eliminates the need for per-branch container configuration while maintaining proper registry usage.
