### PR TITLE
fix: skip non-XKB input methods instead of failing installation

### DIFF
--- a/pyanaconda/modules/localization/live_keyboard.py
+++ b/pyanaconda/modules/localization/live_keyboard.py
@@ -92,11 +92,12 @@ class GnomeShellKeyboard(LiveSystemKeyboardBase):
         result = []
 
         for t in sources:
-            # keep only 'xkb' type and raise an error on 'ibus' variants which can't
-            # be used in localed
+            # keep only 'xkb' type and skip 'ibus' variants which can't
+            # be used in localed (e.g., 'anthy' for Japanese input)
             if t[0] != "xkb":
-                msg = _("The live system has layout '{}' which can't be used for installation.")
-                raise KeyboardConfigurationError(msg.format(t[1]))
+                log.debug("Skipping non-XKB layout '%s' (type '%s') - not usable for installation",
+                          t[1], t[0])
+                continue
 
             layout = t[1]
             # change layout variant from 'cz+qwerty' to 'cz (qwerty)'

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_live_keyboard.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_live_keyboard.py
@@ -18,9 +18,6 @@
 import unittest
 from unittest.mock import patch
 
-import pytest
-
-from pyanaconda.modules.common.errors.configuration import KeyboardConfigurationError
 from pyanaconda.modules.localization.live_keyboard import (
     GnomeShellKeyboard,
     get_live_keyboard_instance,
@@ -41,19 +38,11 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
     def _check_gnome_shell_layouts_conversion(self,
                                               mocked_exec_with_capture,
                                               system_input,
-                                              output,
-                                              unsupported_layout):
+                                              output):
         mocked_exec_with_capture.reset_mock()
         mocked_exec_with_capture.return_value = system_input
 
         gs = GnomeShellKeyboard()
-
-        if unsupported_layout:
-            match = fr'.*{unsupported_layout}.*'
-            with pytest.raises(KeyboardConfigurationError, match=match):
-                gs.read_keyboard_layouts()
-            return
-
         result = gs.read_keyboard_layouts()
 
         assert result == output
@@ -69,46 +58,47 @@ class LiveSystemKeyboardTestCase(unittest.TestCase):
         self._check_gnome_shell_layouts_conversion(
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('xkb', 'cz')]",
-            output=["cz"],
-            unsupported_layout=None
+            output=["cz"]
         )
 
         # test one complex layout is set
         self._check_gnome_shell_layouts_conversion(
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('xkb', 'cz+qwerty')]",
-            output=["cz (qwerty)"],
-            unsupported_layout=None
+            output=["cz (qwerty)"]
         )
 
         # test multiple layouts are set
         self._check_gnome_shell_layouts_conversion(
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('xkb', 'cz+qwerty'), ('xkb', 'us'), ('xkb', 'cz+dvorak-ucw')]",
-            output=["cz (qwerty)", "us", "cz (dvorak-ucw)"],
-            unsupported_layout=None
+            output=["cz (qwerty)", "us", "cz (dvorak-ucw)"]
         )
 
-        # test layouts with ibus (ibus will raise error)
+        # test layouts with ibus (ibus will be skipped, only xkb returned)
         self._check_gnome_shell_layouts_conversion(
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('xkb', 'cz'), ('ibus', 'libpinyin')]",
-            output=[],
-            unsupported_layout='libpinyin'
+            output=["cz"]
         )
 
-        # test only ibus layout (raise the error)
+        # test layouts with anthy (anthy will be skipped, only xkb returned)
+        self._check_gnome_shell_layouts_conversion(
+            mocked_exec_with_capture=mocked_exec_with_capture,
+            system_input=r"[('xkb', 'us'), ('ibus', 'anthy')]",
+            output=["us"]
+        )
+
+        # test only ibus layout (returns empty list, no XKB layouts)
         self._check_gnome_shell_layouts_conversion(
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"[('ibus', 'libpinyin')]",
-            output=[],
-            unsupported_layout='libpinyin'
+            output=[]
         )
 
         # test wrong input
         self._check_gnome_shell_layouts_conversion(
             mocked_exec_with_capture=mocked_exec_with_capture,
             system_input=r"wrong input",
-            output=[],
-            unsupported_layout=None
+            output=[]
         )


### PR DESCRIPTION
    Previously, installations failed when the live system had IBus input
    methods configured (e.g., 'anthy' for Japanese, 'libpinyin' for Chinese).
    
    IBus input methods operate at a higher level than XKB keyboard layouts
    and cannot be configured in systemd-localed. They should be skipped
    during keyboard detection, not cause installation failure.
    
    After this fix:
    - Non-XKB layouts are logged and skipped
    - Live system falls back to XKB layouts or DEFAULT_KEYBOARD ("us")
    - Example: 'us' + 'anthy' uses "us"; 'anthy' only uses "us"
    
    Resolves: rhbz#2496409
    Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>
