### PR TITLE
Add support for --type=anchor to %certificate section

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define libreportanacondaver 2.0.21-1
 %define mehver 0.23-1
 %define nmver 1.0
-%define pykickstartver 3.52.11-1
+%define pykickstartver 3.52.13-1
 %define pypartedver 2.5-2
 %define pythonblivetver 1:3.13.0-1
 %define rpmver 4.15.0

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -416,6 +416,15 @@ CERT_TYPE_TRANSPORT_SUBDIRS = {
     "anchor": "anchor",
 }
 
+# The CA bundle file to append trusted certificates to in the initramfs.
+# In the initramfs we cannot run update-ca-trust extract (p11-kit trust
+# module is not available), so we append directly to the bundle instead.
+# NOTE: the certificate may be appended multiple times if parse-kickstart
+# is run more than once. This is harmless, and the bundle is only used
+# in the initramfs. After switchroot the trust store is properly built
+# by anaconda-import-initramfs-certs service.
+CA_BUNDLE_PATH = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+
 
 def _get_cert_dir(cert):
     """Get the directory for a certificate based on its type."""
@@ -446,6 +455,27 @@ def _dump_certificate(cert, root="/", dump_dir=None):
     with open(dst, 'w') as f:
         f.write(cert.cert)
         f.write('\n')
+
+
+def _append_to_ca_bundle(certificates):
+    """Append anchor certificates to the CA bundle in the initramfs."""
+    if not os.path.exists(CA_BUNDLE_PATH):
+        log.warning("CA bundle %s not found, skipping trust store update.", CA_BUNDLE_PATH)
+        return
+
+    for cert in certificates:
+        cert_type = getattr(cert, 'type', None)
+        if cert_type not in CERT_TYPE_TRANSPORT_SUBDIRS:
+            continue
+        log.info("Appending certificate %s to %s.", cert.filename, CA_BUNDLE_PATH)
+        try:
+            with open(CA_BUNDLE_PATH, 'a') as f:
+                f.write('\n')
+                f.write(cert.cert)
+                f.write('\n')
+        except OSError as e:
+            log.error("Failed to append certificate %s to CA bundle: %s",
+                      cert.filename, e)
 
 
 def process_certificates(handler):
@@ -481,6 +511,10 @@ def process_certificates(handler):
                               dump_dir=subdir+"/")
         else:
             _dump_certificate(cert, root=CERT_TRANSPORT_DIR+"/path/")
+
+    # Append anchor certificates to the CA bundle so they are trusted
+    # immediately in the initramfs (e.g. for fetching repo over HTTPS).
+    _append_to_ca_bundle(handler.certificates)
 
 
 def process_kickstart(ksfile):

--- a/dracut/parse-kickstart
+++ b/dracut/parse-kickstart
@@ -406,9 +406,28 @@ def ksnet_to_dracut(args, lineno, net, bootdev=False):
     return " ".join(line)
 
 
+# Mapping of certificate types to their default directories.
+CERT_TYPE_DIRS = {
+    "anchor": "/etc/pki/ca-trust/source/anchors/",
+}
+
+# Certificate types that are transported by type for post-switchroot import.
+CERT_TYPE_TRANSPORT_SUBDIRS = {
+    "anchor": "anchor",
+}
+
+
+def _get_cert_dir(cert):
+    """Get the directory for a certificate based on its type."""
+    cert_type = getattr(cert, 'type', None)
+    if cert_type and cert_type in CERT_TYPE_DIRS:
+        return CERT_TYPE_DIRS[cert_type]
+    return cert.dir
+
+
 def _dump_certificate(cert, root="/", dump_dir=None):
     """Dump the certificate into specified file."""
-    dump_dir = dump_dir or cert.dir
+    dump_dir = dump_dir or _get_cert_dir(cert)
     if not dump_dir:
         log.error("Certificate destination is missing for %s", cert.filename)
         return
@@ -442,13 +461,26 @@ def process_certificates(handler):
             log.error("Missing certificate file name, skipping.")
             continue
 
