### PR TITLE
storage: skip reformat warning for empty filesystems on allowlisted mounts

### DIFF
--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -107,6 +107,8 @@ def verify_partition_formatting(storage, constraints, report_error, report_warni
         and device.format.linux_native
         and not any(filter(mount.startswith, constraints[STORAGE_REFORMAT_BLOCKLIST]))
         and any(filter(mount.startswith, constraints[STORAGE_REFORMAT_ALLOWLIST]))
+        and device.format.mountable
+        and not device.format.is_empty
     ]
 
     for mount in mountpoints:


### PR DESCRIPTION
verify_partition_formatting only recommends a new filesystem when an existing linux-native format is non-empty, consistent with verify_root.
