### PR TITLE
Infra disable rdp kickstart specification unit tests

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -517,7 +517,7 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
             expected.add(name)
 
         # Ignore specified names if missing.
-        for name in self.IGNORED_MISSING_NAMES:
+        for name in self.IGNORED_MISSING_NAMES.union(self.IGNORED_NAMES):
             if name in expected ^ specified:
                 warnings.warn("Skipping the missing name: {}".format(name))
                 expected.discard(name)
@@ -608,6 +608,10 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
         # Useless commands has to be handled by modules.
         # Otherwise, they has to be handled by the main process.
         for name, command in kickstart.commandMap.items():
+            if name in self.IGNORED_NAMES:
+                warnings.warn("Skipping the missing name: {}".format(name))
+                continue
+
             if issubclass(command, kickstart.UselessCommand):
                 assert name in module_names
             else:

--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -451,6 +451,8 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
+        "rdp",  # Ignored in RHEL-10 until the rdp functionality is backported:
+                # https://github.com/rhinstaller/anaconda/pull/6592
     }
 
     # Names of shared kickstart commands and data that should be temporarily ignored.


### PR DESCRIPTION
* Adds some logic to skip specific verbs when checking that pykickstart and Anaconda recognize the same verbs.
* Disable the rdp verb from this check until the backport to RHEL-10 is completed: https://github.com/rhinstaller/anaconda/pull/6592

Once that is done, we can revert the commit for: [Disable checking for the rdp verb in Anaconda](https://github.com/rhinstaller/anaconda/commit/e3f45910f6ecc55fa11f37f938edcd0ef2e70fdf)