### PR TITLE
fix: check if service is installed before enabling in kickstart

### DIFF
--- a/pyanaconda/modules/services/installation.py
+++ b/pyanaconda/modules/services/installation.py
@@ -21,6 +21,7 @@ from configparser import ConfigParser
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import GRAPHICAL_TARGET, TEXT_ONLY_TARGET
+from pyanaconda.core.i18n import _
 from pyanaconda.core.path import touch
 from pyanaconda.core.service import (
     disable_service,
@@ -28,6 +29,7 @@ from pyanaconda.core.service import (
     is_service_installed,
 )
 from pyanaconda.core.util import get_anaconda_version_string
+from pyanaconda.modules.common.errors.installation import NonCriticalInstallationError
 from pyanaconda.modules.common.task import Task
 from pyanaconda.modules.services.constants import SetupOnBootAction
 
@@ -174,9 +176,24 @@ class ConfigureServicesTask(Task):
             log.debug("Disabling service: %s.", service_name)
             disable_service(service_name, root=self._sysroot)
 
+        missing_services = []
         for service_name in self._enabled_services:
+            # Skip the check for template service instances (e.g., getty@ttyS0.service)
+            # as is_service_installed does not work for template unit files
+            if "@" not in service_name and not is_service_installed(service_name, root=self._sysroot):
+                log.warning("Service '%s' is not installed, skipping enablement.", service_name)
+                missing_services.append(service_name)
+                continue
             log.debug("Enabling service: %s.", service_name)
             enable_service(service_name, root=self._sysroot)
+
+        if missing_services:
+            raise NonCriticalInstallationError(
+                _("Cannot enable the following services because they are not installed: {names}. "
+                  "Make sure the packages providing these services are included in %packages.").format(
+                    names=", ".join(missing_services)
+                )
+            )
 
 
 class ConfigureSystemdDefaultTargetTask(Task):

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
@@ -32,6 +32,7 @@ from pyanaconda.core.constants import (
     TEXT_ONLY_TARGET,
 )
 from pyanaconda.modules.common.constants.services import SERVICES
+from pyanaconda.modules.common.errors.installation import NonCriticalInstallationError
 from pyanaconda.modules.common.task import TaskInterface
 from pyanaconda.modules.services.constants import SetupOnBootAction
 from pyanaconda.modules.services.installation import (
@@ -468,3 +469,36 @@ class ServicesTasksTestCase(unittest.TestCase):
         assert isinstance(obj, TaskInterface)
         assert isinstance(obj.implementation, ConfigureDefaultDesktopTask)
         assert obj.implementation._default_desktop == "GNOME"
+
+    @patch("pyanaconda.modules.services.installation.enable_service")
+    @patch("pyanaconda.modules.services.installation.is_service_installed")
+    def test_configure_services_missing_service(self, mock_is_installed, mock_enable):
+        """Test that valid services are enabled even when some are missing."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            # Simulate service-A and service-C being installed, but service-B missing
+            def is_installed_side_effect(service, root=None):
+                return service in ["service-A", "service-C"]
+
+            mock_is_installed.side_effect = is_installed_side_effect
+
+            task = ConfigureServicesTask(
+                sysroot=sysroot,
+                disabled_services=[],
+                enabled_services=["service-A", "service-B", "service-C"]
+            )
+
+            # The task should raise NonCriticalInstallationError for service-B
+            with self.assertRaises(NonCriticalInstallationError) as cm:
+                task.run()
+
+            # Verify the error message mentions the missing service
+            error_msg = str(cm.exception)
+            assert "service-B" in error_msg
+            assert "not installed" in error_msg
+
+            # Verify that service-A and service-C were still enabled
+            assert mock_enable.call_count == 2
+            enabled_services = [call[0][0] for call in mock_enable.call_args_list]
+            assert "service-A" in enabled_services
+            assert "service-C" in enabled_services
+            assert "service-B" not in enabled_services


### PR DESCRIPTION
When a service is enabled via kickstart but the required package is not installed, this now raises a NonCriticalInstallationError with a clear message directing the user to add the package to %packages, instead of showing a cryptic backtrace with just an error code.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>

Resolves: RHEL-178289

Now:
<img width="1346" height="677" alt="Screenshot 2026-06-17 at 14-19-06 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/e15a7996-7d39-4257-af06-992400d50d00" />

