### PR TITLE
gui: keep disk selection scrollbars permanently visible

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -133,6 +133,8 @@
                                 <property name="margin-left">18</property>
                                 <property name="margin-right">18</property>
                                 <property name="hexpand">True</property>
+                                <property name="overlay-scrolling">False</property>
+                                <property name="hscrollbar-policy">automatic</property>
                                 <property name="vscrollbar-policy">never</property>
                                 <property name="shadow-type">in</property>
                                 <child>
@@ -216,6 +218,8 @@
                                 <property name="margin-left">18</property>
                                 <property name="margin-right">18</property>
                                 <property name="hexpand">True</property>
+                                <property name="overlay-scrolling">False</property>
+                                <property name="hscrollbar-policy">automatic</property>
                                 <property name="vscrollbar-policy">never</property>
                                 <property name="shadow-type">in</property>
                                 <child>


### PR DESCRIPTION
It looks like this with this patch:
<img width="1920" height="1011" alt="Screenshot_fdfd_2026-06-22_11:43:13" src="https://github.com/user-attachments/assets/152abf67-6b9a-4666-a195-9f3bca4849a4" />

<img width="956" height="957" alt="Screenshot_fdfd_2026-06-22_11:46:21" src="https://github.com/user-attachments/assets/7080bb27-a4d2-4409-8d4e-0f73e15c43fc" />

