### PR TITLE
Main increase GUI timeout to 120 seconds

### DIFF
--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -33,7 +33,7 @@ from argparse import (
 from blivet.arch import is_s390
 
 from pyanaconda.anaconda_loggers import get_module_logger
-from pyanaconda.core.constants import VIRTIO_PORT, X_TIMEOUT, DisplayModes
+from pyanaconda.core.constants import VIRTIO_PORT, WAYLAND_TIMEOUT, DisplayModes
 from pyanaconda.core.kernel import KernelArguments
 
 log = get_module_logger(__name__)
@@ -493,7 +493,7 @@ def getArgumentParser(version_string, boot_cmdline=None):
     # Display
     ap.add_argument("--resolution", dest="runres", default=None, metavar="WIDTHxHEIGHT",
                     help=help_parser.help_text("resolution"))
-    ap.add_argument("--xtimeout", dest="xtimeout", action="store", type=int, default=X_TIMEOUT,
+    ap.add_argument("--xtimeout", dest="xtimeout", action="store", type=int, default=WAYLAND_TIMEOUT,
                     metavar="TIMEOUT_IN_SECONDS", help=help_parser.help_text("xtimeout"))
     ap.add_argument("--rdp", action="store_true", default=False, dest="rdp_enabled",
                     help=help_parser.help_text("rdp"))

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -335,7 +335,7 @@ LOGGER_PROGRAM = "program"
 LOGGER_SIMPLELINE = "simpleline"
 
 # Timeout for starting the Wayland compositor
-WAYLAND_TIMEOUT = 60
+WAYLAND_TIMEOUT = 120
 
 # Setup on boot actions.
 SETUP_ON_BOOT_DEFAULT = -1

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -334,8 +334,8 @@ LOGGER_STDOUT = "anaconda.stdout"
 LOGGER_PROGRAM = "program"
 LOGGER_SIMPLELINE = "simpleline"
 
-# Timeout for starting X
-X_TIMEOUT = 60
+# Timeout for starting the Wayland compositor
+WAYLAND_TIMEOUT = 60
 
 # Setup on boot actions.
 SETUP_ON_BOOT_DEFAULT = -1

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -76,7 +76,7 @@ def _gnome_kiosk_supports_vt_switch():
 WAYLAND_TIMEOUT_ADVICE = \
     "Do not load the stage2 image over a slow network link.\n" \
     "Wait longer for Wayland startup with the inst.xtimeout=<SECONDS> boot option." \
-    "The default is 60 seconds.\n" \
+    "The default is 120 seconds.\n" \
     "Load the stage2 image into memory with the rd.live.ram boot option to decrease access " \
     "time.\n" \
     "Enforce text mode when installing from remote media with the inst.text boot option."

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -302,10 +302,10 @@ def setup_display(anaconda, options):
         return
 
     try:
-        xtimeout = int(options.xtimeout)
+        wayland_timeout = int(options.xtimeout)
     except ValueError:
         log.warning("invalid inst.xtimeout option value: %s", options.xtimeout)
-        xtimeout = constants.X_TIMEOUT
+        wayland_timeout = constants.WAYLAND_TIMEOUT
 
     rdp_credentials_sufficient = False
     rdp_creds = rdp_credentials("", "")
@@ -374,7 +374,7 @@ def setup_display(anaconda, options):
     want_gui = anaconda.gui_mode and not (flags.preexisting_wayland or flags.use_rd)
     if want_gui:
         try:
-            do_startup_wl_actions(xtimeout)
+            do_startup_wl_actions(wayland_timeout)
         except TimeoutError as e:
             log.warning("Wayland startup failed: %s", e)
             print("\nWayland did not start in the expected time, falling back to text mode. "
@@ -418,7 +418,7 @@ def setup_display(anaconda, options):
 
     # if they want us to use RDP do that now
     if anaconda.gui_mode and flags.use_rd:
-        do_startup_wl_actions(xtimeout, headless=True, headless_resolution=options.runres)
+        do_startup_wl_actions(wayland_timeout, headless=True, headless_resolution=options.runres)
         grd_server = GRDServer(anaconda)  # The RDP server object
         grd_server.rdp_username = rdp_creds.username
         grd_server.rdp_password = rdp_creds.password


### PR DESCRIPTION
First lets cleanup some stale X serve references, then bump the GUI startup timeout to 120 seconds as requested by users in the linked issues.
