### PR TITLE
fix: improve error when enabling missing services on target

### DIFF
--- a/pyanaconda/modules/services/installation.py
+++ b/pyanaconda/modules/services/installation.py
@@ -189,8 +189,8 @@ class ConfigureServicesTask(Task):
 
         if missing_services:
             raise NonCriticalInstallationError(
-                _("Cannot enable the following services because they are not installed: {names}. "
-                  "Make sure the packages providing these services are included in %packages.").format(
+                _("Cannot enable the following services because they are not installed on "
+                  "the target system: {names}.").format(
                     names=", ".join(missing_services)
                 )
             )


### PR DESCRIPTION
The previous message only mentioned %packages, which does not apply to ostree, bootc, image, and other non-RPM payload installs.

Related: RHEL-178289

