### PR TITLE
 storage: mirror Blivet btrfs default compression in manual reuse

### DIFF
--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -16,6 +16,7 @@
 # Red Hat, Inc.
 #
 from blivet.errors import StorageError
+from blivet.flags import flags
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import _
@@ -49,6 +50,54 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
         log.debug("Setting up the mount points.")
         for mount_data in self._requests:
             self._setup_mount_point(storage, mount_data)
+
+    @classmethod
+    def _btrfs_mountopts_imply_compress(cls, opts):
+        """True if *opts* already specify btrfs compression (``compress``…).
+
+        Used to detect an explicit choice from kickstart so we do not append
+        the profile default again.
+        """
+        if not opts:
+            return False
+        return any(
+            o.strip().startswith("compress")
+            for o in opts.split(",")
+            if o.strip()
+        )
+
+    @classmethod
+    def _ensure_default_btrfs_compression(cls, device, mountopts):
+        """Append profile ``compress=`` for btrfs when it is not already set.
+
+        Blivet adds ``flags.btrfs_compression`` for new btrfs subvolumes. For existing subvolumes,
+        we need to add it to the mount options if not already implied.
+        """
+        raw = device.raw_device
+        if raw.type not in ("btrfs volume", "btrfs subvolume"):
+            return mountopts
+
+        compression = flags.btrfs_compression
+        if not compression:
+            return mountopts
+
+        volume = getattr(raw, "volume", raw)
+
+        line_opts = mountopts if mountopts is not None else device.format.options
+        line_opts = line_opts or ""
+
+        has_compress = cls._btrfs_mountopts_imply_compress(line_opts)
+        vol_mopts = getattr(volume.format, "mountopts", None) or ""
+        if not has_compress:
+            has_compress = cls._btrfs_mountopts_imply_compress(vol_mopts)
+
+        if has_compress:
+            return mountopts if mountopts is not None else device.format.options
+
+        if not line_opts:
+            return "compress={}".format(compression)
+
+        return "{},compress={}".format(line_opts, compression)
 
     def _setup_mount_point(self, storage, mount_data):
         """Set up a mount point.
@@ -95,5 +144,8 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
         if device.format.mountable and mount_point and mount_point != "none":
             device.format.mountpoint = mount_point
 
+        mount_options = self._ensure_default_btrfs_compression(
+            device, mount_data.mount_options
+        )
         device.format.create_options = mount_data.format_options
-        device.format.options = mount_data.mount_options
+        device.format.options = mount_options

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_part_manual.py
@@ -18,9 +18,10 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from blivet.devices import DiskDevice, StorageDevice
+from blivet.flags import flags as blivet_flags
 from blivet.formats import get_format
 from blivet.size import Size
 from dasbus.typing import Bool, Str, get_variant
@@ -262,3 +263,78 @@ class ManualPartitioningInterfaceTestCase(unittest.TestCase):
 
         assert obj.implementation._storage == self.module.storage
         assert obj.implementation._requests == self.module.requests
+
+
+def _mock_btrfs_volume(mountopts):
+    volume = Mock()
+    volume.device_id = "BTRFS-one"
+    volume.format = Mock(mountopts=mountopts)
+    return volume
+
+
+def _mock_btrfs_subvolume(volume, options):
+    device = Mock()
+    device.raw_device = Mock(type="btrfs subvolume", volume=volume)
+    device.format = Mock(mountable=True, options=options)
+    return device
+
+
+def _mock_storage_for_mount_devices(devices):
+    storage = Mock()
+    storage.devicetree.get_device_by_device_id.side_effect = devices.get
+    return storage
+
+
+def _mount_point_request(device_spec, mount_point, mount_options):
+    request = MountPointRequest()
+    request.device_spec = device_spec
+    request.reformat = False
+    request.format_type = ""
+    request.mount_point = mount_point
+    request.format_options = ""
+    request.mount_options = mount_options
+    return request
+
+
+def _root_and_home_btrfs_reuse_setup(volume_mountopts):
+    """Shared mocks for / and /home on one reused btrfs volume."""
+    volume = _mock_btrfs_volume(volume_mountopts)
+    root = _mock_btrfs_subvolume(volume, "subvol=root")
+    home = _mock_btrfs_subvolume(volume, "subvol=home")
+    storage = _mock_storage_for_mount_devices({
+        "dev_root": root,
+        "dev_home": home,
+    })
+    requests = [
+        _mount_point_request("dev_root", "/", "subvol=root"),
+        _mount_point_request("dev_home", "/home", "subvol=home"),
+    ]
+    return storage, root, home, requests
+
+
+class ManualPartitioningTaskTestCase(unittest.TestCase):
+    """Test behavior of the manual partitioning task."""
+
+    @patch.object(blivet_flags, "btrfs_compression", "zstd:1")
+    def test_default_btrfs_compression_reused_btrfs_mounts(self):
+        """Reused btrfs: default ``compress=`` on each mount line (Blivet-style)."""
+        storage, root, home, requests = _root_and_home_btrfs_reuse_setup("")
+
+        ManualPartitioningTask(storage, requests)._configure_partitioning(storage)
+
+        assert root.format.mountpoint == "/"
+        assert root.format.options == "subvol=root,compress=zstd:1"
+        assert home.format.mountpoint == "/home"
+        assert home.format.options == "subvol=home,compress=zstd:1"
+
+    @patch.object(blivet_flags, "btrfs_compression", "zstd:1")
+    def test_default_btrfs_compression_skipped_when_volume_has_compress(self):
+        """Blivet skips appending if parent volume ``mountopts`` already set ``compress``."""
+        storage, root, home, requests = _root_and_home_btrfs_reuse_setup(
+            "compress=zstd:3"
+        )
+
+        ManualPartitioningTask(storage, requests)._configure_partitioning(storage)
+
+        assert root.format.options == "subvol=root"
+        assert home.format.options == "subvol=home"


### PR DESCRIPTION
When / is reused without reformat (e.g. from tooling such as Cockpit), Blivet never injects profile compression; ensure compress= on the manual mount request for / only.

Btrfs compression mount option is filesystem-wide, not per subvolume. We need to add this option only for /.

Resolves: rhbz#2422148
