### PR TITLE
localization: ensure console font persists via systemd-vconsole-setup

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -240,6 +240,10 @@ def setup_locale(locale, localization_proxy=None, text_mode=False):
                     font_set = True
                     break
 
+            if font_set:
+                log.debug("reapplying console font via systemd-vconsole-setup")
+                execWithRedirect("systemctl", ["restart", "systemd-vconsole-setup.service"])
+
         if not font_set:
             log.warning("can't set console font for locale %s", locale)
             # report what exactly went wrong


### PR DESCRIPTION
After setting the console font via set_console_font(), restart systemd-vconsole-setup.service to ensure the font persists through any console resets that may occur during display initialization.

(cherry-picked from: 2643d2a412140b9adbaf7dd10b36d0bdba80f014)
Resolves: RHEL-154012

