### PR TITLE
dockerfile: keep development composes during dnf update on Stream 10

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -28,7 +28,9 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # Add development repositories instead of the production ones
 # We need development repositories to get our dependencies sooner
-RUN rm -f /etc/yum.repos.d/*.repo
+# centos-stream-* reinstall production mirrors; pin via excludepkgs for all dnf commands
+RUN rm -f /etc/yum.repos.d/*.repo && \
+  echo 'excludepkgs=centos-stream-repos centos-gpg-keys centos-stream-release' >> /etc/dnf/dnf.conf
 COPY ["anaconda-centos.repo", "/etc/yum.repos.d/"]
 
 # The anaconda.spec.in is in the repository root. This file will be copied automatically here if

--- a/dockerfile/anaconda-iso-creator/Dockerfile
+++ b/dockerfile/anaconda-iso-creator/Dockerfile
@@ -32,7 +32,9 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 
 # Add development repositories instead of the production ones
 # We need development repositories to get our dependencies sooner
-RUN rm -f /etc/yum.repos.d/*.repo
+# centos-stream-* reinstall production mirrors; pin via excludepkgs for all dnf commands
+RUN rm -f /etc/yum.repos.d/*.repo && \
+  echo 'excludepkgs=centos-stream-repos centos-gpg-keys centos-stream-release' >> /etc/dnf/dnf.conf
 COPY ["anaconda-centos.repo", "/etc/yum.repos.d/"]
 
 # Prepare environment and install build dependencies

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -31,6 +31,8 @@ COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 
 # Prepare environment and install build dependencies
 RUN set -ex; \
+  # centos-stream-* reinstall production mirrors; pin via excludepkgs for all dnf commands
+  echo 'excludepkgs=centos-stream-repos centos-gpg-keys centos-stream-release' >> /etc/dnf/dnf.conf; \
   # Disable production repositories
   dnf config-manager --disable baseos appstream crb; \
   dnf update -y; \


### PR DESCRIPTION
After removing default repos and switching to development composes, dnf update upgrades centos-stream-repos, which reinstalls production baseos/appstream via /etc/yum.repos.d/centos.repo and breaks build dependencies.

Exclude centos-stream-repos, centos-gpg-keys, and centos-stream-release together: they are a version-coupled stack.

