### PR TITLE
bootloader: efi: normalize return type for efibootmgr call

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -65,15 +65,16 @@ class EFIBase:
         return value
 
     def efibootmgr(self, *args, **kwargs):
+        capture_expected = kwargs.pop("capture", False)
         if not conf.target.is_hardware:
             log.info("Skipping efibootmgr for image/directory install.")
-            return ""
+            return "" if capture_expected else 0
 
         if "noefi" in kernel_arguments:
             log.info("Skipping efibootmgr for noefi")
-            return ""
+            return "" if capture_expected else 0
 
-        if kwargs.pop("capture", False):
+        if capture_expected:
             exec_func = util.execWithCapture
         else:
             exec_func = util.execWithRedirect


### PR DESCRIPTION
EFIBase.efibootmgr() function, depending on the arguments, can return either an integer return code, or a string.

The return kind is obvious at the call point, and the change in 23afdae501 corrected the check according to the actual expected return result for efibootmgr invocation. However, if the actual efibootmgr execution is bypassed, a string was always returned.

The change introduces common checks for choosing the expected return type for both regular execution and bypass cases.