### PR TITLE
lorax-build: remove container's %_install_langs restriction

### DIFF
--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -40,6 +40,11 @@ RUN set -ex; \
   lorax; \
   dnf clean all
 
+# Remove the container's restrictive %_install_langs macro (set by
+# glibc-minimal-langpack) so that lorax installs all translations
+# into the boot.iso, not just English.
+RUN rm /etc/rpm/macros.image-language-conf
+
 COPY ["lorax-build", "/"]
 COPY ["lorax-build-webui", "/"]
 COPY ["adjust-templates-for-webui.patch", "/"]


### PR DESCRIPTION
The container base image ships glibc-minimal-langpack which sets %_install_langs to a restrictive value via macros.image-language-conf. When lorax uses RPM to install packages into the boot.iso chroot, RPM inherits this macro from the container and only installs English translation files. This causes the installer language screen to show only English variants.

Remove the macro file from the container image so that all anaconda.mo translation files are installed into the boot.iso.
