### PR TITLE
chore: Support multiple console= kernel entries

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -274,7 +274,7 @@ CMDLINE_FILES = [
 ]
 
 # cmdline arguments that append instead of overwrite
-CMDLINE_APPEND = ["modprobe.blacklist", "ifname", "ip"]
+CMDLINE_APPEND = ["modprobe.blacklist", "ifname", "ip", "console"]
 CMDLINE_LIST = ["addrepo"]
 
 # Filesystems which are not supported by Anaconda

--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -912,11 +912,18 @@ class BootLoader(object):
                 continue
 
             arg = kernel_arguments.get(opt)
-            new_arg = opt
-            if arg:
-                new_arg += "=%s" % arg
 
-            self.boot_args.add(new_arg)
+            # [RHEL-101789]
+            # Parse and store multiple console options to reproduce them
+            # in the same order on deployed system
+            if opt == "console" and arg and " " in arg:
+                log.debug('Multiple "console=" kernel parameters to be preserved')
+                for item in arg.split():
+                    self.boot_args.add("%s=%s" % (opt, item))
+            else:
+                new_arg = opt if not arg else "%s=%s" % (opt, arg)
+
+                self.boot_args.add(new_arg)
 
     def _set_graphical_boot_args(self):
         """Set up the graphical boot."""
@@ -969,6 +976,13 @@ class BootLoader(object):
 
         if not console:
             return
+
+        # Handle multiple console= entries (RHEL-101789)
+        # e.g., "ttyS0,115200n8 tty0" -> "console=ttyS0,115200n8 console=tty0"
+        if " " in console:
+            log.debug('Multiple "console=" kernel parameters found: %s', console)
+            console = console.split()[-1]
+            log.debug("Main console set to: %s", console)
 
         console = os.path.basename(console)
         self.console, _x, self.console_options = console.partition(",")


### PR DESCRIPTION
For usual kernel parameters the new parameter with the same key will overwrite previously declared parameter.

"console=" parameter is special case as system can have a multiple serial outputs and user may want to specify different parameterd for different outputs (frequent for embedded boards).

This commit preserves both: the order and the value of multiple "console=" kernel argumens passed by the user and stores in the config. At the end deployed system will boot with the same "console=" parameters after config will be processed by Grub.

Cherry-picked from: 3a2b9ac01bc601d88499329fe92ba41ffe24dfa6

Resolves: RHEL-101787