+        cert_type = getattr(cert, 'type', None)
+        if cert_type and cert_type not in CERT_TYPE_DIRS:
+            log.error("Unknown certificate type %s, skipping.", cert_type)
+            continue
+
         try:
             _dump_certificate(cert)
         except OSError as e:
             log.error("Dump of certificate %s failed: %s", cert.filename, e)
             continue
+
         # Dump for transport to switchroot
-        _dump_certificate(cert, root=CERT_TRANSPORT_DIR+"/path/")
+        if cert_type and cert_type in CERT_TYPE_TRANSPORT_SUBDIRS:
+            # Transport typed certificates in a type-specific subdirectory
+            # for post-switchroot import (e.g. anchor/ for CA trust anchors)
+            subdir = CERT_TYPE_TRANSPORT_SUBDIRS[cert_type]
+            _dump_certificate(cert, root=CERT_TRANSPORT_DIR+"/type/",
+                              dump_dir=subdir+"/")
+        else:
+            _dump_certificate(cert, root=CERT_TRANSPORT_DIR+"/path/")
 
 
 def process_kickstart(ksfile):

--- a/pyanaconda/modules/common/structures/security.py
+++ b/pyanaconda/modules/common/structures/security.py
@@ -29,6 +29,7 @@ class CertificateData(DBusData):
         self._filename = ""
         self._cert = ""
         self._dir = ""
+        self._type = ""
 
     @property
     def filename(self) -> Str:
@@ -56,3 +57,12 @@ class CertificateData(DBusData):
     @dir.setter
     def dir(self, value: Str) -> None:
         self._dir = value
+
+    @property
+    def type(self) -> Str:
+        """The certificate type (e.g. "anchor")."""
+        return self._type
+
+    @type.setter
+    def type(self, value: Str) -> None:
+        self._type = value

--- a/pyanaconda/modules/security/certificates/certificates.py
+++ b/pyanaconda/modules/security/certificates/certificates.py
@@ -57,13 +57,18 @@ class CertificatesModule(KickstartBaseModule):
             cert_data.cert = cert.cert
             if cert.dir:
                 cert_data.dir = cert.dir
+            if cert.type:
+                cert_data.type = cert.type
             certificates.append(cert_data)
         self.set_certificates(certificates)
 
     def setup_kickstart(self, data):
         """Setup the kickstart data."""
         for cert in self._certificates:
-            cert_ksdata = Certificate(cert=cert.cert, filename=cert.filename, dir=cert.dir)
+            cert_ksdata = Certificate(
+                cert=cert.cert, filename=cert.filename,
+                dir=cert.dir, type=cert.type
+            )
             data.certificates.append(cert_ksdata)
 
     @property

--- a/pyanaconda/modules/security/certificates/installation.py
+++ b/pyanaconda/modules/security/certificates/installation.py
@@ -20,10 +20,19 @@ import os
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import INSTALLATION_PHASE_PREINSTALL, PAYLOAD_TYPE_DNF
 from pyanaconda.core.path import join_paths, make_directories
+from pyanaconda.core.util import execWithRedirect
 from pyanaconda.modules.common.errors.installation import SecurityInstallationError
 from pyanaconda.modules.common.task import Task
 
 log = get_module_logger(__name__)
+
+# Mapping of certificate types to their default directories.
+CERT_TYPE_DIRS = {
+    "anchor": "/etc/pki/ca-trust/source/anchors/",
+}
+
+# Certificate types that require running update-ca-trust extract.
+CERT_TYPES_REQUIRING_UPDATE = {"anchor"}
 
 
 class ImportCertificatesTask(Task):
@@ -47,14 +56,23 @@ class ImportCertificatesTask(Task):
     def name(self):
         return "Import CA certificates"
 
+    @staticmethod
+    def _get_cert_dir(cert):
+        """Get the directory for a certificate based on its type."""
+        if cert.type and cert.type in CERT_TYPE_DIRS:
+            return CERT_TYPE_DIRS[cert.type]
+        return cert.dir
+
     def _dump_certificate(self, cert, root):
         """Dump the certificate into specified file and directory."""
