### PR TITLE
storage: preserve btrfs compression in manual reuse (Resolves: rhbz#2422148)

### DIFF
--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -16,6 +16,7 @@
 # Red Hat, Inc.
 #
 from blivet.errors import StorageError
+from blivet.flags import flags
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
@@ -49,6 +50,25 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
         log.debug("Setting up the mount points.")
         for mount_data in self._requests:
             self._setup_mount_point(storage, mount_data)
+
+    @classmethod
+    def _ensure_default_btrfs_compression(cls, device, mountopts):
+        """Add default btrfs compression to Btrfs mount options if missing."""
+        if getattr(device, "type", None) not in ("btrfs volume", "btrfs subvolume"):
+            return mountopts
+
+        compression = flags.btrfs_compression
+        if not compression:
+            return mountopts
+
+        options = mountopts or device.format.options
+        if not options:
+            return "compress={}".format(compression)
+
+        if any(opt.strip().startswith("compress") for opt in options.split(",")):
+            return options
+
+        return "{},compress={}".format(options, compression)
 
     def _setup_mount_point(self, storage, mount_data):
         """Set up a mount point.
@@ -95,5 +115,8 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
         if device.format.mountable and mount_point and mount_point != "none":
             device.format.mountpoint = mount_point
 
+        mount_options = self._ensure_default_btrfs_compression(
+            device, mount_data.mount_options
+        )
         device.format.create_options = mount_data.format_options
-        device.format.options = mount_data.mount_options
+        device.format.options = mount_options

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
@@ -18,9 +18,10 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from blivet.devices import DiskDevice, StorageDevice
+from blivet.flags import flags as blivet_flags
 from blivet.formats import get_format
 from blivet.size import Size
 from dasbus.typing import Bool, Str, get_variant
@@ -262,3 +263,28 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
         assert obj.implementation._storage == self.module.storage
         assert obj.implementation._requests == self.module.requests
+
+
+class ManualPartitioningTaskTestCase(unittest.TestCase):
+    """Test behavior of the manual partitioning task."""
+
+    @patch.object(blivet_flags, "btrfs_compression", "zstd:1")
+    def test_setup_mount_point_adds_default_compression_for_reused_btrfs_subvolume(self):
+        storage = Mock()
+        device = Mock(type="btrfs subvolume")
+        device.format = Mock(mountable=True, options="subvol=home")
+        storage.devicetree.get_device_by_device_id.return_value = device
+
+        mount_data = MountPointRequest()
+        mount_data.device_spec = "dev1"
+        mount_data.reformat = False
+        mount_data.format_type = ""
+        mount_data.mount_point = "/home"
+        mount_data.format_options = ""
+        mount_data.mount_options = "subvol=home"
+
+        task = ManualPartitioningTask(storage, [mount_data])
+        task._setup_mount_point(storage, mount_data)
+
+        assert device.format.mountpoint == "/home"
+        assert device.format.options == "subvol=home,compress=zstd:1"


### PR DESCRIPTION
Ensure manual mountpoint assignment adds default btrfs compression for reused subvolumes when mount options omit compress=.

Resolves: rhbz#2422148

