### PR TITLE
Revert "fix: persist checkisomd5 media verification output in the journal"

### DIFF
--- a/dracut/anaconda-diskroot
+++ b/dracut/anaconda-diskroot
@@ -14,13 +14,6 @@ run_checkisomd5() {
             [ -x /bin/plymouth ] && /bin/plymouth --hide-splash
             if [ -n "$DRACUT_SYSTEMD" ]; then
                 p=$(dev_unit_name "$livedev")
-                mkdir -p /run/systemd/system/checkisomd5@.service.d
-                cat > /run/systemd/system/checkisomd5@.service.d/journal-logging.conf << 'EOF'
-[Service]
-StandardOutput=journal+console
-StandardError=journal+console
-EOF
-                systemctl daemon-reload
                 systemctl start "checkisomd5@${p}.service"
                 retcode=$(systemctl -p ExecMainStatus show "checkisomd5@${p}.service")
                 status=$(systemctl -p ActiveState show "checkisomd5@${p}.service")


### PR DESCRIPTION
This reverts commit 56418572f858f42412fb6c3ce6d51765e91c9ccd.