-        if not cert.dir:
+        cert_dir = self._get_cert_dir(cert)
+
+        if not cert_dir:
             raise SecurityInstallationError(
                 "Certificate destination is missing for {}".format(cert.filename)
             )
 
-        dst_dir = join_paths(root, cert.dir)
+        dst_dir = join_paths(root, cert_dir)
         if not os.path.exists(dst_dir):
             log.debug("Path %s for certificate %s does not exist, creating.",
                       dst_dir, cert.filename)
@@ -69,6 +87,18 @@ class ImportCertificatesTask(Task):
             f.write(cert.cert)
             f.write('\n')
 
+    def _update_ca_trust(self):
+        """Run update-ca-trust extract to update the system trust store."""
+        log.debug("Running update-ca-trust extract in %s.", self._sysroot)
+        rc = execWithRedirect(
+            "update-ca-trust", ["extract"],
+            root=self._sysroot
+        )
+        if rc != 0:
+            raise SecurityInstallationError(
+                "Certificate update failed: update-ca-trust extract failed with return code {}".format(rc)
+            )
+
     def run(self):
         """Import CA certificates.
 
@@ -80,6 +110,28 @@ class ImportCertificatesTask(Task):
                           self._payload_type)
                 return
 
+        needs_update = False
+
         for cert in self._certificates:
-            log.debug("Importing certificate with filename: %s dir: %s", cert.filename, cert.dir)
+            if cert.type and cert.type not in CERT_TYPE_DIRS:
+                raise SecurityInstallationError(
+                    "Unknown certificate type {} for {}".format(cert.type, cert.filename)
+                )
+
+            # In the pre-install phase the target chroot is empty, so skip
+            # certificates that only make sense with a fully populated system
+            # (e.g. anchor type that needs update-ca-trust).
+            if self._phase == INSTALLATION_PHASE_PREINSTALL \
+                    and cert.type in CERT_TYPES_REQUIRING_UPDATE:
+                log.debug("Skipping type=%s certificate %s in pre-install phase.",
+                          cert.type, cert.filename)
+                continue
+
+            log.debug("Importing certificate with filename: %s dir: %s type: %s",
+                      cert.filename, cert.dir, cert.type)
             self._dump_certificate(cert, self._sysroot)
+            if cert.type in CERT_TYPES_REQUIRING_UPDATE:
+                needs_update = True
+
+        if needs_update:
+            self._update_ca_trust()

--- a/scripts/anaconda-import-initramfs-certs
+++ b/scripts/anaconda-import-initramfs-certs
@@ -2,5 +2,15 @@
 # Transfers CA certificates imported in initramfs via kickstart
 # to anaconda environment after switchroot.
 
+CERT_TRANSPORT_DIR=/run/install/certificates
+
 # certificates dumped to the specified file are copied to root
-cp -rv /run/install/certificates/path/* / || true
+cp -rv ${CERT_TRANSPORT_DIR}/path/* / || true
+
+# Import anchor certificates and update the system trust store
+ANCHOR_DIR=${CERT_TRANSPORT_DIR}/type/anchor
+if [ -d "${ANCHOR_DIR}" ]; then
+    if cp -rv ${ANCHOR_DIR}/* /etc/pki/ca-trust/source/anchors/ 2>/dev/null; then
+        update-ca-trust extract || echo "WARNING: update-ca-trust extract failed" >&2
+    fi
+fi

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -36,7 +36,7 @@ SITE_PACKAGES_PATH = "./usr/lib64/python3.12/site-packages/"
 
 # Anaconda scripts that should be installed into the libexec folder
 LIBEXEC_SCRIPTS = ["log-capture", "start-module", "apply-updates", "anaconda-pre-log-gen",
-                   "run-in-new-session"]
+                   "run-in-new-session", "anaconda-import-initramfs-certs"]
 
 # Anaconda scripts that should be installed into /usr/bin
 USR_BIN_SCRIPTS = ["anaconda-disable-nm-ibft-plugin", "anaconda-nm-disable-autocons"]

--- a/tests/unit_tests/dracut_tests/test_parse_kickstart.py
+++ b/tests/unit_tests/dracut_tests/test_parse_kickstart.py
@@ -34,6 +34,7 @@ EwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMCA0gAMEUCIAet
 yNWXfdraC/AfMM8fqsxlVJM=
 -----END CERTIFICATE-----"""
 
