### PR TITLE
infra: use exec-form ENTRYPOINT in anaconda-iso-creator

### DIFF
--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -53,4 +53,5 @@ RUN mkdir /lorax /anaconda-rpms /images
 
 WORKDIR /lorax
 
-ENTRYPOINT /lorax-build
+# Exec form so `podman run ... -s <repo>` args are passed to lorax-build "$@".
+ENTRYPOINT ["/lorax-build"]


### PR DESCRIPTION
Shell-form ENTRYPOINT runs lorax-build via /bin/sh -c, so extra podman run arguments (e.g. COPR -s repos from kickstart-tests) never reach "$@" in lorax-build.

See:
- Docker ENTRYPOINT (shell vs exec form): https://docs.docker.com/reference/dockerfile/#entrypoint

