### PR TITLE
storage: select default disks in DiskSelectionModule

### DIFF
--- a/anaconda.py
+++ b/anaconda.py
@@ -371,6 +371,17 @@ if __name__ == "__main__":
     log.info("anaconda called with cmdline = %s", sys.argv)
     log.info("Default encoding = %s ", sys.getdefaultencoding())
 
+    # Find a kickstart file.
+    kspath = startup_utils.find_kickstart(opts)
+    log.info("Found a kickstart file: %s", kspath)
+
+    # Publish install-session flags before modules start.
+    conf.set_runtime_install_session(
+        flags.automatedInstall,
+        not opts.noninteractive,
+        opts.pause_at_summary,
+    )
+
     # start dbus session (if not already running) and run boss in it
     try:
         anaconda.dbus_launcher.start()
@@ -380,10 +391,6 @@ if __name__ == "__main__":
         util.ipmi_report(constants.IPMI_ABORTED)
         time.sleep(10)
         sys.exit(1)
-
-    # Find a kickstart file.
-    kspath = startup_utils.find_kickstart(opts)
-    log.info("Found a kickstart file: %s", kspath)
 
     # Run %pre scripts.
     startup_utils.run_pre_scripts(kspath)

--- a/pyanaconda/core/configuration/anaconda.py
+++ b/pyanaconda/core/configuration/anaconda.py
@@ -447,6 +447,9 @@ class AnacondaConfiguration(Configuration):
         self.runtime._set_option("pause_at_summary", pause_at_summary)
         self.validate()
         path = os.environ.get("ANACONDA_CONFIG_TMP", ANACONDA_CONFIG_TMP)
+        dirname = os.path.dirname(path)
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
         self.write(path)
 
 

--- a/pyanaconda/modules/storage/disk_selection/selection.py
+++ b/pyanaconda/modules/storage/disk_selection/selection.py
@@ -18,6 +18,7 @@
 # Red Hat, Inc.
 #
 from pyanaconda.anaconda_loggers import get_module_logger
+from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.dbus import DBus
 from pyanaconda.core.i18n import _
 from pyanaconda.core.signal import Signal
