### PR TITLE
gui: Fix GTK warnings when removing non-existent accelerators

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -400,9 +400,12 @@ class MainWindow(Gtk.Window):
         # Remove the F12 accelerator from the old window
         old_screen = self._stack.get_visible_child()
         if old_screen:
-            old_screen.remove_accelerator(self._accel_group, Gdk.KEY_F12, 0)
-            old_screen.remove_accelerator(self._accel_group, Gdk.KEY_F1, 0)
-            old_screen.remove_accelerator(self._accel_group, Gdk.KEY_F1, Gdk.ModifierType.MOD1_MASK)
+            if self._accel_group.query(Gdk.KEY_F12, 0):
+                old_screen.remove_accelerator(self._accel_group, Gdk.KEY_F12, 0)
+            if self._accel_group.query(Gdk.KEY_F1, 0):
+                old_screen.remove_accelerator(self._accel_group, Gdk.KEY_F1, 0)
+            if self._accel_group.query(Gdk.KEY_F1, Gdk.ModifierType.MOD1_MASK):
+                old_screen.remove_accelerator(self._accel_group, Gdk.KEY_F1, Gdk.ModifierType.MOD1_MASK)
 
         # Check if the widget is already on the stack
         if child not in self._stack_contents:


### PR DESCRIPTION
Check if accelerators exist before attempting to remove them to prevent GTK warnings about missing accelerators in the accel group.

Fixes warnings like:
- no accelerator (65470,0) installed in accel group
- no accelerator (65470,8) installed in accel group

Resolves: RHEL-45999

Cherry-picked from: 9eb141e1199322fe8e73100bb930be951b9b6402

