### PR TITLE
Increase GUI startup timeout to 120 seconds

### DIFF
--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -357,7 +357,7 @@ LOGGER_SIMPLELINE = "simpleline"
 LOGGER_SENSITIVE_INFO = "sensitive_info"
 
 # Timeout for starting X
-X_TIMEOUT = 60
+X_TIMEOUT = 120
 
 # Setup on boot actions.
 SETUP_ON_BOOT_DEFAULT = -1

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -49,7 +49,7 @@ stdout_log = get_stdout_logger()
 X_TIMEOUT_ADVICE = \
     "Do not load the stage2 image over a slow network link.\n" \
     "Wait longer for the X server startup with the inst.xtimeout=<SECONDS> boot option." \
-    "The default is 60 seconds.\n" \
+    "The default is 120 seconds.\n" \
     "Load the stage2 image into memory with the rd.live.ram boot option to decrease access " \
     "time.\n" \
     "Enforce text mode when installing from remote media with the inst.text boot option.\n" \


### PR DESCRIPTION
User reports indicate that 60 seconds is not enough on widely enough available types of hardware. Bumping the number manually via the inst.xtimeout boot option also reportedly fixes the issue, the GUI just takes longer to start on those machines.

So lets bump the default value to 120 seconds so that less users need to apply an override manually.

Resolves: RHEL-92999
Related: RHEL-148965