### PR TITLE
fix(bootc): show bootc error output in the installation error dialog

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -847,6 +847,7 @@ class DeployBootcTask(Task):
 
         log.debug("Executing bootc install command")
         # Install bootc directly to physroot
+        bootc_cmd = "bootc"
         bootc_args = [
             "install",
             "to-filesystem",
@@ -877,14 +878,19 @@ class DeployBootcTask(Task):
             self._physroot
         ])
 
+        bootc_output = []
         try:
             self.report_progress(_("Deploying image..."))
-            for line in execReadlines("bootc", bootc_args):
+            for line in execReadlines(bootc_cmd, bootc_args):
+                bootc_output.append(line)
                 self._parse_bootc_output(line)
         except OSError as e:
-            raise PayloadInstallationError(
-                "bootc installation failed: {}".format(str(e))
-            ) from e
+            error_message = "bootc installation failed, see the logs below:\n\n{logs}\n\nOriginal command:\n\n{bootc_cmd} {bootc_args}".format(
+                logs="\n".join(line for line in bootc_output),
+                bootc_cmd=bootc_cmd,
+                bootc_args=" ".join(cmd for cmd in bootc_args),
+            )
+            raise PayloadInstallationError(error_message) from e
 
         log.info("Bootc deploy complete")
         self.report_progress(_("Bootc deployment complete: {}").format(ref))


### PR DESCRIPTION
Previously, when a bootc installation failed, the error dialog only displayed the generic process exit message (e.g., "process exited with status 1"). The actual error from bootc was only visible in the logs.

Capture bootc stdout/stderr during installation and include the full output in the error dialog, followed by the original command for reference.

Resolves: RHEL-183096

## print screens showing the change
### BEFORE
<img width="1273" height="887" alt="image" src="https://github.com/user-attachments/assets/4103c9a1-fe9d-49cf-a289-a21c5c949f6d" />


### NOW
<img width="772" height="588" alt="image" src="https://github.com/user-attachments/assets/2d906b25-d662-42f1-bfd5-b60e3d071481" />


