### PR TITLE
fix: Use full locale for keyboard layout selection

### DIFF
--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -444,8 +444,9 @@ class LocalizationService(KickstartService):
             # (the x_layouts list comes from kickstart)
             return
 
-        locale = get_language_id(self.language)
-        layouts = get_locale_keyboards(locale)
+        # Use the full locale (with territory) to get the correct keyboard layout.
+        # For example, pt_PT should get 'pt' keyboard, not 'br' keyboard.
+        layouts = get_locale_keyboards(self.language)
         if layouts:
             # take the first locale (with highest rank) from the list and
             # store it normalized
@@ -458,7 +459,7 @@ class LocalizationService(KickstartService):
                 # refer: https://bugzilla.redhat.com/show_bug.cgi?id=1039185
                 new_layouts.insert(0, DEFAULT_KEYBOARD)
         else:
-            log.error("Failed to get layout for chosen locale '%s'", locale)
+            log.error("Failed to get layout for chosen locale '%s'", self.language)
             new_layouts = [DEFAULT_KEYBOARD]
 
         self.set_x_layouts(new_layouts)

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization.py
@@ -169,6 +169,18 @@ class LocalizationInterfaceTestCase(unittest.TestCase):
         self.localization_interface.SetKeyboard("us")
         assert self.localization_interface.VirtualConsoleKeymap == "us"
 
+    @patch("pyanaconda.modules.localization.localization.get_locale_keyboards")
+    def test_set_x_keyboard_defaults_uses_full_locale(self, mock_get_keyboards):
+        """Test that set_x_keyboard_defaults() uses full locale with territory."""
+        mock_get_keyboards.return_value = ["pt"]
+
+        self.localization_interface.Language = "pt_PT.UTF-8"
+        self.localization_interface.XLayouts = []
+        self.localization_module.set_x_keyboard_defaults()
+
+        # Verify get_locale_keyboards was called with full locale, not stripped
+        mock_get_keyboards.assert_called_once_with("pt_PT.UTF-8")
+
     def test_collect_requirements(self):
         """Test the CollectRequirements method."""
         # No default requirements.


### PR DESCRIPTION
Fix bug where selecting Portuguese from Portugal (pt_PT) incorrectly set a Brazilian keyboard (br) instead of the Portuguese keyboard (pt).

The issue was in set_x_keyboard_defaults() which was stripping the territory from the locale (pt_PT → pt) before querying langtable for keyboard layouts. When langtable receives just 'pt', it returns both 'br' and 'pt' keyboards with Brazilian ranked first.

The fix uses the full locale (including territory) when querying for keyboard layouts, allowing langtable to return the correct territory-specific keyboard.


Resolves: rhbz#2491211
