### PR TITLE
infra: CI: run push-tests on rhel-9 and rhel-10 branches

### DIFF
--- a/.github/workflows/push-tests.yml
+++ b/.github/workflows/push-tests.yml
@@ -11,6 +11,8 @@ on:
     branches:
       - main
       - fedora-[0-9]+
+      - rhel-9
+      - rhel-10
 
 permissions:
   contents: read

--- a/.github/workflows/push-tests.yml.j2
+++ b/.github/workflows/push-tests.yml.j2
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - fedora-[0-9]+
+      - rhel-9
+      - rhel-10
 
 permissions:
   contents: read


### PR DESCRIPTION
The push-tests workflow only listened for main and fedora-[0-9]+, so pushes to the RHEL product branches never ran unit tests or uploaded coverage. Add rhel-9 and rhel-10 to on.push.branches.

