### PR TITLE
Catch blivet.errors.ISCSIError in ISCSIDiscoverTask

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define nmver 1.0
 %define pykickstartver 3.65-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.12.1-1
+%define pythonblivetver 1:3.13.0-1
 %define rpmver 4.15.0
 %define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.29.31

--- a/pyanaconda/modules/storage/iscsi/discover.py
+++ b/pyanaconda/modules/storage/iscsi/discover.py
@@ -17,6 +17,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+from blivet.errors import ISCSIError
 from blivet.iscsi import TargetInfo, iscsi
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -105,7 +106,7 @@ class ISCSIDiscoverTask(Task):
                 r_username=credentials.reverse_username,
                 r_password=credentials.reverse_password
             )
-        except Exception as e:  # pylint: disable=broad-except
+        except ISCSIError as e:
             raise StorageDiscoveryError(str(e).split(':')[-1]) from e
 
         if not nodes:


### PR DESCRIPTION
Also bump required version of blivet to 3.13 where the exception type raised changed.

Related:
- https://github.com/rhinstaller/anaconda/pull/6632
- https://github.com/storaged-project/blivet/pull/1416