### PR TITLE
Get full nevra string from dnf instead of composing it

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/transaction_progress.py
+++ b/pyanaconda/modules/payloads/payload/dnf/transaction_progress.py
@@ -98,16 +98,7 @@ class TransactionProgress(libdnf5.rpm.TransactionCallbacks):
             # There reason is some scriptlets (namely file triggers) can be run for a package
             # that is not part of the transaction.
             item.get_package().to_string() if item else "unknown",
-            # FIXME: Get nevra instead of composing it from all the fields.
-            #        See issue: https://github.com/rpm-software-management/dnf5/issues/1644
-            #libdnf5.rpm.to_full_nevra_string(nevra),
-            "{name}-{epoch}:{version}-{release}.{arch}".format(
-                name=nevra.get_name(),
-                epoch=nevra.get_epoch(),
-                version=nevra.get_version(),
-                release=nevra.get_release(),
-                arch=nevra.get_arch()
-            ),
+            libdnf5.rpm.to_full_nevra_string(nevra),
             libdnf5.rpm.TransactionCallbacks.script_type_to_string(type)
         )
         self._queue.put(('configure', "%s.%s" % (nevra.get_name(), nevra.get_arch())))
@@ -127,16 +118,7 @@ class TransactionProgress(libdnf5.rpm.TransactionCallbacks):
             # There reason is some scriptlets (namely file triggers) can be run for a package
             # that is not part of the transaction.
             item.get_package().to_string() if item else "unknown",
-            # FIXME: Get nevra instead of composing it from all the fields.
-            #        See issue: https://github.com/rpm-software-management/dnf5/issues/1644
-            #libdnf5.rpm.to_full_nevra_string(nevra),
-            "{name}-{epoch}:{version}-{release}.{arch}".format(
-                name=nevra.get_name(),
-                epoch=nevra.get_epoch(),
-                version=nevra.get_version(),
-                release=nevra.get_release(),
-                arch=nevra.get_arch()
-            ),
+            libdnf5.rpm.to_full_nevra_string(nevra),
             libdnf5.rpm.TransactionCallbacks.script_type_to_string(type),
             return_code
         )

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -550,9 +550,12 @@ class DNFManagerTestCase(unittest.TestCase):
         package.to_string.return_value = name + "-1.2-3.x86_64"
         package.get_action.return_value = action
 
-        nevra = Mock(spec=libdnf5.rpm.Nevra)
-        nevra.get_name.return_value = name
-        nevra.get_arch.return_value = "x86_64"
+        nevra = libdnf5.rpm.Nevra()
+        nevra.set_name(name)
+        nevra.set_epoch("0")
+        nevra.set_release("3")
+        nevra.set_arch("x86_64")
+        nevra.set_version("1.2")
 
         item = Mock(spec=libdnf5.base.TransactionPackage)
         item.get_package.return_value = package


### PR DESCRIPTION
The libdnf5.rpm.to_full_nevra_string got available even in bindings, so, it can be used when getting the nevra string for reporting transaction progress.