### PR TITLE
Set RHSM machine name based on user provided hostname

### DIFF
--- a/pyanaconda/modules/subscription/runtime.py
+++ b/pyanaconda/modules/subscription/runtime.py
@@ -41,7 +41,7 @@ from pyanaconda.modules.common.constants.objects import (
     RHSM_SYSPURPOSE,
     RHSM_UNREGISTER,
 )
-from pyanaconda.modules.common.constants.services import RHSM
+from pyanaconda.modules.common.constants.services import NETWORK, RHSM
 from pyanaconda.modules.common.errors.subscription import (
     MultipleOrganizationsError,
     RegistrationError,
@@ -301,17 +301,25 @@ class RegisterWithUsernamePasswordTask(Task):
                 )
 
         log.debug("subscription: registering with username and password")
+        # Get user requested hostname (e.g. by kickstart) and pass it to RHSM,
+        # so that the registered host is correctly named on the subscription management console.
+        network_proxy = NETWORK.get_proxy()
+        hostname = network_proxy.Hostname
         with RHSMPrivateBus(self._rhsm_register_server_proxy) as private_bus:
             try:
                 locale = os.environ.get("LANG", "")
 
                 private_register_proxy = private_bus.get_proxy(RHSM.service_name,
                                                                RHSM_REGISTER.object_path)
+                register_options = {"enable_content": get_variant(Bool, True)}
+                # make sure hostname is set by the user before passing it to RHSM
+                if hostname:
+                    register_options["name"] = get_variant(Str, hostname)
                 registration_data = private_register_proxy.Register(
                     self._organization,
                     self._username,
                     self._password,
-                    {"enable_content": get_variant(Bool, True)},
+                    register_options,
                     {},
                     locale
                 )
