### PR TITLE
fix: allow enabling socket and other systemd units via kickstart

### DIFF
--- a/pyanaconda/core/service.py
+++ b/pyanaconda/core/service.py
@@ -23,6 +23,20 @@ log = get_module_logger(__name__)
 __all__ = ["start_service", "stop_service", "restart_service", "is_service_running",
            "is_service_installed", "enable_service", "disable_service"]
 
+SYSTEMD_UNIT_SUFFIXES = (
+    ".service",
+    ".socket",
+    ".device",
+    ".mount",
+    ".automount",
+    ".swap",
+    ".target",
+    ".path",
+    ".timer",
+    ".slice",
+    ".scope",
+)
+
 
 def _run_systemctl(command, service, root):
     """Runs 'systemctl command service'
@@ -89,14 +103,14 @@ def is_service_running(service):
 
 
 def is_service_installed(service, root="/"):
-    """Is a systemd service installed?
+    """Is a systemd unit installed?
 
-    Runs 'systemctl list-unit-files' to determine if the service exists.
+    Runs 'systemctl list-unit-files' to determine if the unit exists.
 
-    :param str service: name of the service to check
+    :param str service: name of the unit to check
     :param str root: path to the sysroot, defaults to installation environment
     """
-    if not service.endswith(".service"):
+    if not service.endswith(SYSTEMD_UNIT_SUFFIXES):
         service += ".service"
 
     args = ["list-unit-files", service, "--no-legend"]

--- a/tests/unit_tests/pyanaconda_tests/core/test_services.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_services.py
@@ -89,6 +89,14 @@ class RunSystemctlTests(unittest.TestCase):
             "list-unit-files", "fake.service", "--no-legend"
         ])
 
+        # socket unit
+        exec_mock.reset_mock()
+        exec_mock.return_value = "cockpit.socket enabled enabled"
+        assert service.is_service_installed("cockpit.socket", root="/")
+        exec_mock.assert_called_once_with("systemctl", [
+            "list-unit-files", "cockpit.socket", "--no-legend"
+        ])
+
     @patch('pyanaconda.core.service.execWithRedirect', return_value=0)
     def test_enable_service(self, exec_mock):
         """Test enable_service"""

--- a/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/common/test_services.py
@@ -502,3 +502,21 @@ class ServicesTasksTestCase(unittest.TestCase):
             assert "service-A" in enabled_services
             assert "service-C" in enabled_services
             assert "service-B" not in enabled_services
+
+    @patch("pyanaconda.modules.services.installation.enable_service")
+    @patch("pyanaconda.modules.services.installation.is_service_installed")
+    def test_configure_services_socket_unit(self, mock_is_installed, mock_enable):
+        """Test that socket-activated units can be enabled."""
+        with tempfile.TemporaryDirectory() as sysroot:
+            mock_is_installed.return_value = True
+
+            task = ConfigureServicesTask(
+                sysroot=sysroot,
+                disabled_services=[],
+                enabled_services=["cockpit.socket"]
+            )
+
+            task.run()
+
+            mock_is_installed.assert_called_once_with("cockpit.socket", root=sysroot)
+            mock_enable.assert_called_once_with("cockpit.socket", root=sysroot)


### PR DESCRIPTION
is_service_installed() always appended .service to unit names, so services --enabled=cockpit.socket was looked up as cockpit.socket.service and reported as missing after the RHEL-178289 install check was added.

Recognize all standard systemd unit suffixes [1] and only default bare names to .service.

Related: RHEL-61134

[1] https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Description
(cherry-picked from: f0d6ad4f539babfe3ccc67d8a3d6b6554097191e)
