### PR TITLE
data/profile.d: fedora-eln: Use slitherer by default

### DIFF
--- a/data/profile.d/fedora-eln.conf
+++ b/data/profile.d/fedora-eln.conf
@@ -14,6 +14,10 @@ variant_id = eln
 forbidden_modules =
     org.fedoraproject.Anaconda.Modules.Subscription
 
+[User Interface]
+# The default browser for the Web UI.
+webui_web_engine = slitherer
+
 [Bootloader]
 efi_dir = fedora
 


### PR DESCRIPTION
For ELN live images (representing CentOS live images), we want slitherer used.