+CERT_TRANSPORT_DIR = "/run/install/certificates"
 
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
@@ -281,7 +282,6 @@ class ParseKickstartTestCase(BaseTestCase):
         self._check_cert_file(cert_file, content)
 
         # Check existence for file for transport to root
-        CERT_TRANSPORT_DIR = "/run/install/certificates"
         transport_file = os.path.join(CERT_TRANSPORT_DIR, cert_file)
         self._check_cert_file(transport_file, content)
 
@@ -309,6 +309,37 @@ class ParseKickstartTestCase(BaseTestCase):
         self._check_cert_file(cert_file, content)
 
         # Check existence for file for transport to root
-        CERT_TRANSPORT_DIR = "/run/install/certificates"
         transport_file = os.path.join(CERT_TRANSPORT_DIR, cert_file)
         self._check_cert_file(transport_file, content)
+
+    def test_certificate_anchor(self):
+        filename = "rvtest2.pem"
+        content = CERT_CONTENT
+        ks_cert = f"""
+%certificate --filename={filename} --type=anchor
+{content}
+%end
+"""
+        EXPECTED_TYPE_DIR = "/etc/pki/ca-trust/source/anchors/"
+        cert_file = os.path.join(EXPECTED_TYPE_DIR, filename)
+
+        CA_BUNDLE_PATH = "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
+
+        with tempfile.NamedTemporaryFile(mode="w+t") as ks_file:
+            ks_file.write(ks_cert)
+            ks_file.flush()
+            lines = self.execParseKickstart(ks_file.name)
+            assert lines == []
+
+        self._check_cert_file(cert_file, content)
+
+        # Check existence for file for transport to root
+        CERT_TYPE_TRANSPORT_SUBDIR = "anchor"
+        transport_file = os.path.join(CERT_TRANSPORT_DIR+"/type/"+CERT_TYPE_TRANSPORT_SUBDIR, filename)
+        self._check_cert_file(transport_file, content)
+
+        # Check that the certificate was appended to the CA bundle
+        with open(CA_BUNDLE_PATH) as f:
+            bundle = f.read()
+        assert bundle.rstrip().endswith(content), \
+            "Certificate not found at the end of CA bundle"

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_certificates.py
@@ -20,6 +20,7 @@
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
@@ -35,7 +36,10 @@ from pyanaconda.modules.security.certificates.certificates import CertificatesMo
 from pyanaconda.modules.security.certificates.certificates_interface import (
     CertificatesInterface,
 )
-from pyanaconda.modules.security.certificates.installation import ImportCertificatesTask
+from pyanaconda.modules.security.certificates.installation import (
+    CERT_TYPE_DIRS,
+    ImportCertificatesTask,
+)
 from tests.unit_tests.pyanaconda_tests import (
     check_dbus_property,
     check_task_creation,
@@ -84,21 +88,26 @@ class CertificatesInterfaceTestCase(unittest.TestCase):
 
     @staticmethod
     def _get_dbus_certs(certs):
-        return [
-            {
+        result = []
+        for values in certs:
+            cert, filename, cdir = values[0], values[1], values[2]
+            ctype = values[3] if len(values) > 3 else ""
+            result.append({
                 'cert': get_variant(Str, cert),
                 'filename': get_variant(Str, filename),
-                'dir': get_variant(Str, cdir)
-            }
-            for cert, filename, cdir in certs
-        ]
+                'dir': get_variant(Str, cdir),
+                'type': get_variant(Str, ctype),
+            })
+        return result
 
     @staticmethod
     def _get_certs(certs_values):
         certs = []
         for values in certs_values:
             c = CertificateData()
-            c.cert, c.filename, c.dir = values
+            c.cert, c.filename, c.dir = values[0], values[1], values[2]
+            if len(values) > 3:
+                c.type = values[3]
             certs.append(c)
         return certs
 
@@ -174,8 +183,9 @@ class CertificatesInterfaceTestCase(unittest.TestCase):
         assert c1 == (obj_c1.cert, obj_c1.filename, obj_c1.dir)
         assert c2 == (obj_c2.cert, obj_c2.filename, obj_c2.dir)
 
-    def _check_cert_file(self, cert, sysroot, is_missing=False):
-        cert_file = sysroot + cert.dir + "/" + cert.filename
+    def _check_cert_file(self, cert, sysroot, is_missing=False, expected_dir=None):
+        cert_dir = expected_dir or cert.dir
+        cert_file = sysroot + cert_dir + "/" + cert.filename
         if is_missing:
             assert os.path.exists(cert_file) is False
         else:
@@ -259,6 +269,19 @@ class CertificatesInterfaceTestCase(unittest.TestCase):
                     certificates=certs,
                 ).run()
 
