### PR TITLE
Log successful media verification to the journal

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -36,6 +36,7 @@ run_checkisomd5() {
                 die "Media check failed!"
                 exit 1
             fi
+            info "Installation media verification passed successfully on ${livedev}."
             [ -x /bin/plymouth ] && /bin/plymouth --show-splash
         fi
     fi


### PR DESCRIPTION
The checkisomd5 PASS message on the console is easy to miss. Record a clear success message via info() so it is captured in the boot journal and in journal.log on the target.

Resolves: RHEL-178288

<img width="673" height="420" alt="Screenshot 2026-06-30 at 16-11-16 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/d82693dd-b41a-410a-8e69-de5ba0db19d0" />
