### PR TITLE
Add stratis as dependency and start stratisd during storage initialization

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -237,6 +237,9 @@ Requires: dosfstools
 Requires: e2fsprogs
 # External tooling for managing NVMe-FC devices in the installation environment
 Recommends: nvme-cli
+Requires: stratisd
+Requires: stratis-cli
+Requires: stratisd-dracut
 
 %description install-env-deps
 The anaconda-install-env-deps metapackage lists all installation environment

--- a/pyanaconda/modules/storage/initialization.py
+++ b/pyanaconda/modules/storage/initialization.py
@@ -25,6 +25,7 @@ from blivet.static_data import luks_data
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.anaconda_logging import program_log_lock
 from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.service import start_service
 
 __all__ = ["enable_installer_mode"]
 
@@ -87,6 +88,12 @@ def enable_installer_mode():
             lvm.disable_lvm_autoactivation()
         except RuntimeError as e:
             log.error("Failed to disable LVM auto-activation: %s", str(e))
+
+    # start stratisd, because it doesn't support DBus activation
+    try:
+        start_service("stratisd")
+    except (OSError, RuntimeError) as e:
+        log.error("Failed to start stratisd: %s", str(e))
 
 
 def _set_default_label_type():


### PR DESCRIPTION
First step for the [Fedora 45 change](https://fedoraproject.org/wiki/Changes/StratisAnacondaSupport). Mostly to make my life easier when working on the support. The change is not yet approved so if it doesn't get approved, we'll need to revert this.