### PR TITLE
ostree: Set sysroot.bootprefix for installs without separate /boot

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -931,6 +931,19 @@ class DeployOSTreeTask(Task):
              stateroot]
         )
 
+        # Enable bootprefix to support installations without a separate /boot partition.
+        # When /boot is a directory on the root filesystem (not a separate partition),
+        # the BLS entry paths need to include the /boot prefix (e.g., /boot/ostree/...)
+        # so GRUB can find the kernel and initramfs correctly.
+        # See: https://issues.redhat.com/browse/RHEL-141936
+        log.info("ostree config set sysroot.bootprefix true")
+        safe_exec_program(
+            "ostree",
+            ["config",
+             "--repo=" + self._physroot + "/ostree/repo",
+             "set", "sysroot.bootprefix", "true"]
+        )
+
         if self._data.is_container():
             log.info("ostree image deploy starting")
 


### PR DESCRIPTION
When using the ostreecontainer kickstart command to install a system
without a separate /boot partition, the BLS (Boot Loader Spec) entries
were being written with incorrect paths. The entries contained paths
like /ostree/... instead of /boot/ostree/..., causing the system to
fail to boot.

This happens because ostree's sysroot.bootprefix config option defaults
to false, which means BLS entry paths are written relative to /boot as
if it were a separate filesystem. When /boot is actually a directory on
the root filesystem, GRUB's $root variable points to the root partition,
so paths need the /boot prefix to be found correctly.

Fix this by setting sysroot.bootprefix=true before running the ostree
deployment, matching what bootc does in its install path. This is safe
to set unconditionally because:
- When /boot IS a separate partition, bootupd sets BOOT_UUID to the boot
  partition's UUID, so GRUB finds files correctly regardless of the prefix
- When /boot is NOT separate, the /boot prefix is required

Resolves: RHEL-141936
Assisted-by: OpenCode (claude-opus-4-5)
