### PR TITLE
Reset comps queries when resetting the dnf base

### DIFF
--- a/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf_manager.py
@@ -207,6 +207,8 @@ class DNFManager:
         self._md_hashes = {}
         self._enabled_system_repositories = []
         self._repositories_loaded = False
+        self._query_environments = None
+        self._query_groups = None
         log.debug("The DNF base has been reset.")
 
     def configure_base(self, data: PackagesConfigurationData):


### PR DESCRIPTION
We are storing the comps queries, but when the base is reset,
the repositories may change and the queries are no longer relevant.