### PR TITLE
pyanaconda: storage: platform: Raise /boot to 2 GiB

### DIFF
--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -136,7 +136,7 @@ class Platform:
         """
         return PartSpec(
             mountpoint="/boot",
-            size=Size("1GiB")
+            size=Size("2GiB")
         )
 
 
@@ -392,7 +392,7 @@ class S390(Platform):
         """The default /boot partition for this platform."""
         return PartSpec(
             mountpoint="/boot",
-            size=Size("1GiB"),
+            size=Size("2GiB"),
             lv=False
         )
 


### PR DESCRIPTION
With the increase in content in initramfs, a long-overdue raise of the default size for /boot is warranted.

Reference: https://pagure.io/fesco/issue/3482
