### PR TITLE
localization: ensure console font persists via systemd-vconsole-setup

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -251,6 +251,10 @@ def setup_locale(locale, localization_proxy=None, text_mode=False):
                     font_set = True
                     break
 
+            if font_set:
+                log.debug("reapplying console font via systemd-vconsole-setup")
+                execWithRedirect("systemctl", ["restart", "systemd-vconsole-setup.service"])
+
         if not font_set:
             log.warning("can't set console font for locale %s", locale)
             # report what exactly went wrong


### PR DESCRIPTION
After setting the console font via set_console_font(), restart systemd-vconsole-setup.service to ensure the font persists through any console resets that may occur during display initialization.

Resolves: RHEL-183264

<img width="1146" height="716" alt="Screenshot 2026-06-24 at 13-33-13 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/28234cd3-c595-44a6-9a04-02db29a2e661" />
