### PR TITLE
Revert "localization: ensure console font persists via systemd-vconsole-setup

### DIFF
--- a/pyanaconda/localization.py
+++ b/pyanaconda/localization.py
@@ -251,10 +251,6 @@ def setup_locale(locale, localization_proxy=None, text_mode=False):
                     font_set = True
                     break
 
-            if font_set:
-                log.debug("reapplying console font via systemd-vconsole-setup")
-                execWithRedirect("systemctl", ["restart", "systemd-vconsole-setup.service"])
-
         if not font_set:
             log.warning("can't set console font for locale %s", locale)
             # report what exactly went wrong


### PR DESCRIPTION
This reverts commit 2f8715d942eb68cae86abd659078aa5dcec7f72c.

The console font regression (RHEL-183264) only affects RHEL 9, which still uses Xorg. On main and RHEL 10, Anaconda runs on Wayland, which does not trigger the console reset behavior that caused the font to be lost during display initialization.

The fix remains valid and necessary on the rhel-9 branch where Xorg is still in use.

Related: RHEL-183264
