### PR TITLE
infra: trigger_webui: fix incorrect usage of replace expression

### DIFF
--- a/.github/workflows/trigger-webui.yml
+++ b/.github/workflows/trigger-webui.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.releases) }}
-    container: registry.fedoraproject.org/fedora:${{ matrix.release | replace('fedora-', '') }}
+    container: registry.fedoraproject.org/fedora:${{ matrix.distro_version }}
 
     steps:
       # Naively this should wait for github.event.pull_request.head.sha, but

--- a/scripts/define-matrix.py
+++ b/scripts/define-matrix.py
@@ -36,7 +36,8 @@ def create_matrix_by_branch(supported_releases: List[Dict[str, str]]) -> Dict[st
         matrix_entry = {
             'release': rel['release'],
             'target_branch': rel['target_branch'],
-            'ci_tag': rel['release']
+            'ci_tag': rel['release'],
+            'distro_version': rel['release'].split('-')[-1]
         }
 
         matrix_by_branch[branch_key].append(matrix_entry)


### PR DESCRIPTION
This workflow got converted in an earlier commit from jinja template to a regular yml file, but the Jinja .replace incorrectly was not ported.

Let's export the distro version in the matrix for usage in the workflow.

Fixup for: fc77a6baf69a6235cf92185cb6b1029a9bc9ba15
