### PR TITLE
infra: override container's %_install_langs to install all translations

### DIFF
--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -38,7 +38,11 @@ RUN set -ex; \
 # required for lorax-build-webui script
   patch \
   lorax; \
-  dnf clean all
+  dnf clean all; \
+# Override the container's restrictive %_install_langs macro (set by
+# glibc-minimal-langpack) so that lorax installs all translations
+# into the boot.iso, not just English.
+  echo "%_install_langs all" > /etc/rpm/macros.image-language-conf
 
 COPY ["lorax-build", "/"]
 COPY ["lorax-build-webui", "/"]


### PR DESCRIPTION
The container base image ships glibc-minimal-langpack which sets %_install_langs to a restrictive value. When lorax uses RPM to install packages into the boot.iso chroot, RPM inherits this macro from the container and only installs English translation files. This causes the installer language screen to show only English variants.

Override the macro before running lorax so that all anaconda.mo translation files are installed into the boot.iso.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Resolves: INSTALLER-4681