### PR TITLE
spec: Enlarge the list of ISOs that use the Web UI

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -70,7 +70,8 @@ BuildRequires: s390utils-devel
 BuildRequires: gdk-pixbuf2-devel
 BuildRequires: libxml2
 
-Requires: anaconda-gui = %{version}-%{release}
+Requires: (anaconda-gui = %{version}-%{release} if (fedora-release-identity-server or fedora-release-identity-basic))
+Requires: (anaconda-webui or anaconda-gui)
 Requires: anaconda-tui = %{version}-%{release}
 
 %description


### PR DESCRIPTION
Use rich RPM dependencies with fedora-release-identity-* packages to automatically select the right UI: anaconda-webui for all variants except Server and Everything (basic), which keep anaconda-gui.

This means that in addition to the live ISOs (which already used the Web UI), the atomic variants (Silverblue, Kinoite, Budgie Atomic, Cosmic Atomic, Sway Atomic, etc.) will now also use the Web UI.

https://fedoraproject.org/wiki/Changes/Anaconda_WebUI_Fedora_Atomic

