### PR TITLE
payload: run bootc install finalize before reboot teardown

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -1090,6 +1090,33 @@ class PullRemoteAndDeleteTask(Task):
             self.report_progress(_("Writing objects"))
 
 
+class FinalizeBootcTask(Task):
+    """Task to run bootc install finalize.
+    """
+
+    def __init__(self, physroot):
+        """Create a new task.
+
+        :param str physroot: a path to the physical root
+        """
+        super().__init__()
+        self._physroot = physroot
+
+    @property
+    def name(self):
+        return "Finalize bootc installation"
+
+    def run(self):
+        """Run bootc install finalize on the physical root."""
+        deployment_path = get_ostree_deployment_path(self._physroot)
+        if not deployment_path:
+            log.debug("No OSTree deployment found, skipping bootc install finalize")
+            return
+
+        log.debug("Running bootc install finalize on %s", self._physroot)
+        safe_exec_program("bootc", ["install", "finalize", self._physroot])
+
+
 class SetSystemRootTask(Task):
     """The installation task for setting up the system root."""
 

--- a/pyanaconda/modules/payloads/payload/rpm_ostree/rpm_ostree.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/rpm_ostree.py
@@ -32,6 +32,7 @@ from pyanaconda.modules.payloads.payload.rpm_ostree.installation import (
     CopyBootloaderDataTask,
     DeployBootcTask,
     DeployOSTreeTask,
+    FinalizeBootcTask,
     InitOSTreeFsAndRepoTask,
     PrepareBootcMountTargetsTask,
     PrepareOSTreeMountTargetsTask,
@@ -265,6 +266,13 @@ class RPMOSTreeModule(PayloadBase):
         :return: a list of tasks
         """
         tasks = super().tear_down_with_tasks()
+
+        if self._get_source(SourceType.BOOTC):
+            tasks.append(
+                FinalizeBootcTask(
+                    physroot=conf.target.physical_root
+                )
+            )
 
         # Tear down mount points for both OSTree and bootc installs
         tasks.append(

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_rpm_ostree.py
@@ -34,6 +34,7 @@ from pyanaconda.modules.payloads.payload.rpm_ostree.installation import (
     ConfigureBootloader,
     CopyBootloaderDataTask,
     DeployOSTreeTask,
+    FinalizeBootcTask,
     InitOSTreeFsAndRepoTask,
     PrepareOSTreeMountTargetsTask,
     PullRemoteAndDeleteTask,
@@ -291,6 +292,24 @@ class RPMOSTreeModuleTestCase(unittest.TestCase):
 
         assert tasks[0]._sources == [rpm_source]
         assert tasks[1]._internal_mounts == ["/path/1", "/path/2"]
+
+    def test_bootc_tear_down_with_tasks(self):
+        """Test the tear_down_with_tasks method with bootc."""
+        bootc_source = SourceFactory.create_source(SourceType.BOOTC)
+
+        self.module.set_sources([bootc_source])
+        self.module._add_internal_mounts(["/path/1", "/path/2"])
+
+        tasks = self.module.tear_down_with_tasks()
+
+        check_instances(tasks, [
+            TearDownSourcesTask,
+            FinalizeBootcTask,
+            TearDownOSTreeMountTargetsTask
+        ])
+
+        assert tasks[0]._sources == [bootc_source]
+        assert tasks[2]._internal_mounts == ["/path/1", "/path/2"]
 
     def test_container_tear_down_with_tasks(self):
         """Test the tear_down_with_tasks method with ostreecontainer."""


### PR DESCRIPTION
Run bootc install finalize on the physical root during bootc payload teardown, after late storage configuration, %post scripts, and other install-time mutations.

https://bootc.dev/bootc/bootc-install.html#postprocessing-after-to-filesystem


see also: https://src.fedoraproject.org/rpms/slitherer/pull-request/1
