### PR TITLE
iSCSI ordering bugfix

### DIFF
--- a/pyanaconda/modules/storage/disk_initialization/initialization.py
+++ b/pyanaconda/modules/storage/disk_initialization/initialization.py
@@ -26,12 +26,14 @@ from pykickstart.constants import (
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.dbus import DBus
+from pyanaconda.core.i18n import _
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.constants.objects import DISK_INITIALIZATION
 from pyanaconda.modules.storage.constants import InitializationMode
 from pyanaconda.modules.storage.disk_initialization.initialization_interface import (
     DiskInitializationInterface,
 )
+from pyanaconda.modules.storage.kickstart import get_device_names
 from pyanaconda.modules.storage.storage_subscriber import StorageSubscriberModule
 
 log = get_module_logger(__name__)
@@ -79,8 +81,20 @@ class DiskInitializationModule(StorageSubscriberModule):
         mode = self._map_clearpart_type(data.clearpart.type)
         self.set_initialization_mode(mode)
 
-        self.set_devices_to_clear(data.clearpart.devices)
-        self.set_drives_to_clear(data.clearpart.drives)
+        devices = get_device_names(
+            data.clearpart.devices,
+            disks_only=False,
+            lineno=data.clearpart.lineno,
+            msg=_('Device "{}" given in clearpart device list does not exist.'),
+        )
+        drives = get_device_names(
+            data.clearpart.drives,
+            disks_only=True,
+            lineno=data.clearpart.lineno,
+            msg=_('Disk "{}" given in clearpart command does not exist.'),
+        )
+        self.set_devices_to_clear(devices)
+        self.set_drives_to_clear(drives)
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""

--- a/pyanaconda/modules/storage/disk_selection/selection.py
+++ b/pyanaconda/modules/storage/disk_selection/selection.py
@@ -19,6 +19,7 @@
 #
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.dbus import DBus
+from pyanaconda.core.i18n import _
 from pyanaconda.core.signal import Signal
 from pyanaconda.modules.common.constants.objects import DISK_SELECTION
 from pyanaconda.modules.common.structures.validation import ValidationReport
@@ -26,6 +27,7 @@ from pyanaconda.modules.storage.disk_selection.selection_interface import (
     DiskSelectionInterface,
 )
 from pyanaconda.modules.storage.disk_selection.utils import check_disk_selection
+from pyanaconda.modules.storage.kickstart import get_device_names
 from pyanaconda.modules.storage.storage_subscriber import StorageSubscriberModule
 
 log = get_module_logger(__name__)
@@ -57,10 +59,27 @@ class DiskSelectionModule(StorageSubscriberModule):
         DBus.publish_object(DISK_SELECTION.object_path, DiskSelectionInterface(self))
 
     def process_kickstart(self, data):
-        """Process the kickstart data."""
-        self.set_selected_disks(data.ignoredisk.onlyuse)
-        self.set_exclusive_disks(data.ignoredisk.onlyuse)
-        self.set_ignored_disks(data.ignoredisk.ignoredisk)
+        """Process the kickstart data.
+
+        Resolve device specs to actual device names here rather than
+        in IgnoreDisk.parse(), so that iSCSI/zFCP/FCoE disks created
+        during parsing are available regardless of command order.
+        """
+        onlyuse = get_device_names(
+            data.ignoredisk.onlyuse,
+            disks_only=True,
+            lineno=data.ignoredisk.lineno,
+            msg=_('Disk "{}" given in ignoredisk command does not exist.'),
+        )
+        ignored = get_device_names(
+            data.ignoredisk.ignoredisk,
+            disks_only=True,
+            lineno=data.ignoredisk.lineno,
+            msg=_('Disk "{}" given in ignoredisk command does not exist.'),
+        )
+        self.set_selected_disks(onlyuse)
+        self.set_exclusive_disks(onlyuse)
+        self.set_ignored_disks(ignored)
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""

--- a/pyanaconda/modules/storage/kickstart.py
+++ b/pyanaconda/modules/storage/kickstart.py
@@ -118,79 +118,44 @@ class BTRFS(COMMANDS.BTRFS):
 
 
 class ClearPart(COMMANDS.ClearPart):
-    """The clearpart kickstart command."""
+    """The clearpart kickstart command.
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Ensure attributes are properly initialized for pylint
-        # These may be overridden in parse() but need to exist for static analysis
-        if not hasattr(self, 'type'):
-            self.type = None
-        if not hasattr(self, 'drives'):
-            self.drives = []
-        if not hasattr(self, 'devices'):
-            self.devices = []
+    Device name resolution (glob expansion via get_device_names) is
+    deferred to DiskInitializationModule.process_kickstart() so that
+    iSCSI, zFCP, and FCoE disks created during parsing are available
+    regardless of command ordering in the kickstart file.
+
+    Note: after this change, glob patterns like ``clearpart --drives=sd*``
+    that appear before ``iscsi`` will now resolve after iSCSI disks are
+    available, potentially matching more devices than before. This is the
+    correct behavior but differs from the old parse-order-dependent
+    resolution.
+    """
 
     def parse(self, args):
-        """Parse the command.
-
-        Do any glob expansion now, since we need to have the real
-        list of disks available before the execute methods run.
-        """
+        """Parse the command."""
         retval = super().parse(args)
 
-        # Set the default type.
-        if self.type is None:
-            self.type = CLEARPART_TYPE_NONE
+        if retval.type is None:
+            retval.type = CLEARPART_TYPE_NONE
 
-        # Check the disk label.
         if self.disklabel and self.disklabel not in DiskLabel.get_platform_label_types():
             raise KickstartParseError(_("Disklabel \"{}\" given in clearpart command is not "
                                         "supported on this platform.").format(self.disklabel),
                                       lineno=self.lineno)
 
-        # Get the disks names to clear.
-        self.drives = get_device_names(self.drives, disks_only=True, lineno=self.lineno,
-                                       msg=_("Disk \"{}\" given in clearpart command does "
-                                             "not exist."))
-
-        # Get the devices names to clear.
-        self.devices = get_device_names(self.devices, disks_only=False, lineno=self.lineno,
-                                        msg=_("Device \"{}\" given in clearpart device list "
-                                              "does not exist."))
-
         return retval
 
 
 class IgnoreDisk(COMMANDS.IgnoreDisk):
-    """The ignoredisk kickstart command."""
+    """The ignoredisk kickstart command.
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Ensure attributes are properly initialized for pylint
-        if not hasattr(self, 'ignoredisk'):
-            self.ignoredisk = []
-        if not hasattr(self, 'onlyuse'):
-            self.onlyuse = []
+    Device name resolution (glob expansion via get_device_names) is
+    deferred to DiskSelectionModule.process_kickstart() so that iSCSI,
+    zFCP, and FCoE disks created during parsing are available regardless
+    of command ordering in the kickstart file.
+    """
 
-    def parse(self, args):
-        """Parse the command.
-
-        Do any glob expansion now, since we need to have the real
-        list of disks available before the execute methods run.
-        """
-        retval = super().parse(args)
-
-        # Get the ignored disk names.
-        self.ignoredisk = get_device_names(self.ignoredisk, disks_only=True, lineno=self.lineno,
-                                           msg=_("Disk \"{}\" given in ignoredisk command does "
-                                                 "not exist."))
-
-        # Get the selected disk names.
-        self.onlyuse = get_device_names(self.onlyuse, disks_only=True, lineno=self.lineno,
-                                        msg=_("Disk \"{}\" given in ignoredisk command does "
-                                              "not exist."))
-        return retval
 
 
 class Fcoe(COMMANDS.Fcoe):

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_ignoredisk_iscsi_ordering.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_ignoredisk_iscsi_ordering.py
@@ -1,0 +1,220 @@
+#
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 31 Milk Street #960789 Boston, MA
+# 02196 USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+from contextlib import contextmanager
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+from pykickstart.errors import KickstartParseError
+
+from pyanaconda.core.kickstart.specification import (
+    KickstartSpecificationHandler,
+    KickstartSpecificationParser,
+)
+from pyanaconda.modules.storage.disk_initialization import DiskInitializationModule
+from pyanaconda.modules.storage.disk_selection import DiskSelectionModule
+from pyanaconda.modules.storage.kickstart import StorageKickstartSpecification
+
+ISCSI_INITIATOR = "iqn.2025-01.com.example:initiator"
+ISCSI_TARGET = "iqn.2025-01.com.example:target0"
+ISCSI_IP = "10.0.0.1"
+ISCSI_PORT = 3260
+ISCSI_DISK = "sda"
+
+KS_ISCSI_BEFORE_IGNOREDISK = f"""\
+iscsiname {ISCSI_INITIATOR}
+iscsi --target={ISCSI_TARGET} --ipaddr={ISCSI_IP}
+ignoredisk --only-use={ISCSI_DISK}
+"""
+
+KS_IGNOREDISK_ONLYUSE_BEFORE_ISCSI = f"""\
+ignoredisk --only-use={ISCSI_DISK}
+iscsiname {ISCSI_INITIATOR}
+iscsi --target={ISCSI_TARGET} --ipaddr={ISCSI_IP}
+"""
+
+KS_IGNOREDISK_DRIVES_BEFORE_ISCSI = f"""\
+ignoredisk --drives={ISCSI_DISK}
+iscsiname {ISCSI_INITIATOR}
+iscsi --target={ISCSI_TARGET} --ipaddr={ISCSI_IP}
+"""
+
+KS_ISCSI_BEFORE_CLEARPART = f"""\
+iscsiname {ISCSI_INITIATOR}
+iscsi --target={ISCSI_TARGET} --ipaddr={ISCSI_IP}
+clearpart --drives={ISCSI_DISK}
+"""
+
+KS_CLEARPART_BEFORE_ISCSI = f"""\
+clearpart --drives={ISCSI_DISK}
+iscsiname {ISCSI_INITIATOR}
+iscsi --target={ISCSI_TARGET} --ipaddr={ISCSI_IP}
+"""
+
+KS_CLEARPART_LIST_BEFORE_ISCSI = f"""\
+clearpart --list={ISCSI_DISK}
+iscsiname {ISCSI_INITIATOR}
+iscsi --target={ISCSI_TARGET} --ipaddr={ISCSI_IP}
+"""
+
+KS_IGNOREDISK_NONEXISTENT = f"""\
+iscsiname {ISCSI_INITIATOR}
+iscsi --target={ISCSI_TARGET} --ipaddr={ISCSI_IP}
+ignoredisk --only-use=nonexistent
+"""
+
+
+@contextmanager
+def _parse_iscsi_kickstart(ks_content):
+    """Parse a kickstart snippet with mocked iSCSI and device_matches.
+
+    Uses a stateful mock: device_matches("sda") returns ["sda"] only
+    after add_target has been called, simulating the disk appearing
+    after iSCSI login.
+
+    Yields inside the patch context so assertions run while mocks are
+    still active — required because the fix defers validation to
+    process_kickstart().
+    """
+    iscsi_connected = False
+
+    def device_matches_side_effect(spec, disks_only=False):
+        if spec == ISCSI_DISK and iscsi_connected:
+            return [ISCSI_DISK]
+        return []
+
+    def add_target_side_effect(*_args, **_kwargs):
+        nonlocal iscsi_connected
+        iscsi_connected = True
+
+    mock_iscsi = MagicMock()
+    type(mock_iscsi).mode = PropertyMock(return_value="none")
+    mock_iscsi.add_target.side_effect = add_target_side_effect
+
+    with (
+        patch(
+            "pyanaconda.modules.storage.kickstart.device_matches",
+            side_effect=device_matches_side_effect,
+        ),
+        patch(
+            "pyanaconda.modules.storage.kickstart.iscsi",
+            mock_iscsi,
+        ),
+        patch(
+            "pyanaconda.modules.storage.kickstart.wait_for_network_devices",
+            return_value=True,
+        ),
+    ):
+        specification = StorageKickstartSpecification
+        handler = KickstartSpecificationHandler(specification)
+        parser = KickstartSpecificationParser(handler, specification)
+
+        parser.readKickstartFromString(ks_content)
+
+        yield handler, mock_iscsi
+
+
+def _assert_add_target_called(mock_iscsi):
+    """Verify add_target was called with the expected iSCSI parameters."""
+    mock_iscsi.add_target.assert_called_once()
+    args, kwargs = mock_iscsi.add_target.call_args
+    ipaddr, port, user, password, user_in, password_in = args
+    assert ipaddr == ISCSI_IP
+    assert port == ISCSI_PORT
+    assert user is None
+    assert password is None
+    assert user_in is None
+    assert password_in is None
+    assert kwargs == {"target": ISCSI_TARGET, "iface": None}
+
+
+@pytest.mark.parametrize(
+    "ks_content",
+    [
+        pytest.param(KS_ISCSI_BEFORE_IGNOREDISK, id="iscsi-before-ignoredisk"),
+        pytest.param(KS_IGNOREDISK_ONLYUSE_BEFORE_ISCSI, id="ignoredisk-onlyuse-before-iscsi"),
+    ],
+)
+def test_ignoredisk_onlyuse_iscsi_ordering(ks_content):
+    """ignoredisk --only-use with iSCSI disks must work regardless of command order.
+
+    Reproducer for INSTALLER-4044 / RHEL-13837 / RHEL-58827.
+    """
+    with _parse_iscsi_kickstart(ks_content) as (handler, mock_iscsi):
+        module = DiskSelectionModule()
+        module.process_kickstart(handler)
+
+        assert module.selected_disks == [ISCSI_DISK]
+        assert module.ignored_disks == []
+        assert mock_iscsi.initiator == ISCSI_INITIATOR
+        _assert_add_target_called(mock_iscsi)
+
+
+@pytest.mark.parametrize(
+    "ks_content",
+    [
+        pytest.param(KS_IGNOREDISK_DRIVES_BEFORE_ISCSI, id="ignoredisk-drives-before-iscsi"),
+    ],
+)
+def test_ignoredisk_drives_iscsi_ordering(ks_content):
+    """ignoredisk --drives with iSCSI disks must work regardless of command order."""
+    with _parse_iscsi_kickstart(ks_content) as (handler, mock_iscsi):
+        module = DiskSelectionModule()
+        module.process_kickstart(handler)
+
+        assert module.selected_disks == []
+        assert module.ignored_disks == [ISCSI_DISK]
+        assert mock_iscsi.initiator == ISCSI_INITIATOR
+        _assert_add_target_called(mock_iscsi)
+
+
+@pytest.mark.parametrize(
+    "ks_content",
+    [
+        pytest.param(KS_ISCSI_BEFORE_CLEARPART, id="iscsi-before-clearpart"),
+        pytest.param(KS_CLEARPART_BEFORE_ISCSI, id="clearpart-before-iscsi"),
+    ],
+)
+def test_clearpart_iscsi_ordering(ks_content):
+    """clearpart --drives with iSCSI disks must work regardless of command order."""
+    with _parse_iscsi_kickstart(ks_content) as (handler, mock_iscsi):
+        module = DiskInitializationModule()
+        module.process_kickstart(handler)
+
+        assert module.drives_to_clear == [ISCSI_DISK]
+        assert mock_iscsi.initiator == ISCSI_INITIATOR
+        _assert_add_target_called(mock_iscsi)
+
+
+def test_clearpart_list_iscsi_ordering():
+    """clearpart --list with iSCSI devices must work regardless of command order."""
+    with _parse_iscsi_kickstart(KS_CLEARPART_LIST_BEFORE_ISCSI) as (handler, mock_iscsi):
+        module = DiskInitializationModule()
+        module.process_kickstart(handler)
+
+        assert module.devices_to_clear == [ISCSI_DISK]
+        assert mock_iscsi.initiator == ISCSI_INITIATOR
+        _assert_add_target_called(mock_iscsi)
+
+
+def test_ignoredisk_nonexistent_device():
+    """ignoredisk with a device that doesn't exist must still raise KickstartParseError."""
+    with _parse_iscsi_kickstart(KS_IGNOREDISK_NONEXISTENT) as (handler, mock_iscsi):
+        module = DiskSelectionModule()
+        with pytest.raises(KickstartParseError, match="nonexistent"):
+            module.process_kickstart(handler)
+        _assert_add_target_called(mock_iscsi)


### PR DESCRIPTION
storage: fix ignoredisk/clearpart ordering with iSCSI disks


IgnoreDisk.parse() and ClearPart.parse() called get_device_names()
at parse time, so if ignoredisk or clearpart appeared before iscsi in
the kickstart file the iSCSI disk was not yet visible in udev and the
install failed with "Disk X given in ignoredisk command does not exist."
Moving resolution to DiskSelectionModule and DiskInitializationModule
process_kickstart() ensures all commands — and their devices — are
available before validation runs, making command order irrelevant.


Related: INSTALLER-4044
Assisted-by: Claude Opus 4.6