+    def test_import_certificates_nonexisting_type(self):
+        """Test the ImportCertificatesTask task with non-existing type"""
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', '', 'NONEXISTING'),
+        ])
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            with self.assertRaises(SecurityInstallationError):
+                ImportCertificatesTask(
+                    sysroot=sysroot,
+                    certificates=certs,
+                ).run()
+
     def test_import_certificates_pre_nondnf_payload(self):
         """Test the ImportCertificatesTask in pre install with non-dnf payload"""
         certs = self._get_certs([
@@ -295,3 +318,138 @@ class CertificatesInterfaceTestCase(unittest.TestCase):
                 phase=INSTALLATION_PHASE_PREINSTALL
             ).run()
             self._check_cert_file(c2, sysroot)
+
+    @patch("pyanaconda.modules.security.certificates.installation.execWithRedirect")
+    @patch("pyanaconda.modules.security.certificates.installation.os.path.exists")
+    def test_import_certificates_type_anchor(self, mock_exists, mock_exec):
+        """Test the ImportCertificatesTask with type=anchor"""
+        mock_exec.return_value = 0
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', '', 'anchor'),
+        ])
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            # The cert dir doesn't exist yet, but update-ca-trust does
+            mock_exists.side_effect = lambda p: "update-ca-trust" in p
+            ImportCertificatesTask(
+                sysroot=sysroot,
+                certificates=certs,
+            ).run()
+
+            # Certificate should be in the anchor directory, not cert.dir
+            expected_dir = CERT_TYPE_DIRS["anchor"]
+            self._check_cert_file(certs[0], sysroot, expected_dir=expected_dir)
+
+            # update-ca-trust extract should have been called
+            mock_exec.assert_called_once_with(
+                "update-ca-trust", ["extract"],
+                root=sysroot
+            )
+
+    @patch("pyanaconda.modules.security.certificates.installation.execWithRedirect")
+    @patch("pyanaconda.modules.security.certificates.installation.os.path.exists")
+    def test_import_certificates_type_anchor_ignores_dir(self, mock_exists, mock_exec):
+        """Test that type=anchor ignores the --dir option"""
+        mock_exec.return_value = 0
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', '/etc/pki/custom/', 'anchor'),
+        ])
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            mock_exists.side_effect = lambda p: "update-ca-trust" in p
+            ImportCertificatesTask(
+                sysroot=sysroot,
+                certificates=certs,
+            ).run()
+
+            # Certificate should be in the anchor directory, NOT /etc/pki/custom/
+            expected_dir = CERT_TYPE_DIRS["anchor"]
+            self._check_cert_file(certs[0], sysroot, expected_dir=expected_dir)
+
+    @patch("pyanaconda.modules.security.certificates.installation.execWithRedirect")
+    @patch("pyanaconda.modules.security.certificates.installation.os.path.exists")
+    def test_import_certificates_mixed_types(self, mock_exists, mock_exec):
+        """Test mixed certificates: one with type=anchor, one without"""
+        mock_exec.return_value = 0
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', '', 'anchor'),
+            (CERT_RVTEST2, 'rvtest2.pem', '/etc/pki/custom/'),
+        ])
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            mock_exists.side_effect = lambda p: "update-ca-trust" in p
+            ImportCertificatesTask(
+                sysroot=sysroot,
+                certificates=certs,
+            ).run()
+
+            # anchor cert in the anchor directory
+            self._check_cert_file(
+                certs[0], sysroot, expected_dir=CERT_TYPE_DIRS["anchor"]
+            )
+            # non-typed cert in its specified dir
+            self._check_cert_file(certs[1], sysroot)
+
+            # update-ca-trust extract should have been called (due to anchor)
+            mock_exec.assert_called_once()
+
+    @patch("pyanaconda.modules.security.certificates.installation.execWithRedirect")
+    def test_import_certificates_no_type_no_extract(self, mock_exec):
+        """Test that update-ca-trust extract is NOT called when no typed certs"""
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', '/etc/pki/dir1'),
+        ])
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            ImportCertificatesTask(
+                sysroot=sysroot,
+                certificates=certs,
+            ).run()
+
+            self._check_cert_file(certs[0], sysroot)
+            mock_exec.assert_not_called()
+
+    @patch("pyanaconda.modules.security.certificates.installation.execWithRedirect")
+    @patch("pyanaconda.modules.security.certificates.installation.os.path.exists")
+    def test_import_certificates_update_ca_trust_failure(self, mock_exists, mock_exec):
+        """Test that update-ca-trust failure raises SecurityInstallationError"""
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', '', 'anchor'),
+        ])
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            mock_exists.side_effect = lambda p: "update-ca-trust" in p
+            mock_exec.return_value = 1
+            with self.assertRaises(SecurityInstallationError):
+                ImportCertificatesTask(
+                    sysroot=sysroot,
+                    certificates=certs,
+                ).run()
+
+    @patch("pyanaconda.modules.security.certificates.installation.execWithRedirect")
+    def test_import_certificates_type_anchor_skipped_in_preinstall(self, mock_exec):
+        """Test that type=anchor certificates are skipped in pre-install phase"""
+        certs = self._get_certs([
+            (CERT_RVTEST, 'rvtest.pem', '', 'anchor'),
+            (CERT_RVTEST2, 'rvtest2.pem', '/etc/pki/dir1'),
+        ])
+
+        with tempfile.TemporaryDirectory() as sysroot:
+            ImportCertificatesTask(
+                sysroot=sysroot,
+                certificates=certs,
+                payload_type=PAYLOAD_TYPE_DNF,
+                phase=INSTALLATION_PHASE_PREINSTALL,
+            ).run()
+
+            # anchor cert should NOT be dumped
+            self._check_cert_file(
+                certs[0], sysroot,
+                expected_dir=CERT_TYPE_DIRS["anchor"],
+                is_missing=True,
+            )
+            # non-typed cert should still be dumped
+            self._check_cert_file(certs[1], sysroot)
+
+            # update-ca-trust should NOT have been called
+            mock_exec.assert_not_called()

