### PR TITLE
 [RHEL-9] Fix rescue mode for OSTree/atomic systems rhel-9

### DIFF
--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -450,3 +450,10 @@ class OSData(DBusData):
         :return: a device name or None
         """
         return self.mount_points.get("/")
+
+    def get_boot_device(self):
+        """Get the boot device.
+
+        :return: a device name or None
+        """
+        return self.mount_points.get("/boot")

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -31,7 +31,10 @@ from pyanaconda.modules.common.constants.services import LOCALIZATION, STORAGE
 from pyanaconda.modules.common.errors.installation import BootloaderInstallationError
 from pyanaconda.modules.common.structures.storage import DeviceData
 from pyanaconda.modules.common.task import Task
-from pyanaconda.modules.payloads.payload.rpm_ostree.util import have_bootupd
+from pyanaconda.modules.payloads.payload.rpm_ostree.util import (
+    get_ostree_deployment_path,
+    have_bootupd,
+)
 from pyanaconda.payload.errors import PayloadInstallError
 
 gi.require_version("OSTree", "1.0")
@@ -739,13 +742,8 @@ class SetSystemRootTask(Task):
         return "Set OSTree system root"
 
     def run(self):
-        sysroot_file = Gio.File.new_for_path(self._physroot)
-        sysroot = OSTree.Sysroot.new(sysroot_file)
-        sysroot.load(None)
-
-        deployments = sysroot.get_deployments()
-        assert len(deployments) > 0
-
-        deployment = deployments[0]
-        deployment_path = sysroot.get_deployment_directory(deployment)
-        set_system_root(deployment_path.get_path())
+        """Reload and find the path to the new deployment."""
+        deployment_path = get_ostree_deployment_path(self._physroot)
+        if not deployment_path:
+            raise PayloadInstallError("Failed to find OSTree deployment")
+        set_system_root(deployment_path)

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/util.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/util.py
@@ -18,11 +18,42 @@
 
 import os.path
 
+import gi
+
+gi.require_version("OSTree", "1.0")
+gi.require_version("Gio", "2.0")
+from gi.repository import Gio, OSTree
+
 from pyanaconda.core.util import join_paths
 
-__all__ = ["have_bootupd"]
+__all__ = ["get_ostree_deployment_path", "have_bootupd"]
 
 
 def have_bootupd(sysroot):
     """Is bootupd/bootupctl present in sysroot?"""
     return os.path.exists(join_paths(sysroot, "/usr/bin/bootupctl"))
+
+
+def get_ostree_deployment_path(sysroot_path):
+    """Get the OSTree deployment path for a given sysroot.
+
+    :param sysroot_path: path to the mounted sysroot
+    :return: deployment directory path, or None if not found
+    """
+    # Check if this looks like an ostree installation
+    ostree_deploy_path = os.path.join(sysroot_path, "ostree", "deploy")
+    if not os.path.isdir(ostree_deploy_path):
+        return None
+
+    sysroot_file = Gio.File.new_for_path(sysroot_path)
+    ostree_sysroot = OSTree.Sysroot.new(sysroot_file)
+    ostree_sysroot.load(None)
+    deployments = ostree_sysroot.get_deployments()
+    if deployments:
+        deployment = deployments[0]
+        deployment_dir = ostree_sysroot.get_deployment_directory(deployment)
+        deployment_path = deployment_dir.get_path()
+        if os.path.isdir(deployment_path):
+            return deployment_path
+
+    return None

--- a/pyanaconda/modules/storage/devicetree/model.py
+++ b/pyanaconda/modules/storage/devicetree/model.py
@@ -19,7 +19,6 @@
 #
 import copy
 import logging
-import os
 
 from blivet.blivet import Blivet
 from blivet.devicelibs.crypto import DEFAULT_LUKS_VERSION
@@ -448,24 +447,6 @@ class InstallerStorage(Blivet):
 
     def parse_fstab(self, chroot=None):
         self.fsset.parse_fstab(chroot=chroot)
-
-    def make_mtab(self, chroot=None):
-        path = "/etc/mtab"
-        target = "/proc/self/mounts"
-        chroot = chroot or conf.target.system_root
-        path = os.path.normpath("%s/%s" % (chroot, path))
-
-        if os.path.islink(path):
-            # return early if the mtab symlink is already how we like it
-            current_target = os.path.normpath(os.path.dirname(path) +
-                                              "/" + os.readlink(path))
-            if current_target == target:
-                return
-
-        if os.path.exists(path):
-            os.unlink(path)
-
-        os.symlink(target, path)
 
     def add_fstab_swap(self, device):
         """

--- a/pyanaconda/modules/storage/devicetree/root.py
+++ b/pyanaconda/modules/storage/devicetree/root.py
@@ -117,18 +117,31 @@ def _find_existing_installations(devicetree):
             blivet_util.umount(mountpoint=sysroot)
             continue
 
