### PR TITLE
dracut: fix dd_extract payload decompression for zstd RPMs

### DIFF
--- a/dracut/dd/rpmutils.c
+++ b/dracut/dd/rpmutils.c
@@ -256,6 +256,23 @@ int checkDDRPM(const char *source,
     return RPM_OK;
 }
 
+static const char *payloadCompressorToIoType(const char *compr)
+{
+    if (!compr || !*compr)
+        return "gzdio";
+    if (!strcmp(compr, "gzip"))
+        return "gzdio";
+    if (!strcmp(compr, "zstd"))
+        return "zstdio";
+    if (!strcmp(compr, "xz"))
+        return "xzdio";
+    if (!strcmp(compr, "bzip2"))
+        return "bzdio";
+    if (!strcmp(compr, "lzma"))
+        return "lzdio";
+    return "gzdio";
+}
+
 /*
  * explode source RPM into the current directory
  * use filters to skip files we do not need
@@ -272,6 +289,7 @@ int explodeDDRPM(const char *source,
     rpmRC rc;
     FD_t gzdi;
     const char *compr;
+    const char *io_type;
     struct archive *cpio;
     struct archive_entry *cpio_entry;
     struct cpio_mydata cpio_mydata;
@@ -285,12 +303,8 @@ int explodeDDRPM(const char *source,
 
     /* Retrieve type of payload compression. */
     compr = headerGetString(h, RPMTAG_PAYLOADCOMPRESSOR);
-    if (compr && strcmp(compr, "gzip")) {
-        checked_asprintf(&rpmio_flags, "r.%sdio", compr);
-    }
-    else {
-        checked_asprintf(&rpmio_flags, "r.gzdio");
-    }
+    io_type = payloadCompressorToIoType(compr);
+    checked_asprintf(&rpmio_flags, "r.%s", io_type);
 
     /* Open uncompressed cpio stream */
     gzdi = Fdopen(fdi, rpmio_flags);


### PR DESCRIPTION
The dd_extract utility opens RPM payloads using librpm's Fdopen() which requires an IO type string like "r.gzdio" or "r.zstdio". The old code naively constructed this string by appending "dio" to the PAYLOADCOMPRESSOR tag value (e.g., "zstd" -> "r.zstddio"), which failed for zstd-compressed RPMs because the compressor name doesn't directly map to the IO type:
  - "zstd" must map to "zstdio" not "zstddio"
  - "bzip2" must map to "bzdio" not "bzip2dio"
  - "lzma" must map to "lzdio" not "lzmadio"
  - "xz" must map to "xzdio" not "xzdio" (this one worked by accident)
  - "gzip" must map to "gzdio" not "gzipdio"

The fix introduces payloadCompressorToIoType() which explicitly maps each compressor name to its correct librpm IO type.

Assisted-By: Cursor <cursoragent@cursor.com>
