### PR TITLE
data: profiles: enable geolocation on Fedora Workstation live image

### DIFF
--- a/data/profile.d/fedora-workstation.conf
+++ b/data/profile.d/fedora-workstation.conf
@@ -27,9 +27,3 @@ webui_web_engine = firefox
 hidden_webui_pages =
     anaconda-screen-accounts
     anaconda-screen-date-time
-
-[Localization]
-# disable localization for the Fedora Workstation live image to avoid
-# it clashing with Gnome Initial Setup setting the Live environmment and
-# installation language first
-use_geolocation = False


### PR DESCRIPTION
Previously, geolocation was disabled to avoid conflicts with GNOME Initial Setup during live installations. Since now Fedora defaults to the Web UI, it is now safe to enable it to auto-detect locale based on geolocation.