### PR TITLE
infra: pin dill for pylint on Python 3.15

### DIFF
--- a/dockerfile/anaconda-ci/requirements.txt
+++ b/dockerfile/anaconda-ci/requirements.txt
@@ -17,6 +17,7 @@ jinja2
 # pylint and its supporting libs
 pylint == 4.0.4
 astroid == 4.0.3
+dill @ git+https://github.com/uqfoundation/dill.git@37d2bf717ac7ac110f06be5210f989847959c2cd  # FIXME: use dill == 0.4.2 from PyPI once released (dill#755)
 
 # ruff for fast linting
 ruff == 0.15.15

--- a/dockerfile/anaconda-rpm/requirements.txt
+++ b/dockerfile/anaconda-rpm/requirements.txt
@@ -9,3 +9,4 @@ pocketlint  # translatable strings and translations, used by pylint and glade te
 # pylint and its supporting libs
 pylint == 4.0.4
 astroid == 4.0.3
+dill @ git+https://github.com/uqfoundation/dill.git@37d2bf717ac7ac110f06be5210f989847959c2cd  # FIXME: use dill == 0.4.2 from PyPI once released (dill#755)


### PR DESCRIPTION
dill 0.4.1 cannot pickle code objects without co_lnotab. Pin the dill#755 fix from git until 0.4.2 is on PyPI.

