### PR TITLE
infra: remove workflow files from container rebuild paths

### DIFF
--- a/.structure-config
+++ b/.structure-config
@@ -22,6 +22,5 @@ docs/ci-status.rst
 RPM_REBUILD_PATHS=(
 anaconda.spec.in
 dockerfile/anaconda-rpm
-.github/workflows/tests.yml
 branch-config.mk
 )

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -116,7 +116,6 @@ XGETTEXT = $(top_srcdir)/translation-canary/xgettext_werror.sh
 XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --keyword=P_:1,2 \
 		   --keyword=C_:1c,2 --keyword=CN_:1c,2 --keyword=CP_:1c,2,3 \
 		   --add-comments=TRANSLATORS: \
-		   --sort-output \
 		   --from-code=UTF-8 --package-name=$(PACKAGE) \
 		   --package-version=$(PACKAGE_VERSION) \
 		   --copyright-holder="$(COPYRIGHT_HOLDER)" \


### PR DESCRIPTION
Remove .github/workflows/tests.yml from RPM_REBUILD_PATHS to prevent unnecessary container rebuilds when workflow files change.

