### PR TITLE
tests: update expected kickstart output for new pykickstart quoting

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -35,7 +35,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libreportanacondaver 2.0.21-1
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.65-1
+%define pykickstartver 3.70-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.13.0-1
 %define rpmver 4.15.0

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf.py
@@ -186,7 +186,7 @@ class DNFKickstartTestCase(unittest.TestCase):
         """
         ks_out = """
         # Use hard drive installation media
-        harddrive --dir=top-secret --partition=nsa-device
+        harddrive --dir="top-secret" --partition=nsa-device
 
         %packages
 
@@ -213,7 +213,7 @@ class DNFKickstartTestCase(unittest.TestCase):
         """
         ks_out = """
         # Use NFS installation media
-        nfs --server=gotham.city --dir=/secret/underground/base --opts="nomount"
+        nfs --server=gotham.city --dir="/secret/underground/base" --opts="nomount"
 
         %packages
 

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -220,7 +220,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         %end
         """
         ks_out = """
-        %certificate --filename=rvtest.pem --dir=/cert_dir
+        %certificate --filename="rvtest.pem" --dir="/cert_dir"
         -----BEGIN CERTIFICATE-----
         MIIBjTCCATOgAwIBAgIUWR5HO3v/0I80Ne0jQWVZFODuWLEwCgYIKoZIzj0EAwIw
         FDESMBAGA1UEAwwJUlZURVNUIENBMB4XDTI0MTEyMDEzNTk1N1oXDTM0MTExODEz
@@ -234,7 +234,7 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         -----END CERTIFICATE-----
         %end
 
-        %certificate --filename=rvtest2.pem --dir=/cert_dir2
+        %certificate --filename="rvtest2.pem" --dir="/cert_dir2"
         -----BEGIN CERTIFICATE-----
         MIIBkTCCATegAwIBAgIUN6r4TjFJqP/TS6U25iOGL2Wt/6kwCgYIKoZIzj0EAwIw
         FjEUMBIGA1UEAwwLUlZURVNUIDIgQ0EwHhcNMjQxMTIwMTQwMzIxWhcNMzQxMTE4


### PR DESCRIPTION
pykickstart commit 1c8aba38 ("Fix handling files with special characters") now quotes --dir and --filename values in generated kickstart output. Update expected ks_out strings in the affected tests to match.

PR based on container update failure (new pykickstart): https://github.com/rhinstaller/anaconda/actions/workflows/container-autoupdate.yml