### PR TITLE
fix(storage): update device_spec after reformatting in manual partitioning

### DIFF
--- a/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/manual/manual_partitioning.py
@@ -135,6 +135,10 @@ class ManualPartitioningTask(NonInteractivePartitioningTask):
                                                     dependencies=requested_devices)
             if mount_options is not None:
                 mount_data.mount_options = mount_options
+            # Update device_spec to the new device's ID after reformatting
+            # This is needed because reformatting BTRFS volumes destroys
+            # the old device and creates a new one with a different UUID
+            mount_data.device_spec = device.device_id
 
         # add "mounted" swaps to fstab
         if device.format.type == "swap" and mount_point == "none":


### PR DESCRIPTION
When a BTRFS volume is reformatted, the old device is destroyed and a new one is created with a different UUID. The MountPointRequest's device_spec was not being updated to reflect the new device ID, causing the later kickstart generation to fail when trying to look up the device by the old UUID.

This fix updates the device_spec to the new device's ID after any reformat operation, ensuring the request points to the correct device.

Resolves: rhbz#2463653

WebUI test for this: https://github.com/rhinstaller/anaconda-webui/pull/1363