-        if not os.access(sysroot + "/etc/fstab", os.R_OK):
+        # Find the root filesystem by locating /etc/fstab
+        # This handles deployments where the root filesystem is nested (such as atomic OSTree deployments)
+        chroot_path = _find_root_from_fstab(sysroot) or sysroot
+
+        if not os.access(chroot_path + "/etc/fstab", os.R_OK):
             blivet_util.umount(mountpoint=sysroot)
             device.teardown()
             continue
 
-        architecture, product, version = get_release_string(chroot=sysroot)
-        (mounts, devices) = _parse_fstab(devicetree, chroot=sysroot)
+        architecture, product, version = get_release_string(chroot=chroot_path)
+        (mounts, devices) = _parse_fstab(devicetree, chroot=chroot_path)
         blivet_util.umount(mountpoint=sysroot)
 
         if not mounts and not devices:
             # empty /etc/fstab. weird, but I've seen it happen.
             continue
+
+        # Deduplicate: skip if we already have a Root with the same root device
+        root_device = mounts.get('/')
+        if root_device:
+            root_device_id = root_device.id
+            if any((existing_dev := existing_root.mounts.get('/')) and existing_dev.id == root_device_id
+                   for existing_root in roots):
+                device.teardown()
+                continue
 
         roots.append(Root(
             product=product,
@@ -139,6 +152,20 @@ def _find_existing_installations(devicetree):
         ))
 
     return roots
+
+
+def _find_root_from_fstab(mountpoint):
+    """Find the root filesystem by locating /etc/fstab.
+
+    :param mountpoint: path to the mounted device
+    :return: root filesystem path (where /etc/fstab exists), or None if not found
+    """
+    for root, dirs, _files in os.walk(mountpoint):
+        if 'etc' in dirs:
+            fstab_path = os.path.join(root, 'etc', 'fstab')
+            if os.path.isfile(fstab_path):
+                return root
+    return None
 
 
 def get_release_string(chroot):

--- a/pyanaconda/modules/storage/devicetree/root.py
+++ b/pyanaconda/modules/storage/devicetree/root.py
@@ -65,9 +65,6 @@ def mount_existing_system(storage, root_device, read_only=None):
         except StorageError as e:
             log.error("Error enabling swap: %s", str(e))
 
-    # Generate mtab.
-    if not read_only:
-        storage.make_mtab(chroot=root_path)
 
 
 def find_existing_installations(devicetree, teardown_all=True):

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -283,7 +283,6 @@ class WriteConfigurationTask(Task):
 
         self._write_escrow_packets(storage, sysroot)
 
-        storage.make_mtab()
         storage.fsset.write()
 
         self._write_lvm_devices_file(self._storage, sysroot)

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -35,6 +35,7 @@ from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import ANACONDA_CLEANUP, QUIT_MESSAGE, THREAD_STORAGE
 from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.util import set_system_root
 from pyanaconda.flags import flags
 from pyanaconda.kickstart import runPostScripts
 from pyanaconda.modules.common.constants.objects import DEVICE_TREE
@@ -251,8 +252,10 @@ class Rescue(object):
         makeFStab()
 
         # Check if this is an OSTree/immutable system
-        if get_ostree_deployment_path(conf.target.system_root):
+        deployment_path = get_ostree_deployment_path(conf.target.physical_root)
+        if deployment_path:
             self.is_ostree = True
+            set_system_root(deployment_path)
 
         # run %post if we've mounted everything
         if not self.ro and self._scripts:
@@ -454,11 +457,6 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
                                      "command line for autorelabel to work properly.\n")
                                    if self._rescue.autorelabel else "")
 
-                # For OSTree installations, find the deployment directory for chroot
-                mountpoint = conf.target.system_root
-                deployment_path = get_ostree_deployment_path(mountpoint)
-                chroot_path = deployment_path if deployment_path else mountpoint
-
                 ostree_warning = (_("Warning: An immutable system has been detected. "
                                     "It is not recommended to make manual changes to the deployment "
                                     "directories as this may break system integrity. Only modify "
@@ -468,8 +466,8 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
                 text = TextWidget(_("Your system has been mounted under %(mountpoint)s.\n\n"
                                     "If you would like to make the root of your system the "
                                     "root of the active system, run the command:\n\n"
-                                    "\tchroot %(chroot_path)s\n\n")
-                                  % {"mountpoint": mountpoint, "chroot_path": chroot_path}
+                                    "\tchroot %(mountpoint)s\n\n")
+                                  % {"mountpoint": conf.target.system_root}
                                   + ostree_warning + autorelabel_msg + finish_msg)
             elif status == RescueModeStatus.MOUNT_FAILED:
                 if self._rescue.reboot:

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -155,6 +155,7 @@ class Rescue(object):
         self.ro = False
 
         self.autorelabel = False
+        self.is_ostree = False
 
         self.status = RescueModeStatus.NOT_SET
         self.error = None
@@ -239,6 +240,10 @@ class Rescue(object):
 
         # create /etc/fstab in ramdisk so it's easier to work with RO mounted fs
         makeFStab()
+
+        # Check if this is an OSTree/immutable system
+        if get_ostree_deployment_path(conf.target.system_root):
+            self.is_ostree = True
 
         # run %post if we've mounted everything
         if not self.ro and self._scripts:
@@ -440,12 +445,23 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
                                      "command line for autorelabel to work properly.\n")
                                    if self._rescue.autorelabel else "")
 
