### PR TITLE
Revert "payloads: fix rsync progress parsing for localized numbers"

### DIFF
--- a/pyanaconda/modules/payloads/payload/live_image/installation.py
+++ b/pyanaconda/modules/payloads/payload/live_image/installation.py
@@ -530,21 +530,16 @@ class InstallFromImageTask(Task):
         if "to-chk=" not in line:
             return
 
-        # extract global progress
-        # we search for the token ending with '%' because depending on the locale
-        # rsync might use spaces as thousand separators for the number of bytes
-        str_pct = next((word for word in line.split() if word.endswith("%")), None)
-        if not str_pct:
-            return
-
-        if self._rsync_progress == str_pct:
-            return
-
-        self._rsync_progress = str_pct
-        log.debug("rsync progress: %s", self._rsync_progress)
-        # Use the same translation string as in InstallationProgress for consistency and better i18n.
-        # Since str_pct already contains '%', we strip it to match the expected format.
-        self.report_progress(_("Installing software {}%").format(self._rsync_progress.rstrip("%")))
+        try:
+            # second field has global progress
+            str_pct = line.split()[1]
+            if self._rsync_progress == str_pct:
+                return
+            self._rsync_progress = str_pct
+            log.debug("rsync progress: %s", self._rsync_progress)
+            self.report_progress(_("Installing software {}").format(self._rsync_progress))
+        except IndexError:
+            pass
 
 
 class RemoveImageTask(Task):


### PR DESCRIPTION
This reverts commit 95a4418c5b7e6e5d791cd18b2444af6f10ab0cc8.


The 'fix' was not fixing the suggested bug. rsync is spawned via startProgress which resets the locale via `env.update({"LC_ALL": "C"})`

https://github.com/rhinstaller/anaconda/blob/main/pyanaconda/core/util.py#L132