### PR TITLE
docs: update doc for pykickstart update in anaconda-ci container

### DIFF
--- a/tests/README.rst
+++ b/tests/README.rst
@@ -121,9 +121,10 @@ __________________________________________________________
 
 3. Do your required changes in the container (install pykickstart in this example)::
 
+      rpm -e --nodeps python3-kickstart
       cd /pykickstart && make install DESTDIR=/
 
-4. Commit the changed container as updated one. **DO NOT exit the running container, run this command in new terminal!**
+4. Commit the changed container as updated one. **DO NOT exit the running container, run this command in new terminal!**::
 
       podman commit cnt-add quay.io/rhinstaller/anaconda-ci:latest
 


### PR DESCRIPTION
It is required to remove the old package, otherwise it fails with:

× Cannot uninstall pykickstart 3.72
╰─> The package's contents are unknown:
    no RECORD file was found for pykickstart.

Also fixes formatting

