### PR TITLE
fix: use static string for tmux status line to reduce CPU usage

### DIFF
--- a/data/tmux.conf
+++ b/data/tmux.conf
@@ -20,7 +20,7 @@ set-option -g history-limit 10000
 # then re-attach to it in the tmux service run on the console tty.
 new-session -d -s anaconda -n main anaconda
 
-set-option status-right '#[fg=blue]#(echo -n "Switch tab: Alt+Tab | Help: F1 ")'
+set-option status-right '#[fg=blue]Switch tab: Alt+Tab | Help: F1 '
 
 new-window -d -n shell          "bash --login"
 new-window -d -n log            "tail -F /tmp/anaconda.log"


### PR DESCRIPTION
Replace the #(echo -n "...") construct with a plain static string in the tmux status line. The shell command construct causes tmux to fork a shell repeatedly, resulting in high CPU usage (~70% on slow machines) just to display static text.

Resolves: RHEL-182044
