### PR TITLE
fix: persist checkisomd5 media verification output in the journal

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -14,6 +14,13 @@ run_checkisomd5() {
             [ -x /bin/plymouth ] && /bin/plymouth --hide-splash
             if [ -n "$DRACUT_SYSTEMD" ]; then
                 p=$(dev_unit_name "$livedev")
+                mkdir -p /run/systemd/system/checkisomd5@.service.d
+                cat > /run/systemd/system/checkisomd5@.service.d/journal-logging.conf << 'EOF'
+[Service]
+StandardOutput=journal+console
+StandardError=journal+console
+EOF
+                systemctl daemon-reload
                 systemctl start "checkisomd5@${p}.service"
                 retcode=$(systemctl -p ExecMainStatus show "checkisomd5@${p}.service")
                 status=$(systemctl -p ActiveState show "checkisomd5@${p}.service")


### PR DESCRIPTION
When mediacheck is enabled, checkisomd5 prints progress and a final PASS. or FAIL. line. That output is easy to miss because Anaconda takes over the TTY as soon as the check finishes.

The stock dracut checkisomd5@.service uses StandardOutput=inherit, so its output follows the initramfs console and is not recorded in the journal. Before starting the service, install a runtime drop-in that sets StandardOutput=journal+console and StandardError=journal+console.

Assisted-by: Cursor (GPT-5.3-codex)
(cherry-picked from: 56418572f858f42412fb6c3ce6d51765e91c9ccd)
Resolves: RHEL-73812

