### PR TITLE
Fix: UnboundLocalError: local variable 'e' referenced before assignment

### DIFF
--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -252,7 +252,7 @@ class PayloadManager(object):
         # Check if that failed
         if not payload.base_repo:
             log.error("No base repo configured")
-            self._error = "%s: %s" % (self.ERROR_MD, e)
+            self._error = self.ERROR_MD
             self._set_state(PayloadState.ERROR)
             payload.unsetup()
             return


### PR DESCRIPTION
This is a regression from: d8d74ffbf1b0ccc0d27007efbcea2d16ae986d92

Related to: RHEL-4705

I tested only the one path when implementing this. The untested one was broken in a trivial way :/