### PR TITLE
Revert "infra: Temporary override for COPR use in containers"

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -44,10 +44,6 @@ RUN set -ex; \
   # Enable COPR repositories
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     CI_TAG="${ci_tag}"; \
-    # FIXME: remove after Fedora COPR can build Fedora 43 packages
-    if [ $CI_TAG == "fedora-43" ]; then \
-      CI_TAG="fedora-rawhide"; \
-    fi; \
     dnf copr enable -y ${copr_repo} ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/blivet-daily ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/udisks-daily ${CI_TAG}-x86_64; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -49,10 +49,6 @@ RUN set -ex; \
   rpmlint; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
     CI_TAG=${ci_tag}; \
-    # FIXME: remove after Fedora COPR can build Fedora 43 packages
-    if [ $CI_TAG == "fedora-43" ]; then \
-      CI_TAG="fedora-rawhide"; \
-    fi; \
     dnf copr enable -y ${copr_repo} ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/blivet-daily ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/udisks-daily ${CI_TAG}-x86_64; \


### PR DESCRIPTION
COPR now supports Fedora 43 so the override is no longer needed.

This reverts commit 9d023355927860b926f61e74215e07c4e1068fb0.