@@ -186,3 +187,57 @@ class DiskSelectionModule(StorageSubscriberModule):
         :return: a list of disk IDs
         """
         return [disk.device_id for disk in self.storage.usable_disks]
+
+    def on_storage_changed(self, storage):
+        """Keep the instance of the current storage."""
+        super().on_storage_changed(storage)
+
+        if storage.disks:
+            self.select_default_disks()
+
+    def select_default_disks(self):
+        """Select default disks for the partitioning.
+
+        If there are some disks already selected, do nothing.
+        In the automatic installation, select all disks. In
+        the interactive installation, select a disk if there
+        is only one available.
+
+        :return: a list of selected disks
+        """
+        if self._selected_disks:
+            log.debug(
+                "Skipping default disk selection, disks already selected: %s",
+                self._selected_disks,
+            )
+            return self._selected_disks
+
+        log.debug(
+            "Default disk selection: automated_install=%s, interactive_mode=%s, "
+            "storage disks=%s, usable disks=%s",
+            conf.runtime.automated_install,
+            conf.runtime.interactive_mode,
+            [d.device_id for d in self.storage.disks],
+            self.get_usable_disks(),
+        )
+
+        if conf.runtime.automated_install:
+            all_disks = [d.device_id for d in self.storage.disks]
+            drives = [d for d in all_disks if d not in self._ignored_disks]
+            self.set_selected_disks(drives)
+            log.debug("Selecting all disks by default: %s", ",".join(drives))
+        else:
+            usable_disks = self.get_usable_disks()
+            available_disks = [d for d in usable_disks if d not in self._ignored_disks]
+
+            if len(available_disks) == 1:
+                self.set_selected_disks(available_disks)
+                log.debug("Single disk detected, selecting it for installation: %s", available_disks[0])
+            else:
+                log.debug(
+                    "Not selecting disks by default in interactive mode "
+                    "(%d usable disks available)",
+                    len(available_disks),
+                )
+
+        return self._selected_disks

--- a/pyanaconda/ui/gui/spokes/storage.py
+++ b/pyanaconda/ui/gui/spokes/storage.py
@@ -83,7 +83,6 @@ from pyanaconda.ui.lib.storage import (
     is_local_disk,
     is_passphrase_required,
     reset_storage,
-    select_default_disks,
     set_required_passphrase,
 )
 
@@ -531,9 +530,6 @@ class StorageSpoke(NormalSpoke, StorageCheckHandler):
         disks = self._disk_select_module.GetUsableDisks()
         DasdFormatting.run_automatically(disks, self._show_dasdfmt_report)
         hubQ.send_message(self.__class__.__name__, _(constants.PAYLOAD_STATUS_PROBING_STORAGE))
-
-        # Update the selected disks.
-        select_default_disks()
 
         # Automatically apply the preconfigured partitioning.
         # Do not set ready in the automated installation before

--- a/pyanaconda/ui/lib/storage.py
+++ b/pyanaconda/ui/lib/storage.py
@@ -33,7 +33,6 @@ from pyanaconda.core.i18n import P_, _
 from pyanaconda.core.storage import device_matches
 from pyanaconda.errors import ERROR_RAISE
 from pyanaconda.errors import errorHandler as error_handler
-from pyanaconda.flags import flags
 from pyanaconda.modules.common.constants.objects import (
     BOOTLOADER,
     DEVICE_TREE,
@@ -125,47 +124,6 @@ def reset_bootloader():
     """Reset the bootloader."""
     bootloader_proxy = STORAGE.get_proxy(BOOTLOADER)
     bootloader_proxy.Drive = BOOTLOADER_DRIVE_UNSET
-
-
-def select_default_disks():
-    """Select default disks for the partitioning.
-
-    If there are some disks already selected, do nothing.
-    In the automatic installation, select all disks. In
-    the interactive installation, select a disk if there
-    is only one available.
-
-    :return: a list of selected disks
-    """
-    disk_select_proxy = STORAGE.get_proxy(DISK_SELECTION)
-    selected_disks = disk_select_proxy.SelectedDisks
-    ignored_disks = disk_select_proxy.IgnoredDisks
-
-    if selected_disks:
-        # Do nothing if there are some disks selected.
-        pass
-    elif flags.automatedInstall:
-        # Get all disks.
-        device_tree = STORAGE.get_proxy(DEVICE_TREE)
-        all_disks = device_tree.GetDisks()
-
-        # Select all disks.
-        selected_disks = [d for d in all_disks if d not in ignored_disks]
-        disk_select_proxy.SelectedDisks = selected_disks
-        log.debug("Selecting all disks by default: %s", ",".join(selected_disks))
-    else:
-        # Get usable disks.
-        usable_disks = disk_select_proxy.GetUsableDisks()
-        available_disks = [d for d in usable_disks if d not in ignored_disks]
-
-        # Select a usable disk if there is only one available.
-        if len(available_disks) == 1:
-            selected_disks = available_disks
-            apply_disk_selection(selected_disks)
-
-        log.debug("Selecting one or less disks by default: %s", ",".join(selected_disks))
-
-    return selected_disks
 
 
 def apply_disk_selection(selected_names, reset_boot_drive=False):

--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -72,7 +72,6 @@ from pyanaconda.ui.lib.storage import (
     get_disks_summary,
     is_passphrase_required,
     reset_storage,
-    select_default_disks,
     set_required_passphrase,
 )
 from pyanaconda.ui.tui.spokes import NormalTUISpoke
@@ -439,9 +438,6 @@ class StorageSpoke(NormalTUISpoke):
         # Automatically format DASDs if allowed.
         disks = self._disk_select_module.GetUsableDisks()
         DasdFormatting.run_automatically(disks)
-
-        # Update the selected disks.
-        select_default_disks()
 
         # Automatically apply the preconfigured partitioning.
         if flags.automatedInstall and self._is_preconfigured:

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_disk_select.py
@@ -18,9 +18,11 @@
 # Red Hat Author(s): Vendula Poncova <vponcova@redhat.com>
 #
 import unittest
+from unittest.mock import patch
 
 import pytest
 from blivet.devices import DiskDevice
+from blivet.flags import flags
 from blivet.formats import get_format
 from blivet.size import Size
 
@@ -173,3 +175,26 @@ class DiskSelectionInterfaceTestCase(unittest.TestCase):
 
         self.disk_selection_module.on_storage_changed(create_storage())
         assert self.disk_selection_interface.GetUsableDisks() == []
+
+    def _add_disks(self, storage, names):
+        flags.testing = True
+        for name in names:
+            disk = DiskDevice(
+                name,
+                exists=False,
+                size=Size("15 GiB"),
+                fmt=get_format("disklabel"),
+            )
+            storage.devicetree._add_device(disk)
+
+        return storage
+
+    @patch("pyanaconda.modules.storage.disk_selection.selection.conf")
+    def test_select_default_disks_automated_install(self, mock_conf):
+        """Test all disks are selected by default in an automated installation."""
+        mock_conf.runtime.automated_install = True
+
+        storage = self._add_disks(create_storage(), ["sda", "sdb"])
+        self.disk_selection_module.on_storage_changed(storage)
+
+        assert self.disk_selection_module.selected_disks == ["sda", "sdb"]

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -88,6 +88,15 @@ from tests.unit_tests.pyanaconda_tests import (
 )
 
 
+def _mock_storage():
+    """Return a storage mock with disk list properties used by DiskSelectionModule."""
+    storage = Mock()
+    storage.disks = []
+    storage.usable_disks = []
+    storage.copy.side_effect = _mock_storage
+    return storage
+
+
 class StorageInterfaceTestCase(unittest.TestCase):
     """Test DBus interface of the storage module."""
 
@@ -175,6 +184,29 @@ class StorageInterfaceTestCase(unittest.TestCase):
         storage_changed_callback.assert_called_once()
         partitioning_reset_callback.assert_not_called()
 
+    @patch("pyanaconda.modules.storage.disk_selection.selection.conf")
+    def test_select_default_disks_on_rescan(self, mock_conf):
+        """Default disk selection is skipped on rescan if disks are already selected."""
+        mock_conf.runtime.automated_install = True
+
+        disk1 = Mock()
+        disk1.device_id = "sda"
+        disk2 = Mock()
+        disk2.device_id = "sdb"
+
+        scanned = _mock_storage()
+        scanned.disks = [disk1, disk2]
+
+        self.storage_module._set_storage(scanned)
+        assert self.storage_module._disk_selection_module.selected_disks == ["sda", "sdb"]
+
+        self.storage_module._disk_selection_module.set_selected_disks(["sda"])
+
+        rescanned = _mock_storage()
+        rescanned.disks = [disk1, disk2]
+        self.storage_module._set_storage(rescanned)
+        assert self.storage_module._disk_selection_module.selected_disks == ["sda"]
+
     @patch_dbus_publish_object
     def test_create_partitioning(self, published):
         """Test CreatePartitioning."""
@@ -230,9 +262,11 @@ class StorageInterfaceTestCase(unittest.TestCase):
     @patch('pyanaconda.modules.storage.partitioning.validate.storage_checker')
     def test_apply_partitioning(self, storage_checker, published):
         """Test ApplyPartitioning."""
-        storage_1 = Mock()
-        storage_2 = storage_1.copy.return_value
-        storage_3 = storage_2.copy.return_value
+        storage_1 = _mock_storage()
+        storage_2 = _mock_storage()
+        storage_3 = _mock_storage()
+        storage_1.copy.side_effect = lambda: storage_2
+        storage_2.copy.side_effect = lambda: storage_3
 
         report = StorageCheckerReport()
         storage_checker.check.return_value = report
@@ -261,7 +295,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
     @patch('pyanaconda.modules.storage.partitioning.validate.storage_checker')
     def test_applied_partitioning(self, storage_checker, publisher):
         """Test the property AppliedPartitioning."""
-        storage = Mock()
+        storage = _mock_storage()
 
         report = StorageCheckerReport()
         storage_checker.check.return_value = report
@@ -279,9 +313,11 @@ class StorageInterfaceTestCase(unittest.TestCase):
     @patch('pyanaconda.modules.storage.partitioning.validate.storage_checker')
     def test_reset_partitioning(self, storage_checker, published):
         """Test ResetPartitioning."""
-        storage_1 = Mock()
-        storage_2 = storage_1.copy.return_value
-        storage_3 = storage_2.copy.return_value
+        storage_1 = _mock_storage()
+        storage_2 = _mock_storage()
+        storage_3 = _mock_storage()
+        storage_1.copy.side_effect = lambda: storage_2
+        storage_2.copy.side_effect = lambda: storage_3
 
         report = StorageCheckerReport()
         storage_checker.check.return_value = report
@@ -299,8 +335,8 @@ class StorageInterfaceTestCase(unittest.TestCase):
         assert self.storage_interface.AppliedPartitioning == partitioning
         assert self.storage_module.storage == storage_3
 
-        storage_4 = Mock()
-        storage_1.copy.return_value = storage_4
+        storage_4 = _mock_storage()
+        storage_1.copy.side_effect = lambda: storage_4
 
         self.storage_interface.ResetPartitioning()
         assert self.storage_interface.AppliedPartitioning == ""
@@ -310,7 +346,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
     @patch("pyanaconda.modules.storage.storage.platform", S390())
     def test_collect_requirements(self):
         """Test CollectRequirements."""
-        storage = Mock()
+        storage = _mock_storage()
         storage.bootloader = GRUB2()
         storage.packages = ["lvm2"]
 


### PR DESCRIPTION
Move default disk selection from the UI layer into the disk selection module so it runs when storage is initialized or rescanned.

Remove the duplicate logic from GTK/TUI storage spokes and we need to also remove this code from WebUI.

Resolves: INSTALLER-4781

