### PR TITLE
Enable SELinx for ISO images generated by anaconda scripts

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -289,6 +289,11 @@ Requires: podman
 # needed for encrypted DNS
 Requires: dnsconfd
 Requires: dnsconfd-dracut
+Requires: selinux-policy
+Requires: libselinux-utils
+Requires: selinux-policy-targeted
+Requires: policycoreutils
+Requires: policycoreutils-python-utils
 
 %description install-img-deps
 The anaconda-install-img-deps metapackage lists all boot.iso installation

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -43,6 +43,7 @@ RUN set -ex; \
 COPY ["lorax-build", "/"]
 COPY ["lorax-build-webui", "/"]
 COPY ["adjust-templates-for-webui.patch", "/"]
+COPY ["whitelist_selinux.patch", "/"]
 
 RUN mkdir /lorax /anaconda-rpms /images
 

--- a/dockerfile/anaconda-iso-creator/lorax-build
+++ b/dockerfile/anaconda-iso-creator/lorax-build
@@ -36,6 +36,9 @@ mkdir -p $REPO_DIR
 cp -a $INPUT_RPMS/* $REPO_DIR || echo "RPM files can't be copied!"  # We could just do the build with official repositories only
 createrepo_c $REPO_DIR
 
+cp -r /usr/share/lorax/templates.d/ /lorax/
+patch -p2 -i /whitelist_selinux.patch
+
 # build boot.iso with our rpms
 . /etc/os-release
 # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
@@ -51,6 +54,7 @@ fi
 
 lorax -p Fedora -v "$VERSION_ID" -r "$VERSION_ID" \
       --volid Fedora-S-dvd-x86_64-$VOLID_VERSION \
+      --sharedir ./templates.d/99-generic/ \
       -s http://dl.fedoraproject.org/pub/fedora/linux/development/$FEDORA_VERSION/Everything/x86_64/os/ \
       -s file://$REPO_DIR/ \
       "$@" \

--- a/dockerfile/anaconda-iso-creator/lorax-build.j2
+++ b/dockerfile/anaconda-iso-creator/lorax-build.j2
@@ -29,6 +29,9 @@ mkdir -p $REPO_DIR
 cp -a $INPUT_RPMS/* $REPO_DIR || echo "RPM files can't be copied!"  # We could just do the build with official repositories only
 createrepo_c $REPO_DIR
 
+cp -r /usr/share/lorax/templates.d/ /lorax/
+patch -p2 -i /whitelist_selinux.patch
+
 # build boot.iso with our rpms
 . /etc/os-release
 # The download.fedoraproject.org automatic redirector often selects download-ib01.f.o. for GitHub's cloud, which is too unreliable; use a mirror
@@ -45,6 +48,7 @@ fi
 
 lorax -p Fedora -v "$VERSION_ID" -r "$VERSION_ID" \
       --volid Fedora-S-dvd-x86_64-$VOLID_VERSION \
+      --sharedir ./templates.d/99-generic/ \
       -s http://dl.fedoraproject.org/pub/fedora/linux/development/$FEDORA_VERSION/Everything/x86_64/os/ \
 {% elif distro_name == "rhel" and distro_release == 10 %}
 MAJOR_VERSION=${VERSION_ID%%.*}

--- a/dockerfile/anaconda-iso-creator/whitelist_selinux.patch
+++ b/dockerfile/anaconda-iso-creator/whitelist_selinux.patch
@@ -1,0 +1,60 @@
+From e7b6b1c8ea2d435e187205e7b505b564974e2c7a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pawe=C5=82=20Po=C5=82awski?= <ppolawsk@redhat.com>
+Date: Fri, 10 Oct 2025 00:02:02 +0200
+Subject: [PATCH] Do not remove SELinux from the runtime
+
+* Do not remove SELinux packages when ISO is created
+* Update the /etc/selinux file to:
+    * SELINUX=disabled
+    * SELINUXTYPE=targeted
+---
+ share/templates.d/99-generic/runtime-cleanup.tmpl     | 6 ------
+ share/templates.d/99-generic/runtime-install.tmpl     | 2 +-
+ share/templates.d/99-generic/runtime-postinstall.tmpl | 1 +
+ 3 files changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/share/templates.d/99-generic/runtime-cleanup.tmpl b/share/templates.d/99-generic/runtime-cleanup.tmpl
+index d33c02b8..8c686834 100644
+--- a/share/templates.d/99-generic/runtime-cleanup.tmpl
++++ b/share/templates.d/99-generic/runtime-cleanup.tmpl
+@@ -18,12 +18,6 @@ removefrom dracut --allbut /usr/lib/dracut/modules.d/30convertfs/convertfs.sh \
+                   /usr/lib/dracut/modules.d/99base/dracut-lib.sh \
+                   /usr/lib/systemd/* /usr/lib/dracut/modules.d/98dracut-systemd/*.service \
+                   /usr/lib/dracut/dracut-initramfs-restore
+-## we don't run SELinux (not in enforcing, anyway)
+-removepkg selinux-policy libselinux-utils
+-
+-## selinux checks for the /etc/selinux/config file's existance
+-## The removepkg above removes it, create an empty one. See rhbz#1243168
+-append etc/selinux/config ""
+ 
+ ## keep enough of shadow-utils to create accounts
+ removefrom shadow-utils --allbut /usr/bin/chage /usr/*bin/chpasswd \
+diff --git a/share/templates.d/99-generic/runtime-install.tmpl b/share/templates.d/99-generic/runtime-install.tmpl
+index a2ffd036..28212530 100644
+--- a/share/templates.d/99-generic/runtime-install.tmpl
++++ b/share/templates.d/99-generic/runtime-install.tmpl
+@@ -120,7 +120,7 @@ installpkg volume_key
+ installpkg nss-tools
+ 
+ ## SELinux support
+-installpkg selinux-policy-targeted audit
++installpkg selinux-policy libselinux-utils selinux-policy-targeted audit
+ 
+ ## network tools/servers
+ installpkg ethtool openssh-server nfs-utils openssh-clients
+diff --git a/share/templates.d/99-generic/runtime-postinstall.tmpl b/share/templates.d/99-generic/runtime-postinstall.tmpl
+index 31cb0ff8..142b05a6 100644
+--- a/share/templates.d/99-generic/runtime-postinstall.tmpl
++++ b/share/templates.d/99-generic/runtime-postinstall.tmpl
+@@ -76,6 +76,7 @@ install ${configdir}/sysctl.conf etc/sysctl.d/anaconda.conf
+ install ${configdir}/spice-vdagentd etc/sysconfig
+ mkdir etc/NetworkManager/conf.d
+ install ${configdir}/91-anaconda-autoconnect-slaves.conf etc/NetworkManager/conf.d
++install ${configdir}/selinux.config etc/selinux/config
+ install ${configdir}/vconsole.conf etc
+ install ${configdir}/92-anaconda-loglevel-debug.conf etc/NetworkManager/conf.d
+ 
+-- 
+2.51.0
+


### PR DESCRIPTION
This is required by the bootc.
When the VM is booting kernel command line need to be ammended by: `selinux=0 enforcing=0`

