### PR TITLE
Track if an installation task is currently running in the backend

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -19,6 +19,7 @@
 #
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.dbus import DBus
+from pyanaconda.core.signal import Signal
 from pyanaconda.modules.boss.boss_interface import BossInterface
 from pyanaconda.modules.boss.install_manager import InstallManager
 from pyanaconda.modules.boss.installation import (
@@ -43,6 +44,8 @@ class Boss(Service):
         self._module_manager = ModuleManager()
         self._kickstart_manager = KickstartManager()
         self._install_manager = InstallManager()
+        self._installation_task = None
+        self.active_installation_task_changed = Signal()
 
         self._module_manager.module_observers_changed.connect(
             self._kickstart_manager.on_module_observers_changed
@@ -101,19 +104,52 @@ class Boss(Service):
         """
         return self._install_manager.collect_requirements()
 
+    def get_installation_task(self):
+        """Get the active installation task, if any.
+
+        :return: the active installation task or None
+        """
+        if self._installation_task is not None \
+                and self._installation_task.is_running:
+            return self._installation_task
+
+        return None
+
     def install_with_tasks(self):
         """Return installation tasks of this module.
 
-        FIXME: This is a temporary workaround for the Web UI.
+        If an installation task is already running, return
+        the existing task to allow reconnection. Otherwise,
+        create a new one.
 
-        :return: a list of DBus paths of the installation tasks
+        :return: a list of installation tasks
         """
+        if self._installation_task is not None:
+            return [self._installation_task]
 
-        return [
-            RunInstallationTask(
-                install_manager=self._install_manager,
-            )
-        ]
+        self._installation_task = RunInstallationTask(
+            install_manager=self._install_manager,
+        )
+
+        self._installation_task.started_signal.connect(
+            self._on_installation_started
+        )
+        self._installation_task.stopped_signal.connect(
+            self._on_installation_stopped
+        )
+
+        return [self._installation_task]
+
+    def _on_installation_started(self):
+        """Handle the installation task start."""
+        log.info("The installation has started.")
+        self.active_installation_task_changed.emit()
+
+    def _on_installation_stopped(self):
+        """Handle the installation task stop."""
+        log.info("The installation has stopped.")
+        self._installation_task = None
+        self.active_installation_task_changed.emit()
 
     def collect_configure_runtime_tasks(self):
         """Collect tasks for configuration of the runtime environment.

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -45,6 +45,29 @@ def get_proxy_identification(proxy):
 class BossInterface(InterfaceTemplate):
     """DBus interface for the Boss."""
 
+    def connect_signals(self):
+        """Connect the signals."""
+        self.watch_property(
+            "ActiveInstallationTask",
+            self.implementation.active_installation_task_changed
+        )
+
+    @property
+    def ActiveInstallationTask(self) -> ObjPath:
+        """The active installation task.
+
+        If an installation task is currently running, return its
+        D-Bus object path. Otherwise, return an empty string.
+
+        :return: a D-Bus object path or an empty string
+        """
+        task = self.implementation.get_installation_task()
+
+        if task is None:
+            return ""
+
+        return TaskContainer.to_object_path(task)
+
     def GetModules(self) -> List[BusName]:
         """Get service names of running modules.
 

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -233,6 +233,55 @@ class BossInterfaceTestCase(unittest.TestCase):
         task_paths = self.interface.InstallWithTasks()
         check_task_creation_list(task_paths, publisher, [RunInstallationTask])
 
+    @patch_dbus_publish_object
+    def test_install_with_tasks_returns_same_when_running(self, publisher):
+        """Test that InstallWithTasks returns the same task when running."""
+        task_paths_1 = self.interface.InstallWithTasks()
+        task_proxy = check_task_creation(task_paths_1[0], publisher, RunInstallationTask)
+        task = task_proxy.implementation
+
+        with patch.object(type(task), 'is_running', new_callable=lambda: property(lambda self: True)):
+            task_paths_2 = self.interface.InstallWithTasks()
+            assert task_paths_1 == task_paths_2
+
+    def test_install_with_tasks_creates_new_when_previous_finished(self):
+        """Test that InstallWithTasks creates a new task when previous finished."""
+        tasks_1 = self.module.install_with_tasks()
+        self.module._on_installation_stopped()
+        tasks_2 = self.module.install_with_tasks()
+        assert tasks_1[0] is not tasks_2[0]
+
+    @patch_dbus_publish_object
+    def test_active_installation_task_none(self, publisher):
+        """Test ActiveInstallationTask when no task is active."""
+        assert self.interface.ActiveInstallationTask == ""
+
+    @patch_dbus_publish_object
+    def test_active_installation_task_active(self, publisher):
+        """Test ActiveInstallationTask when a task is running."""
+        task_paths = self.interface.InstallWithTasks()
+        task_proxy = check_task_creation(task_paths[0], publisher, RunInstallationTask)
+        task = task_proxy.implementation
+
+        with patch.object(type(task), 'is_running', new_callable=lambda: property(lambda self: True)):
+            result = self.interface.ActiveInstallationTask
+            assert result == task_paths[0]
+
+    def test_active_installation_task_changed(self):
+        """Test ActiveInstallationTaskChanged signal."""
+        callback = Mock()
+        self.module.active_installation_task_changed.connect(callback)
+
+        self.module.install_with_tasks()
+
+        self.module._on_installation_started()
+        callback.assert_called()
+
+        callback.reset_mock()
+
+        self.module._on_installation_stopped()
+        callback.assert_called()
+
     def test_quit(self):
         """Test Quit."""
         assert self.interface.Quit() is None

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -24,10 +24,12 @@ from dasbus.typing import *  # pylint: disable=wildcard-import
 from pyanaconda.core.constants import DEFAULT_LANG
 from pyanaconda.modules.boss.boss import Boss
 from pyanaconda.modules.boss.boss_interface import BossInterface
+from pyanaconda.modules.boss.installation import RunInstallationTask
 from pyanaconda.modules.boss.module_manager.start_modules import StartModulesTask
 from pyanaconda.modules.common.structures.requirement import Requirement
 from tests.unit_tests.pyanaconda_tests import (
     check_task_creation,
+    check_task_creation_list,
     patch_dbus_get_proxy,
     patch_dbus_publish_object,
 )
@@ -224,6 +226,12 @@ class BossInterfaceTestCase(unittest.TestCase):
             ("B", "/task/3"),
             ("B", "/task/4"),
         ]
+
+    @patch_dbus_publish_object
+    def test_install_with_tasks(self, publisher):
+        """Test InstallWithTasks."""
+        task_paths = self.interface.InstallWithTasks()
+        check_task_creation_list(task_paths, publisher, [RunInstallationTask])
 
     def test_quit(self):
         """Test Quit."""


### PR DESCRIPTION
Expose Boss D-Bus API so remote clients can detect an ongoing installation and reconnect to its task for progress updates.