### PR TITLE
storage: devicetree: read VERSION or VERSION_CODENAME for identifying OS from os-release

### DIFF
--- a/pyanaconda/modules/storage/devicetree/root.py
+++ b/pyanaconda/modules/storage/devicetree/root.py
@@ -242,6 +242,10 @@ def _release_from_os_release(fn):
                 # Throw away the "=".
                 parser.get_token()
                 rel_ver = parser.get_token().strip("'\"")
+            elif key  == "VERSION_CODENAME" and not rel_ver:
+                # Throw away the "=".
+                parser.get_token()
+                rel_ver = parser.get_token().strip("'\"")
 
     return rel_name, rel_ver
 


### PR DESCRIPTION
Rolling releases like arch or debian testing don't have VERSION. We still can identify them and show them to the installer user by quoting VERSION_CODENAME.

See more: https://metadata.ftp-master.debian.org/changelogs//main/b/base-files/base-files_14_changelog
