### PR TITLE
webui: remove inst.pauseatsummary requirement for kickstart installs

### DIFF
--- a/pyanaconda/ui/webui/__init__.py
+++ b/pyanaconda/ui/webui/__init__.py
@@ -34,7 +34,6 @@ from pyanaconda.core.path import touch
 from pyanaconda.core.process_watchers import PidWatcher
 from pyanaconda.core.threads import thread_manager
 from pyanaconda.core.util import startProgram
-from pyanaconda.flags import flags
 
 log = get_module_logger(__name__)
 
@@ -92,11 +91,6 @@ class CockpitUserInterface(ui.UserInterface):
         # Make sure that Web UI can be used only on boot.iso or Live media.
         if not conf.system.supports_web_ui:
             raise RuntimeError("This installation environment is not supported by Web UI.")
-
-        if flags.automatedInstall and not conf.runtime.pause_at_summary:
-            raise RuntimeError(
-                "Web UI with kickstart requires inst.pauseatsummary."
-            )
 
         # Finish all initialization jobs. Don't remove this unless you fully understand all
         # consequences of such removal. Web UI is not able to check the initialization threads,

--- a/tests/unit_tests/pyanaconda_tests/ui/test_webui.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_webui.py
@@ -77,34 +77,6 @@ class SimpleWebUITestCase(unittest.TestCase):
         mocked_print_message.assert_called_once_with("""My detailed error\n\nSuch a detail!""")
 
     @patch("pyanaconda.ui.webui.conf")
-    @patch("pyanaconda.ui.webui.flags")
-    def test_setup_non_interactive_installation(self, mocked_flags, mocked_conf):
-        """Test webui setup succeeds for kickstart-driven install with inst.pauseatsummary."""
-        mocked_flags.automatedInstall = True
-        mocked_flags.ksprompt = False
-        mocked_conf.target.is_directory = False
-        mocked_conf.target.is_image = False
-        mocked_conf.system.supports_web_ui = True
-        mocked_conf.runtime.pause_at_summary = True
-        self._setup_interface()
-
-    @patch("pyanaconda.ui.webui.conf")
-    @patch("pyanaconda.ui.webui.flags")
-    def test_setup_automated_requires_pause_at_summary(self, mocked_flags, mocked_conf):
-        """Kickstart-driven Web UI is rejected without inst.pauseatsummary."""
-        mocked_flags.automatedInstall = True
-        mocked_flags.ksprompt = False
-        mocked_conf.target.is_directory = False
-        mocked_conf.target.is_image = False
-        mocked_conf.system.supports_web_ui = True
-        mocked_conf.runtime.pause_at_summary = False
-
-        with pytest.raises(RuntimeError) as cm:
-            self._setup_interface()
-
-        assert "inst.pauseatsummary" in str(cm.value)
-
-    @patch("pyanaconda.ui.webui.conf")
     def test_setup_dir_installation(self, mocked_conf):
         """Test webui setup call for a dir installation."""
         mocked_conf.target.is_directory = True


### PR DESCRIPTION
Related: INSTALLER-4694
