### PR TITLE
Add loongarch64 uefi support

### DIFF
--- a/pyanaconda/modules/storage/bootloader/efi.py
+++ b/pyanaconda/modules/storage/bootloader/efi.py
@@ -33,6 +33,7 @@ log = get_module_logger(__name__)
 
 __all__ = [
     "EFIGRUB",
+    "LOONGARCH64EFIGRUB",
     "RISCV64EFIGRUB",
     "Aarch64EFIGRUB",
     "Aarch64EFISystemdBoot",
@@ -292,3 +293,11 @@ class RISCV64EFIGRUB(EFIGRUB):
     def __init__(self):
         super().__init__()
         self._packages64 = ["grub2-efi-riscv64"]
+
+class LOONGARCH64EFIGRUB(EFIGRUB):
+    _serial_consoles = ["ttyS"]
+    _efi_binary = "\\grubloongarch64.efi"
+
+    def __init__(self):
+        super().__init__()
+        self._packages64 = ["grub2-efi-loongarch64"]

--- a/pyanaconda/modules/storage/bootloader/factory.py
+++ b/pyanaconda/modules/storage/bootloader/factory.py
@@ -164,4 +164,8 @@ class BootLoaderFactory:
             from pyanaconda.modules.storage.bootloader.efi import RISCV64EFIGRUB
             return RISCV64EFIGRUB
 
+        if platform_class is platform.LOONGARCH64EFI:
+            from pyanaconda.modules.storage.bootloader.efi import LOONGARCH64EFIGRUB
+            return LOONGARCH64EFIGRUB
+
         return None

--- a/pyanaconda/modules/storage/platform.py
+++ b/pyanaconda/modules/storage/platform.py
@@ -458,6 +458,13 @@ class RISCV64EFI(EFI):
         """Format types of devices with non-linux operating systems."""
         return ["vfat", "ntfs"]
 
+class LOONGARCH64EFI(EFI):
+
+    @property
+    def non_linux_format_types(self):
+        """Format types of devices with non-linux operating systems."""
+        return ["vfat", "ntfs"]
+
 
 def get_platform():
     """Check the architecture of the system and return an instance of a
@@ -487,6 +494,8 @@ def get_platform():
             return ArmEFI()
         elif arch.is_riscv64():
             return RISCV64EFI()
+        elif arch.is_loongarch(bits=64):
+            return LOONGARCH64EFI()
         else:
             return EFI()
     elif arch.is_x86():

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_platform.py
@@ -26,6 +26,7 @@ from pyanaconda.modules.storage.partitioning.specification import PartSpec
 from pyanaconda.modules.storage.platform import (
     ARM,
     EFI,
+    LOONGARCH64EFI,
     PS3,
     RISCV64,
     RISCV64EFI,
@@ -57,6 +58,7 @@ class PlatformTestCase(unittest.TestCase):
         arch.is_x86.return_value = False
         arch.is_arm.return_value = False
         arch.is_riscv64.return_value = False
+        arch.is_loongarch.return_value = False
 
     def _check_platform(self, platform_cls, packages=None, non_linux_format_types=None):
         """Check the detected platform."""
@@ -368,6 +370,44 @@ class PlatformTestCase(unittest.TestCase):
 
         self._check_platform(
             platform_cls=RISCV64EFI,
+            non_linux_format_types=["vfat", "ntfs"]
+        )
+
+        self._check_partitions(
+            PartSpec(mountpoint="/boot/efi", fstype="efi", grow=True,
+                     size=Size("500MiB"), max_size=Size("600MiB")),
+            PartSpec(mountpoint="/boot", size=Size("2GiB"))
+        )
+
+        self._check_constraints(
+            constraints={
+                "format_types": ["efi"],
+                "device_types": ["partition", "mdarray"],
+                "disklabel_types": ["gpt", "msdos"],
+                "mountpoints": ["/boot/efi"],
+                "raid_levels": [raid.RAID1],
+                "raid_metadata": ["1.0"]
+            },
+            descriptions={
+                "partition": "EFI System Partition",
+                "mdarray": "RAID Device"
+            },
+            error_message=str(
+                "For a UEFI installation, you must include "
+                "an EFI System Partition on a GPT-formatted "
+                "disk, mounted at /boot/efi."
+            )
+        )
+
+    @patch("pyanaconda.modules.storage.platform.arch")
+    def test_loongarch64_efi(self, arch):
+        """Test the loongarch64 EFI platform."""
+        self._reset_arch(arch)
+        arch.is_efi.return_value = True
+        arch.is_loongarch.return_value = True
+
+        self._check_platform(
+            platform_cls=LOONGARCH64EFI,
             non_linux_format_types=["vfat", "ntfs"]
         )
 


### PR DESCRIPTION
Add GRUB support for loongarch64 UEFI.

This PR adds GRUB support for loongarch64 UEFI and also includes a new unit test.

I have tested this commit on a loongarch64 machine.

Code conventions tests:
PASS: ruff/run_ruff.sh
PASS: pylint/runpylint.py

Unit test:
unit_tests/pyanaconda_tests/modules/storage/test_platform.py::PlatformTestCase::test_loongarch64_efi PASSED [ 79%]

Please let me know if there are any problems.