### PR TITLE
Use slots (and a dataclass) to enforce Flag names

### DIFF
--- a/pyanaconda/flags.py
+++ b/pyanaconda/flags.py
@@ -16,37 +16,33 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+from dataclasses import dataclass, field
+
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import ANACONDA_ENVIRON
 
 log = get_module_logger(__name__)
 
 
-# A lot of effort, but it only allows a limited set of flags to be referenced
+@dataclass(slots=True)
 class Flags:
-    def __setattr__(self, attr, val):
-        # pylint: disable=no-member
-        if attr not in self.__dict__ and not self._in_init:
-            raise AttributeError(attr)
-        else:
-            self.__dict__[attr] = val
+    """
+    Limit the Anaconda Flags to just the ones listed here.
+    """
+    use_rd: bool = False
+    rd_question: bool = True
+    preexisting_wayland: bool = False
+    preexisting_x11: bool = False
+    automatedInstall: bool = False
+    eject: bool = True
 
-    def __init__(self):
-        self.__dict__['_in_init'] = True
-        self.use_rd = False
-        self.rd_question = True
-        self.preexisting_wayland = False
-        self.preexisting_x11 = False
-        self.automatedInstall = False
-        self.eject = True
-        # ksprompt is whether or not to prompt for missing ksdata
-        self.ksprompt = True
-        self.rescue_mode = False
-        self.kexec = False
-        # current runtime environments
-        self.environs = [ANACONDA_ENVIRON]
-        # Lock it down: no more creating new flags!
-        self.__dict__['_in_init'] = False
+    # ksprompt is whether or not to prompt for missing ksdata
+    ksprompt: bool = True
+    rescue_mode: bool = False
+    kexec: bool = False
+
+    # current runtime environments
+    environs: list[str] = field(default_factory=lambda: [ANACONDA_ENVIRON])
 
 
 flags = Flags()


### PR DESCRIPTION
We want Anaconda Flags to be a specific set of names.  To enforce that, we had a custom class that checked whether new attribute names were being allocated outside of `__init__()`.  If that was the case, it raised an exception.  We can use Python's `__slots__` feature for that instead. `__slots__` disables the dynamicism of Python classes and only allows attributes which already exist to be used.

This patch implements __slots__ by using dataclasses (a Python-3.7 feature).  That seems like the easiest way to use them here as we don't have to repeat the names of variables twice, once when we allow them in the __slots__ and once when we set their default values in __init__().