### PR TITLE
modules: rpm_ostree: fix bootc install when /boot is on root partition

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -785,12 +785,19 @@ class DeployBootcTask(Task):
         entries = list(os.listdir(self._physroot))
         for entry in entries:
             path = os.path.join(self._physroot, entry)
-            # Try to unmount if it's a mount point, use lazy unmount for busy mounts
-            if os.path.ismount(path):
-                # Skip if /boot
-                if path == self._physroot + "/boot":
+            if entry == "boot":
+                if os.path.ismount(path):
                     log.debug("Bootc workaround: skip unmounting /boot")
                     continue
+                for boot_entry in os.listdir(path):
+                    boot_entry_path = os.path.join(path, boot_entry)
+                    if os.path.ismount(boot_entry_path):
+                        continue
+                    safe_exec_program("rm", ["-rf", boot_entry_path])
+                continue
+
+            # Try to unmount if it's a mount point, use lazy unmount for busy mounts
+            if os.path.ismount(path):
                 safe_exec_program("umount", ["-l", path])
 
             safe_exec_program("rm", ["-rf", path])


### PR DESCRIPTION
When /boot is not a separate mount point, clean only non-mounted entries inside /boot instead of removing the directory itself, so /boot/efi stays mounted for UEFI installs without a dedicated /boot.

(cherry-picked from: 5a3f4a9ca3bb88b3da90779ce0d9cc1ab4c5ed39)
Resolves: RHEL-147437