### PR TITLE
gui: disable overlay scrolling on disk selection lists

### DIFF
--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -133,6 +133,8 @@
                                 <property name="margin-left">18</property>
                                 <property name="margin-right">18</property>
                                 <property name="hexpand">True</property>
+                                <property name="overlay-scrolling">False</property>
+                                <property name="hscrollbar-policy">automatic</property>
                                 <property name="vscrollbar-policy">never</property>
                                 <property name="shadow-type">in</property>
                                 <child>
@@ -216,6 +218,8 @@
                                 <property name="margin-left">18</property>
                                 <property name="margin-right">18</property>
                                 <property name="hexpand">True</property>
+                                <property name="overlay-scrolling">False</property>
+                                <property name="hscrollbar-policy">automatic</property>
                                 <property name="vscrollbar-policy">never</property>
                                 <property name="shadow-type">in</property>
                                 <child>


### PR DESCRIPTION
Set overlay-scrolling to False on the Local Standard Disks and Specialized Disks scrolled windows so scrollbars do not hide and remain draggable. Use automatic horizontal scrollbar policy so the bar is shown only when scrolling is needed and hidden when all disks fit in the view.

Resolves: RHEL-69902

Assisted-by: Cursor (claude-4.6-sonnet-medium-thinking)
(cherry picked from commit ed680f12fb8fd0f4f2541aba34b4ff826fd7a958)