+                # For OSTree installations, find the deployment directory for chroot
+                mountpoint = conf.target.system_root
+                deployment_path = get_ostree_deployment_path(mountpoint)
+                chroot_path = deployment_path if deployment_path else mountpoint
+
+                ostree_warning = (_("Warning: An immutable system has been detected. "
+                                    "It is not recommended to make manual changes to the deployment "
+                                    "directories as this may break system integrity. Only modify "
+                                    "/etc, /var, or boot loader configuration files as needed.\n\n")
+                                 if self._rescue.is_ostree else "")
+
                 text = TextWidget(_("Your system has been mounted under %(mountpoint)s.\n\n"
                                     "If you would like to make the root of your system the "
                                     "root of the active system, run the command:\n\n"
-                                    "\tchroot %(mountpoint)s\n\n")
-                                  % {"mountpoint": conf.target.system_root} + autorelabel_msg
-                                  + finish_msg)
+                                    "\tchroot %(chroot_path)s\n\n")
+                                  % {"mountpoint": mountpoint, "chroot_path": chroot_path}
+                                  + ostree_warning + autorelabel_msg + finish_msg)
             elif status == RescueModeStatus.MOUNT_FAILED:
                 if self._rescue.reboot:
                     finish_msg = exit_reboot_msg

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -42,6 +42,7 @@ from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.errors.storage import MountFilesystemError
 from pyanaconda.modules.common.structures.storage import DeviceFormatData, OSData
 from pyanaconda.modules.common.task import sync_run_task
+from pyanaconda.modules.payloads.payload.rpm_ostree.util import get_ostree_deployment_path
 from pyanaconda.threading import threadMgr
 from pyanaconda.ui.tui import tui_quit_callback
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -202,6 +203,14 @@ class Rescue(object):
             task_proxy = STORAGE.get_proxy(task_path)
             sync_run_task(task_proxy)
             log.info("System has been mounted under: %s", conf.target.system_root)
+
+            # Mount /boot if it exists
+            # This is needed for OSTree deployments to be detected properly
+            boot_device = root.get_boot_device()
+            if boot_device:
+                boot_path = os.path.join(conf.target.system_root, "boot")
+                read_only = "ro" if self.ro else ""
+                self._device_tree_proxy.MountDevice(boot_device, boot_path, read_only)
         except MountFilesystemError as e:
             log.error("Mounting system under %s failed: %s", conf.target.system_root, e)
             self.status = RescueModeStatus.MOUNT_FAILED

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree_tasks.py
@@ -1051,17 +1051,14 @@ class PullRemoteAndDeleteTaskTestCase(unittest.TestCase):
 
 
 class SetSystemRootTaskTestCase(unittest.TestCase):
-    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.OSTree.Sysroot.new")
+    @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.get_ostree_deployment_path")
     @patch("pyanaconda.modules.payloads.payload.rpm_ostree.installation.set_system_root")
-    def test_run(self, set_mock, new_sysroot_mock):
+    def test_run(self, set_mock, get_deployment_path_mock):
         """Test OSTree sysroot set task"""
-        sysroot_mock = new_sysroot_mock()
-        sysroot_mock.get_deployments.return_value = [None]
+        get_deployment_path_mock.return_value = "/physroot/ostree/deploy/default/deploy/abc123.0"
 
         task = SetSystemRootTask("/physroot")
         task.run()
 
-        assert len(new_sysroot_mock.mock_calls) == 2+4
-        # 2 above: new, get_deployments;
-        # 4 in run(): new(), load(), get_deployments(), get_deployment_directory()
-        set_mock.assert_called_once()
+        get_deployment_path_mock.assert_called_once_with("/physroot")
+        set_mock.assert_called_once_with("/physroot/ostree/deploy/default/deploy/abc123.0")


### PR DESCRIPTION
<img width="1920" height="1011" alt="drive-scrollbars-fitting" src="https://github.com/user-attachments/assets/c9870722-0433-4b5c-9306-4dc9bbc5c735" />
<img width="831" height="476" alt="drive-scrollbars" src="https://github.com/user-attachments/assets/d3432311-04de-48c3-9c9c-d1345f8f3f9c" />
