### PR TITLE
flatpak: surface errors when requested flatpaks cannot be installed

### DIFF
--- a/pyanaconda/modules/common/errors/payload.py
+++ b/pyanaconda/modules/common/errors/payload.py
@@ -27,6 +27,12 @@ class SourceSetupError(AnacondaError):
     pass
 
 
+@dbus_error("NonCriticalSourceSetupError", namespace=PAYLOADS_NAMESPACE)
+class NonCriticalSourceSetupError(SourceSetupError):
+    """Non-critical error raised when a secondary source is unavailable."""
+    pass
+
+
 @dbus_error("SourceTearDownError", namespace=PAYLOADS_NAMESPACE)
 class SourceTearDownError(AnacondaError):
     """Error raised during the source tear down."""

--- a/pyanaconda/modules/payloads/payload/dnf/dnf.py
+++ b/pyanaconda/modules/payloads/payload/dnf/dnf.py
@@ -373,6 +373,9 @@ class DNFModule(PayloadBase):
         if self.side_payload and self.side_payload.type == PayloadType.FLATPAK:
             self.side_payload.set_sources(self.sources)
             self.side_payload.set_flatpak_refs(self.get_flatpak_refs())
+            self.side_payload.set_ignore_missing(
+                self._packages_configuration.missing_ignored
+            )
 
     def validate_packages_selection_with_task(self, data):
         """Validate the specified packages selection.

--- a/pyanaconda/modules/payloads/payload/flatpak/flatpak.py
+++ b/pyanaconda/modules/payloads/payload/flatpak/flatpak.py
@@ -111,6 +111,13 @@ class FlatpakModule(PayloadBase):
         log.debug("Flatpak refs are set to: %s", refs)
         self._flatpak_manager.set_flatpak_refs(refs)
 
+    def set_ignore_missing(self, ignore_missing):
+        """Set whether missing flatpaks should be ignored.
+
+        :param bool ignore_missing: True to suppress errors for missing flatpaks
+        """
+        self._flatpak_manager.set_ignore_missing(ignore_missing)
+
     def calculate_required_space(self):
         """Calculate space required for the installation.
 

--- a/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
+++ b/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
@@ -31,7 +31,10 @@ from pyanaconda.modules.common.constants.services import SUBSCRIPTION
 from pyanaconda.modules.common.errors.installation import (
     NonCriticalInstallationError,
 )
-from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.errors.payload import (
+    NonCriticalSourceSetupError,
+    SourceSetupError,
+)
 from pyanaconda.modules.common.structures.subscription import SubscriptionRequest
 from pyanaconda.modules.common.task.progress import ProgressReporter
 from pyanaconda.modules.common.util import is_module_available
@@ -217,10 +220,16 @@ class FlatpakManager:
         try:
             self._download_size, self._install_size = \
                 self.get_source().calculate_size(self._flatpak_refs)
