### PR TITLE
infra: fix rpm_macro unit_test failures

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_installation.py
@@ -65,8 +65,10 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         calls = [call(*macro) for macro in expected_macros]
         mock_rpm.addMacro.assert_has_calls(calls)
 
+    @patch("pyanaconda.modules.payloads.payload.dnf.installation.os")
     @patch("pyanaconda.modules.payloads.payload.dnf.installation.rpm")
-    def test_set_rpm_macros_default(self, mock_rpm):
+    def test_set_rpm_macros_default(self, mock_rpm, mock_os):
+        mock_os.access.return_value = False  # No selinux policy-context files are present
         data = PackagesConfigurationData()
 
         macros = [
@@ -76,8 +78,10 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         task = self._run_task(data)
         self._check_macros(task, mock_rpm, macros)
 
+    @patch("pyanaconda.modules.payloads.payload.dnf.installation.os")
     @patch("pyanaconda.modules.payloads.payload.dnf.installation.rpm")
-    def test_set_rpm_macros_exclude_docs(self, mock_rpm):
+    def test_set_rpm_macros_exclude_docs(self, mock_rpm, mock_os):
+        mock_os.access.return_value = False  # No selinux policy-context files are present
         data = PackagesConfigurationData()
         data.docs_excluded = True
 
@@ -89,8 +93,10 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         task = self._run_task(data)
         self._check_macros(task, mock_rpm, macros)
 
+    @patch("pyanaconda.modules.payloads.payload.dnf.installation.os")
     @patch("pyanaconda.modules.payloads.payload.dnf.installation.rpm")
-    def test_set_rpm_macros_install_langs(self, mock_rpm):
+    def test_set_rpm_macros_install_langs(self, mock_rpm, mock_os):
+        mock_os.access.return_value = False  # No selinux policy-context files are present
         data = PackagesConfigurationData()
         data.languages = "en:es"
 
@@ -102,8 +108,10 @@ class SetRPMMacrosTaskTestCase(unittest.TestCase):
         task = self._run_task(data)
         self._check_macros(task, mock_rpm, macros)
 
+    @patch("pyanaconda.modules.payloads.payload.dnf.installation.os")
     @patch("pyanaconda.modules.payloads.payload.dnf.installation.rpm")
-    def test_set_rpm_macros_no_install_langs(self, mock_rpm):
+    def test_set_rpm_macros_no_install_langs(self, mock_rpm, mock_os):
+        mock_os.access.return_value = False  # No selinux policy-context files are present
         data = PackagesConfigurationData()
         data.languages = RPM_LANGUAGES_NONE
 


### PR DESCRIPTION
Rawhide containers now contain /etc/selinux/targeted/contexts/files/file_contexts from the targeted selinux policy.  So we now have to configure our rpm_macros tests to pretend like that file does not exist when we are testing for non-selinux macros.

This could have been fixed in a couple different ways:
1. Add selinux information to all of the expected macros.  We would have to case this on whether the files were present on the system to begin with.
2. Disable selinux via `conf.security.selinux = 0`. If done this way, we would need to add selinux to all the macros but it would be set to `%{nil}` in tests that we were not checking for selinux in.
3. What we're doing here, fix by mocking the `os` library to pretend that the file is not present.  This is the least intrusive so what I chose here.  If it doesn't seem right to others, I would go with option 2 instead.