### PR TITLE
infra: kickstart-tests: backport some KS tests workflow adjustments

### DIFF
--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -235,7 +235,7 @@ jobs:
       - name: Build anaconda-iso-creator container image
         working-directory: ./anaconda
         run: |
-          sudo make -f ./Makefile.am anaconda-iso-creator-build CI_TAG=$CONTAINER_TAG
+          sudo -E make -f ./Makefile.am anaconda-iso-creator-build CI_TAG=$CONTAINER_TAG
 
       - name: Build anaconda-rpm container (for RPM build)
         working-directory: ./anaconda

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -110,7 +110,7 @@ jobs:
        ISO_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-iso-creator'
        RPM_BUILD_CONTAINER_NAME: 'quay.io/rhinstaller/anaconda-rpm'
        TEST_JOBS: 16
-       CONTAINER_TAG: {$ distro_name $}-{$ distro_release $}
+       CI_TAG: {$ distro_name $}-{$ distro_release $}
     steps:
       # we post statuses manually as this does not run from a pull_request event
       # https://developer.github.com/v3/repos/statuses/#create-a-status
@@ -235,18 +235,18 @@ jobs:
       - name: Build anaconda-iso-creator container image
         working-directory: ./anaconda
         run: |
-          sudo -E make -f ./Makefile.am anaconda-iso-creator-build CI_TAG=$CONTAINER_TAG
+          sudo -E make -f ./Makefile.am anaconda-iso-creator-build
 
       - name: Build anaconda-rpm container (for RPM build)
         working-directory: ./anaconda
         run: |
-          make -f ./Makefile.am anaconda-rpm-build CI_TAG=$CONTAINER_TAG
+          make -f ./Makefile.am anaconda-rpm-build
 
       - name: Build Anaconda RPM files
         working-directory: ./anaconda
         run: |
           # output of the build will be stored in ./result/build/01-rpm-build/*.rpm
-          make -f ./Makefile.am container-rpms-scratch CI_TAG=$CONTAINER_TAG
+          make -f ./Makefile.am container-rpms-scratch
           mkdir -p ${{ github.workspace }}/kickstart-tests/data/additional_repo/
           cp -av ./result/build/01-rpm-build/*.rpm ${{ github.workspace }}/kickstart-tests/data/additional_repo/
 
@@ -258,14 +258,14 @@ jobs:
             --tmpfs /var/tmp:rw,mode=1777 \
             -v ${{ github.workspace }}/kickstart-tests/data/additional_repo:/anaconda-rpms:ro \
             -v ${{ github.workspace }}/images:/images:z \
-            $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG
+            $ISO_BUILD_CONTAINER_NAME:$CI_TAG
 
       - name: Clean up after lorax
         if: always()
         run: |
           # remove container images together with the container
-          sudo podman rmi -f $ISO_BUILD_CONTAINER_NAME:$CONTAINER_TAG || true
-          sudo podman rmi -f $RPM_BUILD_CONTAINER_NAME:$CONTAINER_TAG || true
+          sudo podman rmi -f $ISO_BUILD_CONTAINER_NAME:$CI_TAG || true
+          sudo podman rmi -f $RPM_BUILD_CONTAINER_NAME:$CI_TAG || true
 
       - name: Create Permian settings file
         working-directory: ./permian


### PR DESCRIPTION
This is not affecting at all this branch, as the KS test workflow is picked up by main.