### PR TITLE
pyanaconda: tui: installation_source: log progress messages to TTY

### DIFF
--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -273,7 +273,7 @@ class DNFPayload(MigratedDBusPayload):
         if payload_manager.is_running:
             return False
 
-        return self.proxy.GetEnabledRepositories()
+        return bool(self.proxy.GetEnabledRepositories())
 
     # pylint: disable=arguments-differ
     def setup(self, report_progress, only_on_change=False):

--- a/pyanaconda/ui/tui/spokes/installation_source.py
+++ b/pyanaconda/ui/tui/spokes/installation_source.py
@@ -155,6 +155,9 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
         NormalTUISpoke.refresh(self, args)
         thread_manager.wait(THREAD_PAYLOAD)
 
+        # Show any error/warning messages
+        self._add_messages_widget_if_any()
+
         self._container = ListColumnContainer(1, columns_width=78, spacing=1)
 
         if args == self.SET_NETWORK_INSTALL_MODE:
@@ -246,6 +249,12 @@ class SourceSpoke(NormalTUISpoke, SourceSwitchHandler):
 
         # Restart the payload setup.
         payloadMgr.start(self.payload)
+
+    def _add_messages_widget_if_any(self):
+        if self._error:
+            msgs = payloadMgr.report.get_messages()
+            if msgs:
+                self.window.add_with_separator(TextWidget("\n".join(msgs)))
 
 
 class SpecifyRepoSpoke(NormalTUISpoke, SourceSwitchHandler):

--- a/pyanaconda/ui/tui/spokes/software_selection.py
+++ b/pyanaconda/ui/tui/spokes/software_selection.py
@@ -33,6 +33,7 @@ from pyanaconda.core.constants import (
 from pyanaconda.core.i18n import N_, _
 from pyanaconda.core.threads import thread_manager
 from pyanaconda.flags import flags
+from pyanaconda.payload.manager import payloadMgr
 from pyanaconda.ui.categories.software import SoftwareCategory
 from pyanaconda.ui.context import context
 from pyanaconda.ui.lib.software import (
@@ -145,12 +146,17 @@ class SoftwareSpoke(NormalTUISpoke):
     def ready(self):
         """Is the spoke ready?
 
-        By default, the software selection spoke is not ready. We have to
-        wait until the installation source spoke is completed. This could be
-        because the user filled something out, or because we're done fetching
-        repo metadata from the mirror list, or we detected a DVD/CD.
+        The spoke becomes ready when it is not processing data and the
+        installation source reached a terminal state: either it is set up
+        (payload is ready) or its setup finished with an error. This lets the
+        summary hub appear and surface the error if any.
         """
-        return not self._processing_data and self._source_is_set
+        return not self._processing_data and (self._source_is_set or self._source_has_error)
+
+    @property
+    def _source_has_error(self):
+        """Did installation source setup finish with an error?"""
+        return (not payloadMgr.is_running) and (not payloadMgr.report.is_valid())
 
     @property
     def _source_is_set(self):


### PR DESCRIPTION
Now source setup progress messages are printed to TTY as well as messages on payload setup errors.

Related: RHEL-60724

