### PR TITLE
storage: check disk space in cmdline mode before starting installation

### DIFF
--- a/pyanaconda/ui/tui/hubs/summary.py
+++ b/pyanaconda/ui/tui/hubs/summary.py
@@ -99,11 +99,15 @@ class SummaryHub(TUIHub):
         if flags.automatedInstall and not incomplete_spokes:
 
             # Check the available space.
-            if flags.ksprompt and self._checker and not self._checker.check():
+            if self._checker and not self._checker.check():
 
                 # Space is not ok.
                 print(self._checker.error_message)
                 log.error(self._checker.error_message)
+
+                if not flags.ksprompt:
+                    # In cmdline mode, raise an error — cannot prompt the user.
+                    raise CmdlineError(self._checker.error_message)
 
                 # Unset the checker so everything passes next time.
                 self._checker = None


### PR DESCRIPTION
Direct backport of upstream https://github.com/rhinstaller/anaconda/pull/7116

The space check in the TUI summary hub was skipped entirely in cmdline mode (non-interactive kickstart). This caused installations to proceed even with insufficient disk space, only to fail later during the RPM transaction or flatpak installation — after disks had already been formatted.

The check was removed in commit 61018a881e (2018) as a workaround for a crash when depsolving wasn't complete yet. However, the check is already gated on all spokes being complete, which means depsolving is done by the time this code runs. The workaround is no longer needed.

Now when the space check fails in cmdline mode, a CmdlineError is raised — the same pattern used for incomplete spokes. In text mode, the existing behavior is preserved (warn and let user press 'b' to override).

Resolves: RHEL-142734