--- a/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/security/test_module_security.py
@@ -218,6 +218,20 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         CFOCLuymezWz+1rdIXLU1+XStLuB
         -----END CERTIFICATE-----
         %end
+
+        %certificate --filename=rvtest3.pem --type=anchor
+        -----BEGIN CERTIFICATE-----
+        MIIBkTCCATegAwIBAgIUN6r4TjFJqP/TS6U25iOGL2Wt/6kwCgYIKoZIzj0EAwIw
+        FjEUMBIGA1UEAwwLUlZURVNUIDIgQ0EwHhcNMjQxMTIwMTQwMzIxWhcNMzQxMTE4
+        MTQwMzIxWjAWMRQwEgYDVQQDDAtSVlRFU1QgMiBDQTBZMBMGByqGSM49AgEGCCqG
+        SM49AwEHA0IABOtXBMEhtcH43dIDHkelODXrSWQQ8PW7oo8lQUEYTNAL1rpWJJDD
+        1u+bpLe62Z0kzYK0CpeKuXFfwGrzx7eA6vajYzBhMB0GA1UdDgQWBBStV+z7SZSi
+        YXlamkx+xjm/W1sMSTAfBgNVHSMEGDAWgBStV+z7SZSiYXlamkx+xjm/W1sMSTAP
+        BgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAgNIADBF
+        AiEAkQjETC3Yx2xOkA+R0/YR+R+QqpR8p1fd/cGKWFUYxSoCIEuDJcfvPJfFYdzn
+        CFOCLuymezWz+1rdIXLU1+XStLuB
+        -----END CERTIFICATE-----
+        %end
         """
         ks_out = """
         %certificate --filename=rvtest.pem --dir=/cert_dir
