### PR TITLE
Fix setting of kernel log level for anaconda

### DIFF
--- a/data/systemd/anaconda-pre.service
+++ b/data/systemd/anaconda-pre.service
@@ -14,6 +14,8 @@ Wants=systemd-logind.service
 [Service]
 Type=oneshot
 ExecStart=/usr/libexec/anaconda/anaconda-pre-log-gen
+# RHEL-110525 (sysctl configuration/API does not work)
+ExecStart=/bin/dmesg --console-level emerg
 StandardInput=tty
 StandardOutput=journal+console
 StandardError=journal+console


### PR DESCRIPTION
Resolves: RHEL-110525

sysctl API (kernel.printk=1) stopped working and the recommendation from kernel developers is to use klogctl API. Set it via dmesg run in anaconda-pre service.

- [x] kickstart test: https://github.com/rhinstaller/kickstart-tests/pull/1495