@@ -355,15 +363,23 @@ class RegisterWithOrganizationKeyTask(Task):
         :rtype: str
         """
         log.debug("subscription: registering with organization and activation key")
+        # Get user requested hostname (e.g. by kickstart) and pass it to RHSM,
+        # so that the registered host is correctly named on the subscription management console.
+        network_proxy = NETWORK.get_proxy()
+        hostname = network_proxy.Hostname
         with RHSMPrivateBus(self._rhsm_register_server_proxy) as private_bus:
             try:
                 locale = os.environ.get("LANG", "")
                 private_register_proxy = private_bus.get_proxy(RHSM.service_name,
                                                                RHSM_REGISTER.object_path)
+                register_options = {}
+                # make sure hostname is set by the user before passing it to RHSM
+                if hostname:
+                    register_options["name"] = get_variant(Str, hostname)
                 registration_data = private_register_proxy.RegisterWithActivationKeys(
                     self._organization,
                     self._activation_keys,
-                    {},
+                    register_options,
                     {},
                     locale
                 )

--- a/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/subscription/test_subscription_tasks.py
@@ -692,17 +692,21 @@ class RHSMPrivateBusTestCase(unittest.TestCase):
 class RegistrationTasksTestCase(unittest.TestCase):
     """Test the registration tasks."""
 
+    @patch("pyanaconda.modules.common.constants.services.NETWORK.get_proxy")
     @patch("os.environ.get", return_value="en_US.UTF-8")
     @patch("pyanaconda.modules.subscription.runtime.RHSMPrivateBus")
-    def test_username_password_success(self, private_bus, environ_get):
+    def test_username_password_success(self, private_bus, environ_get, get_proxy):
         """Test the RegisterWithUsernamePasswordTask - success."""
         # register server proxy
         register_server_proxy = Mock()
         # private register proxy
-        get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
-        private_register_proxy = get_proxy.return_value
+        private_get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
+        private_register_proxy = private_get_proxy.return_value
         # make the Register() method return some JSON data
         private_register_proxy.Register.return_value = '{"json":"stuff"}'
+        # Network module proxy
+        network_proxy = get_proxy.return_value
+        network_proxy.Hostname = "TEST_HOST_NAME"
         # instantiate the task and run it
         task = RegisterWithUsernamePasswordTask(rhsm_register_server_proxy=register_server_proxy,
                                                 username="foo_user",
@@ -714,23 +718,30 @@ class RegistrationTasksTestCase(unittest.TestCase):
             "foo_org",
             "foo_user",
             "bar_password",
-            {"enable_content": get_variant(Bool, True)},
+            {
+                "enable_content": get_variant(Bool, True),
+                "name" : get_variant(Str, "TEST_HOST_NAME")
+            },
             {},
             "en_US.UTF-8"
         )
 
+    @patch("pyanaconda.modules.common.constants.services.NETWORK.get_proxy")
     @patch("os.environ.get", return_value="en_US.UTF-8")
     @patch("pyanaconda.modules.subscription.runtime.RHSMPrivateBus")
-    def test_username_password_failure(self, private_bus, environ_get):
+    def test_username_password_failure(self, private_bus, environ_get, get_proxy):
         """Test the RegisterWithUsernamePasswordTask - failure."""
         # register server proxy
         register_server_proxy = Mock()
         # private register proxy
-        get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
-        private_register_proxy = get_proxy.return_value
+        private_get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
+        private_register_proxy = private_get_proxy.return_value
         # raise DBusError with error message in JSON
         json_error = '{"message": "Registration failed."}'
         private_register_proxy.Register.side_effect = DBusError(json_error)
+        # Network module proxy
+        network_proxy = get_proxy.return_value
+        network_proxy.Hostname = "TEST_HOST_NAME"
         # instantiate the task and run it
         task = RegisterWithUsernamePasswordTask(rhsm_register_server_proxy=register_server_proxy,
                                                 username="foo_user",
@@ -743,21 +754,25 @@ class RegistrationTasksTestCase(unittest.TestCase):
             "foo_org",
             "foo_user",
             "bar_password",
-            {"enable_content": get_variant(Bool, True)},
+            {
+                "enable_content": get_variant(Bool, True),
+                "name" : get_variant(Str, "TEST_HOST_NAME")
+            },
             {},
             "en_US.UTF-8"
         )
 
+    @patch("pyanaconda.modules.common.constants.services.NETWORK.get_proxy")
     @patch("pyanaconda.modules.subscription.runtime.RetrieveOrganizationsTask")
     @patch("os.environ.get", return_value="en_US.UTF-8")
     @patch("pyanaconda.modules.subscription.runtime.RHSMPrivateBus")
-    def test_username_password_org_single(self, private_bus, environ_get, retrieve_orgs_task):
+    def test_username_password_org_single(self, private_bus, environ_get, retrieve_orgs_task, get_proxy):
         """Test the RegisterWithUsernamePasswordTask - parsed single org."""
         # register server proxy
         register_server_proxy = Mock()
         # private register proxy
-        get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
-        private_register_proxy = get_proxy.return_value
+        private_get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
+        private_register_proxy = private_get_proxy.return_value
         # make the Register() method return some JSON data
         private_register_proxy.Register.return_value = '{"json":"stuff"}'
         # mock the org data retrieval task to return single organization
@@ -770,7 +785,10 @@ class RegistrationTasksTestCase(unittest.TestCase):
         org_data_json = json.dumps(org_data)
         org_data_list = RetrieveOrganizationsTask._parse_org_data_json(org_data_json)
         retrieve_orgs_task.return_value.run.return_value = org_data_list
-        # prepare mock data callaback as well
+        # Network module proxy
+        network_proxy = get_proxy.return_value
+        network_proxy.Hostname = "TEST_HOST_NAME"
+        # prepare mock data callback as well
         # instantiate the task and run it - we set organization to "" to make the task
         # fetch organization list
         task = RegisterWithUsernamePasswordTask(rhsm_register_server_proxy=register_server_proxy,
@@ -785,10 +803,14 @@ class RegistrationTasksTestCase(unittest.TestCase):
             "",
             "foo_user",
             "bar_password",
-            {"enable_content": get_variant(Bool, True)},
+            {
+                "enable_content": get_variant(Bool, True),
+                "name" : get_variant(Str, "TEST_HOST_NAME")
+            },
             {},
             "en_US.UTF-8"
         )
+
 
     @patch("pyanaconda.modules.subscription.runtime.RetrieveOrganizationsTask")
     @patch("os.environ.get", return_value="en_US.UTF-8")
@@ -825,18 +847,22 @@ class RegistrationTasksTestCase(unittest.TestCase):
         with pytest.raises(MultipleOrganizationsError):
             task.run()
 
+    @patch("pyanaconda.modules.common.constants.services.NETWORK.get_proxy")
     @patch("os.environ.get", return_value="en_US.UTF-8")
     @patch("pyanaconda.modules.subscription.runtime.RHSMPrivateBus")
-    def test_org_key_success(self, private_bus, environ_get):
+    def test_org_key_success(self, private_bus, environ_get, get_proxy):
         """Test the RegisterWithOrganizationKeyTask - success."""
         # register server proxy
         register_server_proxy = Mock()
         # private register proxy
-        get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
-        private_register_proxy = get_proxy.return_value
+        private_get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
+        private_register_proxy = private_get_proxy.return_value
         private_register_proxy.Register.return_value = True, ""
         # make the Register() method return some JSON data
         private_register_proxy.RegisterWithActivationKeys.return_value = '{"json":"stuff"}'
+        # Network module proxy
+        network_proxy = get_proxy.return_value
+        network_proxy.Hostname = "TEST_HOST_NAME"
         # instantiate the task and run it
         task = RegisterWithOrganizationKeyTask(rhsm_register_server_proxy=register_server_proxy,
                                                organization="123456789",
@@ -846,20 +872,24 @@ class RegistrationTasksTestCase(unittest.TestCase):
         private_register_proxy.RegisterWithActivationKeys.assert_called_with(
             "123456789",
             ["foo", "bar", "baz"],
-            {},
+            {"name" : get_variant(Str, "TEST_HOST_NAME")},
             {},
             'en_US.UTF-8'
         )
 
+    @patch("pyanaconda.modules.common.constants.services.NETWORK.get_proxy")
     @patch("os.environ.get", return_value="en_US.UTF-8")
     @patch("pyanaconda.modules.subscription.runtime.RHSMPrivateBus")
-    def test_org_key_failure(self, private_bus, environ_get):
+    def test_org_key_failure(self, private_bus, environ_get, get_proxy):
         """Test the RegisterWithOrganizationKeyTask - failure."""
         # register server proxy
         register_server_proxy = Mock()
         # private register proxy
-        get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
-        private_register_proxy = get_proxy.return_value
+        private_get_proxy = private_bus.return_value.__enter__.return_value.get_proxy
+        private_register_proxy = private_get_proxy.return_value
+        # Network module proxy
+        network_proxy = get_proxy.return_value
+        network_proxy.Hostname = "TEST_HOST_NAME"
         # raise DBusError with error message in JSON
         json_error = '{"message": "Registration failed."}'
         private_register_proxy.RegisterWithActivationKeys.side_effect = DBusError(json_error)
@@ -873,7 +903,7 @@ class RegistrationTasksTestCase(unittest.TestCase):
         private_register_proxy.RegisterWithActivationKeys.assert_called_with(
             "123456789",
             ["foo", "bar", "baz"],
-            {},
+            {"name" : get_variant(Str, "TEST_HOST_NAME")},
             {},
             'en_US.UTF-8'
         )


### PR DESCRIPTION
By default RHSM sets the machine name used to identify the machine (in the subscription console and elsewhere) based on the currently set hostname.

This does not work reliably during the installation, as we register the machine already from the installation environment. In the installation environment the user provided hostname (usually via kickstart) is not set & we only set it for the installed system chroot.

The reason for not setting the hostname system wide are quite complex, such as the hostname ending up encoded in all kinds of places, like in LVM VG names, reducing installation determinism and causing various issues later.

So lets just check if user explicitly provided a hostname that should be set to the installed system and pass it to RHSM as the system name.

This way we fix the issue & avoid potentially breaking changes in the installation environment.

(cherry picked from commit 7c275b0e7fe62b7179647e03067390f7a8b87d16)

Resolves: RHEL-169779
Related: RHEL-149198