@@ -235,6 +249,20 @@ class SecurityInterfaceTestCase(unittest.TestCase):
         %end
 
         %certificate --filename=rvtest2.pem --dir=/cert_dir2
+        -----BEGIN CERTIFICATE-----
+        MIIBkTCCATegAwIBAgIUN6r4TjFJqP/TS6U25iOGL2Wt/6kwCgYIKoZIzj0EAwIw
+        FjEUMBIGA1UEAwwLUlZURVNUIDIgQ0EwHhcNMjQxMTIwMTQwMzIxWhcNMzQxMTE4
+        MTQwMzIxWjAWMRQwEgYDVQQDDAtSVlRFU1QgMiBDQTBZMBMGByqGSM49AgEGCCqG
+        SM49AwEHA0IABOtXBMEhtcH43dIDHkelODXrSWQQ8PW7oo8lQUEYTNAL1rpWJJDD
+        1u+bpLe62Z0kzYK0CpeKuXFfwGrzx7eA6vajYzBhMB0GA1UdDgQWBBStV+z7SZSi
+        YXlamkx+xjm/W1sMSTAfBgNVHSMEGDAWgBStV+z7SZSiYXlamkx+xjm/W1sMSTAP
+        BgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAgNIADBF
+        AiEAkQjETC3Yx2xOkA+R0/YR+R+QqpR8p1fd/cGKWFUYxSoCIEuDJcfvPJfFYdzn
+        CFOCLuymezWz+1rdIXLU1+XStLuB
+        -----END CERTIFICATE-----
+        %end
+
+        %certificate --filename=rvtest3.pem --type=anchor
         -----BEGIN CERTIFICATE-----
         MIIBkTCCATegAwIBAgIUN6r4TjFJqP/TS6U25iOGL2Wt/6kwCgYIKoZIzj0EAwIw
         FjEUMBIGA1UEAwwLUlZURVNUIDIgQ0EwHhcNMjQxMTIwMTQwMzIxWhcNMzQxMTE4

--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -290,6 +290,12 @@ class KickstartSpecificationTestCase(unittest.TestCase):
         XIIDazCCAlOgAwIBAgIJAJzQz1Zz1Zz1MA0GCSqGSIb3DQEBCwUAMIGVMQswCQYD
         -----END CERTIFICATE-----
         %end
+
+        %certificate --filename=cert3.pem --type=anchor
+        -----BEGIN CERTIFICATE-----
+        XIIDazCCAlOgAwIBAgIJAJzQz1Zz1Zz1MA0GCSqGSIb3DQEBCwUAMIGVMQswCQYD
+        -----END CERTIFICATE-----
+        %end
         """
 
         with pytest.raises(KickstartParseError):
@@ -297,12 +303,16 @@ class KickstartSpecificationTestCase(unittest.TestCase):
 
         self.parse_kickstart(specification, "")
         handler = self.parse_kickstart(specification, ks_in)
-        assert len(handler.certificates) == 2
-        cert1, cert2 = handler.certificates
+        assert len(handler.certificates) == 3
+        cert1, cert2, cert3 = handler.certificates
         assert isinstance(cert1, Certificate)
         assert isinstance(cert2, Certificate)
+        assert isinstance(cert3, Certificate)
         assert cert1.filename == "cert1.pem"
         assert cert2.filename == "cert2.pem"
+        assert cert2.dir == "/cert_dir"
+        assert cert3.type == "anchor"
+
 
     def test_full_specification(self):
         """Test a full specification."""


### PR DESCRIPTION
Port of https://github.com/rhinstaller/anaconda/pull/7068
Depends on https://github.com/pykickstart/pykickstart/pull/575