### PR TITLE
flatpak: enable installation with CDROM source type

### DIFF
--- a/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
+++ b/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
@@ -122,13 +122,14 @@ class FlatpakManager:
             _, remote_url = conf.payload.flatpak_remote
             log.debug("Using Flatpak registry source: %s", remote_url)
             self._source = FlatpakRegistrySource(remote_url)
-        elif isinstance(source, RepositorySourceMixin) or source.type == SourceType.REPO_PATH:
+        elif isinstance(source, RepositorySourceMixin) or source.type in (SourceType.REPO_PATH, SourceType.CDROM):
             # synchronize input for FlatpakStaticSource from different DNF input sources
-            repository = (
-                source.generate_repo_configuration()
-                if source.type == SourceType.REPO_PATH
-                else source.repository
-            )
+            # TODO: when CDN installations are supported, prefer installing from online sources as the packages
+            # would be more up to date
+            if source.type in (SourceType.REPO_PATH, SourceType.CDROM):
+                repository = source.generate_repo_configuration()
+            else:
+                repository = source.repository
 
             # verify this Flatpak source is already created and used
             if self._source and isinstance(self._source, FlatpakStaticSource) \

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_flatpak_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_flatpak_manager.py
@@ -36,6 +36,7 @@ from pyanaconda.modules.payloads.payload.flatpak.source import (
     FlatpakStaticSource,
 )
 from pyanaconda.modules.payloads.source.cdn.cdn import CDNSourceModule
+from pyanaconda.modules.payloads.source.cdrom.cdrom import CdromSourceModule
 from pyanaconda.modules.payloads.source.closest_mirror.closest_mirror import (
     ClosestMirrorSourceModule,
 )
@@ -109,6 +110,16 @@ class FlatpakManagerTestCase(unittest.TestCase):
 
         assert isinstance(fp_source, FlatpakStaticSource)
         assert fp_source.repository_config == source.repository
+
+    def test_set_source_with_cdrom(self):
+        """Test FlatpakManager the set_sources method with CDROM source."""
+        source = CdromSourceModule()
+
+        fm = FlatpakManager()
+        fm.set_sources([source])
+        fp_source = fm.get_source()
+
+        assert isinstance(fp_source, FlatpakStaticSource)
 
     def test_set_source_with_cdn(self):
         """Test FlatpakManager the set_sources method with CDN source."""


### PR DESCRIPTION
Install flatpak from CDROM media.