-        except SourceSetupError as e:
-            log.error("Flatpak source not available, skipping size calculation %s: %s",
+        # SourceSetupError: missing index.json; OSError: HTTP failures; ValueError: corrupted manifest JSON.
+        except (SourceSetupError, OSError, ValueError) as e:
+            log.error("Flatpak source not available for %s: %s",
                       ", ".join(self._flatpak_refs), e)
             self._skip_installation = True
+            raise NonCriticalSourceSetupError(
+                _("Cannot install the following Flatpaks because the source "
+                  "is not available: {refs}").format(
+                      refs=", ".join(self._flatpak_refs))
+            ) from e
 
     @property
     def download_size(self):
@@ -254,10 +263,16 @@ class FlatpakManager:
             self._collection_location = self.get_source().download(self._flatpak_refs,
                                                                    self._download_location,
                                                                    progress)
-        except SourceSetupError as e:
-            log.error("Flatpak source not available, skipping download %s: %s",
+        # OSError covers requests.HTTPError (blob download failures) in addition to SourceSetupError.
+        except (SourceSetupError, OSError) as e:
+            log.error("Flatpak download failed for %s: %s",
                       ", ".join(self._flatpak_refs), e)
             self._skip_installation = True
+            raise NonCriticalInstallationError(
+                _("Cannot download Flatpaks because the source is not "
+                  "available: {refs}").format(
+                      refs=", ".join(self._flatpak_refs))
+            ) from e
 
     def install(self, progress: ProgressReporter):
         """Install the Flatpak content to the target system.
@@ -308,7 +323,7 @@ class FlatpakManager:
             self._progress = progress
             self._transaction.run()
         except GError as e:
-            raise NonCriticalInstallationError("Failed to install flatpaks: {}".format(e)) from e
+            raise NonCriticalInstallationError(_("Failed to install Flatpaks: {}").format(e)) from e
         finally:
             if self._transaction:
                 self._transaction.run_dispose()

--- a/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
+++ b/pyanaconda/modules/payloads/payload/flatpak/flatpak_manager.py
@@ -76,6 +76,7 @@ class FlatpakManager:
 
         self._source = None
         self._skip_installation = True
+        self._ignore_missing = False
         # location of the local installation source ready for installation in flatpak format
         self._collection_location = None
         self._progress: Optional[ProgressReporter] = None
@@ -170,6 +171,14 @@ class FlatpakManager:
         else:
             self._source = None
 
+    def set_ignore_missing(self, ignore_missing: bool):
+        """Set whether missing flatpaks should be ignored.
+
+        When True, flatpak source errors are logged but do not raise
+        NonCriticalInstallationError — matching %packages --ignoremissing.
+        """
+        self._ignore_missing = ignore_missing
+
     def set_flatpak_refs(self, refs: Optional[List[str]]):
         """Set the Flatpak refs to be installed.
 
@@ -225,6 +234,9 @@ class FlatpakManager:
             log.error("Flatpak source not available for %s: %s",
                       ", ".join(self._flatpak_refs), e)
             self._skip_installation = True
+            if self._ignore_missing:
+                log.error("Ignoring Flatpak error due to %packages --ignoremissing flag")  # pylint: disable=logging-unsupported-format
+                return
             raise NonCriticalSourceSetupError(
                 _("Cannot install the following Flatpaks because the source "
                   "is not available: {refs}").format(
@@ -268,9 +280,11 @@ class FlatpakManager:
             log.error("Flatpak download failed for %s: %s",
                       ", ".join(self._flatpak_refs), e)
             self._skip_installation = True
+            if self._ignore_missing:
+                log.error("Ignoring Flatpak error due to %packages --ignoremissing flag")  # pylint: disable=logging-unsupported-format
+                return
             raise NonCriticalInstallationError(
-                _("Cannot download Flatpaks because the source is not "
-                  "available: {refs}").format(
+                _("Cannot download Flatpaks because the source is not available: {refs}").format(
                       refs=", ".join(self._flatpak_refs))
             ) from e
 
@@ -323,6 +337,10 @@ class FlatpakManager:
             self._progress = progress
             self._transaction.run()
         except GError as e:
+            log.error("Flatpak install failed: %s", e)
+            if self._ignore_missing:
+                log.error("Ignoring Flatpak error due to %packages --ignoremissing flag")  # pylint: disable=logging-unsupported-format
+                return
             raise NonCriticalInstallationError(_("Failed to install Flatpaks: {}").format(e)) from e
         finally:
             if self._transaction:

--- a/pyanaconda/modules/payloads/payload/flatpak/installation.py
+++ b/pyanaconda/modules/payloads/payload/flatpak/installation.py
@@ -83,7 +83,8 @@ class CleanUpDownloadLocationTask(Task):
         """Run the task."""
         path = self._flatpak_manager.download_location
 
-        if not os.path.exists(path):
+        # path is None when calculate_size() raised before set_download_location() ran.
+        if not path or not os.path.exists(path):
             # If nothing was downloaded, there is nothing to clean up.
             return
 

--- a/pyanaconda/payload/dnf/payload.py
+++ b/pyanaconda/payload/dnf/payload.py
@@ -32,7 +32,7 @@ from pyanaconda.core.constants import (
     SOURCE_TYPE_URL,
 )
 from pyanaconda.modules.common.constants.services import PAYLOADS
-from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.errors.payload import NonCriticalSourceSetupError, SourceSetupError
 from pyanaconda.modules.common.structures.packages import (
     PackagesConfigurationData,
     PackagesSelectionData,
@@ -44,7 +44,6 @@ from pyanaconda.modules.payloads.payload.dnf.repositories import (
     generate_driver_disk_repositories,
 )
 from pyanaconda.modules.payloads.source.utils import verify_valid_repository
-from pyanaconda.payload.manager import NonCriticalSourceSetupError
 from pyanaconda.payload.manager import payloadMgr as payload_manager
 from pyanaconda.payload.migrated import MigratedDBusPayload
 from pyanaconda.ui.lib.payload import (
@@ -359,7 +358,10 @@ class DNFPayload(MigratedDBusPayload):
             if side_payload_path:
                 side_payload = PAYLOADS.get_proxy(side_payload_path)
                 side_task_proxy = PAYLOADS.get_proxy(side_payload.CalculateSizeWithTask())
-                sync_run_task(side_task_proxy)
+                try:
+                    sync_run_task(side_task_proxy)
+                except NonCriticalSourceSetupError as e:
+                    report.error_messages.append(str(e))
 
         # This validation is no longer required.
         self._software_validation_required = False

--- a/pyanaconda/payload/manager.py
+++ b/pyanaconda/payload/manager.py
@@ -31,19 +31,16 @@ from pyanaconda.core.i18n import _
 from pyanaconda.core.threads import thread_manager
 from pyanaconda.errors import ERROR_RAISE
 from pyanaconda.errors import errorHandler as error_handler
-from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.errors.payload import (
+    NonCriticalSourceSetupError,
+)
 from pyanaconda.modules.common.structures.validation import ValidationReport
 from pyanaconda.modules.common.task.progress import ProgressReporter
 from pyanaconda.modules.common.task.runnable import Runnable
 
 log = get_module_logger(__name__)
 
-__all__ = ["payloadMgr", "NonCriticalSourceSetupError"]
-
-
-class NonCriticalSourceSetupError(SourceSetupError):
-    """Non-critical error raised during the source setup."""
-    pass
+__all__ = ["payloadMgr"]
 
 
 class _PayloadManager(Runnable, ProgressReporter):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_flatpak_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_flatpak_manager.py
@@ -285,6 +285,22 @@ class FlatpakManagerTestCase:
 
         assert fm.skip_installation is True
 
+    @patch.object(FlatpakManager, "get_source")
+    def test_calculate_size_ignored_when_missing_ignored(self, get_source_mock, caplog):
+        """calculate_size does not raise when ignore_missing is set."""
+        source = Mock(spec=FlatpakStaticSource)
+        source.calculate_size.side_effect = SourceSetupError
+        get_source_mock.return_value = source
+
+        fm = FlatpakManager()
+        refs = ["app/org.example.App1/amd64/stable"]
+        fm.set_flatpak_refs(refs)
+        fm.set_ignore_missing(True)
+
+        fm.calculate_size()
+
+        assert fm.skip_installation is True
+        assert "Ignoring Flatpak error due to %packages --ignoremissing flag" in caplog.text
 
     @patch.object(FlatpakManager, "get_source")
     def test_download(self, get_source_mock):
@@ -326,6 +342,42 @@ class FlatpakManagerTestCase:
             fm.download(progress)
 
         assert fm.skip_installation is True
+
+    @patch.object(FlatpakManager, "get_source")
+    def test_download_ignored_when_missing_ignored(self, get_source_mock, caplog):
+        """Test download does not raise when ignore_missing is set."""
+        source = Mock(spec=FlatpakStaticSource)
+        source.download.side_effect = SourceSetupError("gone")
+        get_source_mock.return_value = source
+        progress = Mock()
+
+        fm = FlatpakManager()
+        fm.set_flatpak_refs([TEST_REF])
+        fm.set_download_location("test-location")
+        fm.set_ignore_missing(True)
+
+        fm.download(progress)
+
+        assert fm.skip_installation is True
+        assert "Ignoring Flatpak error due to %packages --ignoremissing flag" in caplog.text
+
+    @patch.object(FlatpakManager, "get_source")
+    def test_download_ignored_when_missing_ignored_oserror(self, get_source_mock, caplog):
+        """Test download does not raise on OSError when ignore_missing is set."""
+        source = Mock(spec=FlatpakStaticSource)
+        source.download.side_effect = OSError("network error")
+        get_source_mock.return_value = source
+        progress = Mock()
+
+        fm = FlatpakManager()
+        fm.set_flatpak_refs([TEST_REF])
+        fm.set_download_location("test-location")
+        fm.set_ignore_missing(True)
+
+        fm.download(progress)
+
+        assert fm.skip_installation is True
+        assert "Ignoring Flatpak error due to %packages --ignoremissing flag" in caplog.text
 
     @patch("pyanaconda.modules.payloads.payload.flatpak.flatpak_manager.Transaction")
     @patch("pyanaconda.modules.payloads.payload.flatpak.flatpak_manager.Installation")
@@ -472,6 +524,32 @@ class FlatpakManagerTestCase:
             fm.install(progress)
         transaction.run.assert_called_once()
         transaction.run_dispose.assert_called()
+
+    @patch("pyanaconda.modules.payloads.payload.flatpak.flatpak_manager.Transaction")
+    @patch("pyanaconda.modules.payloads.payload.flatpak.flatpak_manager.Installation")
+    @patch("pyanaconda.modules.payloads.payload.flatpak.flatpak_manager.is_module_available")
+    def test_install_ignored_when_missing_ignored(self, is_subscription_module_available, installation_mock, transaction_mock, caplog):
+        """Test install does not raise when ignore_missing is set."""
+        progress = Mock()
+        installation = Mock()
+        transaction = Mock()
+        installation_mock.new_system.return_value = installation
+        transaction_mock.new_for_installation.return_value = transaction
+        is_subscription_module_available.return_value = False
+
+        fm = FlatpakManager()
+        fm._source = Mock(spec=FlatpakStaticSource)
+        fm._skip_installation = False
+        fm.set_flatpak_refs([TEST_REF])
+        fm.set_ignore_missing(True)
+
+        transaction.run.side_effect = GError("Test error")
+
+        fm.install(progress)
+
+        transaction.run.assert_called_once()
+        transaction.run_dispose.assert_called()
+        assert "Ignoring Flatpak error due to %packages --ignoremissing flag" in caplog.text
 
     def _create_transaction_operation(self):
         operation = Mock()

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_flatpak_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_flatpak_manager.py
@@ -27,7 +27,7 @@ from pyanaconda.core.glib import GError
 from pyanaconda.modules.common.errors.installation import (
     NonCriticalInstallationError,
 )
-from pyanaconda.modules.common.errors.payload import SourceSetupError
+from pyanaconda.modules.common.errors.payload import NonCriticalSourceSetupError, SourceSetupError
 from pyanaconda.modules.common.structures.payload import RepoConfigurationData
 from pyanaconda.modules.common.structures.subscription import SubscriptionRequest
 from pyanaconda.modules.payloads.payload.flatpak.flatpak_manager import (
@@ -52,6 +52,17 @@ from gi.repository.Flatpak import TransactionOperationType
 
 REMOTE_NAME = "Anaconda"
 REMOTE_PATH = "file:///flatpak/repo"
+
+TEST_REF = "org.fedoraproject.Stable:app/org.example.App1/amd64/stable"
+TEST_REF_INSTALLED = "app/org.example.App1/amd64/stable"
+
+
+def _mock_installed_ref(ref_str):
+    """Create a mock InstalledRef with the given format_ref() return."""
+    ref = Mock()
+    ref.format_ref.return_value = ref_str
+    return ref
+
 
 
 class FlatpakManagerTestCase:
@@ -240,7 +251,7 @@ class FlatpakManagerTestCase:
     @patch.object(FlatpakManager, "get_source")
     def test_calculate_size(self, get_source_mock):
         """Test FlatpakManager the calculate_size method."""
-        source = Mock()
+        source = Mock(spec=FlatpakStaticSource)
         source.calculate_size.return_value = (10, 20)
         get_source_mock.return_value = source
 
@@ -263,18 +274,22 @@ class FlatpakManagerTestCase:
         assert fm.download_size == 10
         assert fm.install_size == 20
 
-        # set skip installation to True if no source is set
+        # raise NonCriticalSourceSetupError when source fails
         fm._skip_installation = False
         refs = ["org.fedoraproject.Stable:app/org.example.App1/amd64/stable"]
         source.calculate_size.side_effect = SourceSetupError
         fm.set_flatpak_refs(refs)
-        fm.calculate_size()
+
+        with pytest.raises(NonCriticalSourceSetupError, match=r"source is not available.*App1"):
+            fm.calculate_size()
+
         assert fm.skip_installation is True
+
 
     @patch.object(FlatpakManager, "get_source")
     def test_download(self, get_source_mock):
         """Test FlatpakManager the download method."""
-        source = Mock()
+        source = Mock(spec=FlatpakStaticSource)
         source.download.return_value = "download_location"
         get_source_mock.return_value = source
         progress = Mock()
@@ -300,13 +315,16 @@ class FlatpakManagerTestCase:
                                                 "test-location",
                                                 progress)
 
-        # source is not ready
+        # raise NonCriticalInstallationError when source fails
         fm._skip_installation = False
         refs = ["org.fedoraproject.Stable:app/org.example.App1/amd64/stable"]
         fm.set_flatpak_refs(refs)
         fm.set_download_location("test-location")
         source.download.side_effect = SourceSetupError
-        fm.download(progress)
+
+        with pytest.raises(NonCriticalInstallationError, match=r"source is not available.*App1"):
+            fm.download(progress)
+
         assert fm.skip_installation is True
 
     @patch("pyanaconda.modules.payloads.payload.flatpak.flatpak_manager.Transaction")
@@ -334,8 +352,9 @@ class FlatpakManagerTestCase:
 
         # Working prerequisites
         fm._skip_installation = False
-        refs = ["org.fedoraproject.Stable:app/org.example.App1/amd64/stable"]
+        refs = [TEST_REF]
         fm.set_flatpak_refs(refs)
+        installation.list_installed_refs.return_value = [_mock_installed_ref(TEST_REF_INSTALLED)]
 
         # run installation
         fm.install(progress)
@@ -357,12 +376,13 @@ class FlatpakManagerTestCase:
         remote = Mock()
         remote.get_url.return_value = "https://example.org"
         installation.list_remotes.return_value = [remote]
+        installation.list_installed_refs.return_value = [_mock_installed_ref(TEST_REF_INSTALLED)]
 
         fm = FlatpakManager()
 
         # Working prerequisites
         fm._skip_installation = False
-        refs = ["org.fedoraproject.Stable:app/org.example.App1/amd64/stable"]
+        refs = [TEST_REF]
         fm.set_flatpak_refs(refs)
 
         # set collection
@@ -395,12 +415,13 @@ class FlatpakManagerTestCase:
         remote1.get_url.return_value = "https://example.org"
         remote1.get_name.return_value = "remote1"
         installation.list_remotes.return_value = [remote, remote1]
+        installation.list_installed_refs.return_value = [_mock_installed_ref(TEST_REF_INSTALLED)]
 
         fm = FlatpakManager()
 
         # Working prerequisites
         fm._skip_installation = False
-        refs = ["org.fedoraproject.Stable:app/org.example.App1/amd64/stable"]
+        refs = [TEST_REF]
         fm.set_flatpak_refs(refs)
 
         # set collection
@@ -436,6 +457,7 @@ class FlatpakManagerTestCase:
         is_subscription_module_available.return_value = False
 
         fm = FlatpakManager()
+        fm._source = Mock(spec=FlatpakStaticSource)
 
         # Working prerequisites
         fm._skip_installation = False
@@ -448,7 +470,8 @@ class FlatpakManagerTestCase:
         # run installation
         with pytest.raises(NonCriticalInstallationError):
             fm.install(progress)
-        transaction.run_dispose.assert_called_once()
+        transaction.run.assert_called_once()
+        transaction.run_dispose.assert_called()
 
     def _create_transaction_operation(self):
         operation = Mock()


### PR DESCRIPTION
Raise `NonCriticalInstallationError/NonCriticalSourceSetupError` instead of silently setting `_skip_installation` when the flatpak source is unavailable during size calculation, download, or installation. This surfaces the error to the user via the existing continue/abort dialog.

Honor %packages --ignoremissing for flatpak errors: when set, source failures and missing flatpaks are logged as warnings but do not raise `NonCriticalInstallationError/NonCriticalSourceSetupError`, allowing the installation to complete without the flatpaks.

cherry-picked from e5e8f3ef30966581f51c7263fa5a9cd066561289 and 9cfb09f7d1f5f4d668752d584730f0afbfbefd6b

Resolves: RHEL-101748

Assisted-by: Claude Opus 4.6