### PR TITLE
infra: expose CI_TAG on KS tests (fixes regression from 031e684a6575)

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -116,6 +116,7 @@ jobs:
        ISO_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-iso-creator'
        RPM_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-rpm'
        TEST_JOBS: 16
+       CONTAINER_TAG: fedora-rawhide
     steps:
       # we post statuses manually as this does not run from a pull_request event
       # https://developer.github.com/v3/repos/statuses/#create-a-status
@@ -240,12 +241,12 @@ jobs:
       - name: Build anaconda-iso-creator container image
         working-directory: ./anaconda
         run: |
-          sudo make -f ./Makefile.am anaconda-iso-creator-build
+          sudo make -f ./Makefile.am anaconda-iso-creator-build CI_TAG=$CONTAINER_TAG
 
       - name: Build anaconda-rpm container (for RPM build)
         working-directory: ./anaconda
         run: |
-          make -f ./Makefile.am anaconda-rpm-build
+          make -f ./Makefile.am anaconda-rpm-build CI_TAG=$CONTAINER_TAG
 
       - name: Build Anaconda RPM files
         working-directory: ./anaconda

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -110,6 +110,7 @@ jobs:
        ISO_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-iso-creator'
        RPM_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-rpm'
        TEST_JOBS: 16
+       CONTAINER_TAG: {$ distro_name $}-{$ distro_release $}
     steps:
       # we post statuses manually as this does not run from a pull_request event
       # https://developer.github.com/v3/repos/statuses/#create-a-status
@@ -234,12 +235,12 @@ jobs:
       - name: Build anaconda-iso-creator container image
         working-directory: ./anaconda
         run: |
-          sudo make -f ./Makefile.am anaconda-iso-creator-build
+          sudo make -f ./Makefile.am anaconda-iso-creator-build CI_TAG=$CONTAINER_TAG
 
       - name: Build anaconda-rpm container (for RPM build)
         working-directory: ./anaconda
         run: |
-          make -f ./Makefile.am anaconda-rpm-build
+          make -f ./Makefile.am anaconda-rpm-build CI_TAG=$CONTAINER_TAG
 
       - name: Build Anaconda RPM files
         working-directory: ./anaconda


### PR DESCRIPTION
Commit 031e684a657548f357c513164be95521af20afae partially removed CONTAINER_TAG, leaving stray usages that made CI_TAG undefined, and broke KS runs. On main, we intentionally keep CI_TAG=fedora-rawhide for now to run KS tests against Fedora Rawhide while in the future we will add support for additional releases on main branch (e.g., Fedora 43).

