### PR TITLE
Do not setup default_environment for fedora-eln profile

### DIFF
--- a/data/profile.d/fedora-eln.conf
+++ b/data/profile.d/fedora-eln.conf
@@ -17,7 +17,6 @@ forbidden_modules =
 efi_dir = fedora
 
 [Payload]
-default_environment = custom-environment
 default_source = CLOSEST_MIRROR
 default_rpm_gpg_keys =
     /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-eln-$basearch


### PR DESCRIPTION
Like RHEL, this should be managed by environments in comps, the first of
which is "Server with GUI" which is also the default in RHEL and CentOS.

This is a follow-up to https://github.com/rhinstaller/anaconda/pull/7029

See also: https://github.com/fedora-eln/eln/issues/490
