### PR TITLE
Revert "anaconda.conf: Add split_lock_detect to preserved_arguments"

### DIFF
--- a/data/anaconda.conf
+++ b/data/anaconda.conf
@@ -151,9 +151,6 @@ menu_auto_hide = False
 nonibft_iscsi_boot = False
 
 # Arguments preserved from the installation system.
-# split_lock_detect is preserved to carry over the workaround for UEFI firmware
-# split lock bugs that cause kernel crashes (e.g., during efibootmgr calls).
-# This can be removed in the future if the root cause is fixed in the kernel.
 preserved_arguments =
     cio_ignore zfcp.allow_lun_scan
     speakup_synth apic noapic apm ide noht acpi video
@@ -161,7 +158,6 @@ preserved_arguments =
     biosdevname ipv6.disable net.ifnames net.ifnames.prefix
     nosmt vga rd.net.dns rd.net.dns-resolve-mode rd.net.dns-backend console
     clk_ignore_unused pd_ignore_unused arm64.nopauth systemd.tpm2_wait
-    split_lock_detect
 
 
 [Storage]


### PR DESCRIPTION
This reverts commit 77e8e7869680bab4bce2c404893aeed1f76d7e65.

Reference: https://github.com/rhinstaller/anaconda/pull/7074#issuecomment-4556782893


On CPUs that support split lock detection, the default behavior of the Linux kernel is warn. There is no reason that this was causing first boot issues. 

