### PR TITLE
spec: enable live in ELN

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -16,13 +16,10 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).
 
+%bcond glade %{undefined rhel}
+%bcond live %[%{defined fedora} || %{defined eln}]
 %if ! 0%{?rhel}
-%bcond_without glade
-%bcond_without live
 %define blivetguiver 2.4.2-3
-%else
-%bcond_with glade
-%bcond_with live
 %endif
 %define dasbusver 1.3
 %define dbusver 1.2.3


### PR DESCRIPTION
ELN (the future RHEL 11) and ELN Extras (which prepares for EPEL 11) are
built in tandem.  While RHEL itself does not include any live ISOs, the
CentOS Alternative Images SIG does produce some based on CS with EPEL. As
building live introduces no new build dependencies, this safely allows the
live subpackage to be built for ELN only (but not RHEL) for the purpose of
creating ELN Alternative Images.

https://github.com/fedora-eln/eln/issues/263
