### PR TITLE
Add read-only fstab options for OSTree root and boot

### DIFF
--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -669,7 +669,7 @@ class RunInstallationTask(InstallationTask):
         early_storage.append_dbus_tasks(STORAGE, storage_proxy.InstallWithTasks())
 
         if payload_proxy.Type == PAYLOAD_TYPE_DNF:
-            conf_task = storage_proxy.WriteConfigurationWithTask()
+            conf_task = storage_proxy.WriteConfigurationWithTask(payload_proxy.Type)
             early_storage.append_dbus_tasks(STORAGE, [conf_task])
 
         installation_queue.append(early_storage)
@@ -743,7 +743,7 @@ class RunInstallationTask(InstallationTask):
                 _("Configuring storage"),
                 CATEGORY_STORAGE,
             )
-            conf_task = storage_proxy.WriteConfigurationWithTask()
+            conf_task = storage_proxy.WriteConfigurationWithTask(payload_proxy.Type)
             late_storage.append_dbus_tasks(STORAGE, [conf_task])
             installation_queue.append(late_storage)
 

--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -33,6 +33,7 @@ from blivet.util import get_current_entropy
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
+from pyanaconda.core.constants import PAYLOAD_TYPE_RPM_OSTREE
 from pyanaconda.core.i18n import _
 from pyanaconda.core.path import make_directories
 from pyanaconda.core.util import execWithRedirect, join_paths
@@ -248,10 +249,15 @@ class MountFilesystemsTask(Task):
 class WriteConfigurationTask(Task):
     """Installation task for writing out the storage configuration."""
 
-    def __init__(self, storage):
-        """Create a new task."""
+    def __init__(self, storage, payload_type):
+        """Create a new task.
+
+        :param storage: the storage object
+        :param payload_type: a string with the payload type
+        """
         super().__init__()
         self._storage = storage
+        self._payload_type = payload_type
 
     @property
     def name(self):
@@ -280,6 +286,7 @@ class WriteConfigurationTask(Task):
 
         self._write_escrow_packets(storage, sysroot)
         self._adjust_luks_options(storage)
+        self._adjust_mount_options_for_rpm_ostree(storage, sysroot)
 
         storage.fsset.write()
 
@@ -332,6 +339,46 @@ class WriteConfigurationTask(Task):
             if device in root_ancestors:
                 log.debug("adding x-initrd.attach option for LUKS device containing / volume to /etc/crypttab")
                 self._add_luks_option(device, "x-initrd.attach")
+
+    @staticmethod
+    def _add_ro_mount_option(device):
+        """Add the ro mount option to a device unless ro or rw is already set."""
+        fmt = getattr(device, "format", None)
+        if not fmt or not hasattr(fmt, "options"):
+            return
+
+        opts = fmt.options
+        if not opts or opts == "defaults":
+            fmt.options = "ro"
+        else:
+            opt_list = opts.split(",")
+            if "ro" in opt_list or "rw" in opt_list:
+                return
+            fmt.options = opts + ",ro"
+
+        log.debug("Added 'ro' mount option for OSTree installation on %s: %s",
+                  getattr(fmt, "mountpoint", device.name),
+                  fmt.options)
+
+    def _adjust_mount_options_for_rpm_ostree(self, storage, sysroot):
+        """Set read-only mount options for OSTree/bootc installations.
+
+        OSTree expects the physical root and boot filesystems to be mounted
+        read-only at runtime. Use root_device and boot_device so
+        unified layouts (boot on root) are handled without duplicating
+        options on the same partition.
+
+        :type storage: an instance of InstallerStorage
+        :param sysroot: a path to the target OS installation
+        """
+        if self._payload_type != PAYLOAD_TYPE_RPM_OSTREE:
+            return
+
+        devices = {storage.root_device, storage.boot_device}
+        devices.discard(None)
+
+        for device in devices:
+            self._add_ro_mount_option(device)
 
     def _write_escrow_packets(self, storage, sysroot):
         """Write the escrow packets.

--- a/pyanaconda/modules/storage/storage.py
+++ b/pyanaconda/modules/storage/storage.py
@@ -385,14 +385,15 @@ class StorageService(KickstartService):
             MountFilesystemsTask(storage)
         ]
 
-    def write_configuration_with_task(self):
+    def write_configuration_with_task(self, payload_type):
         """Write the storage configuration with a task.
 
         FIXME: This is a temporary workaround.
 
+        :param payload_type: a string with the payload type
         :return: an installation task
         """
-        return WriteConfigurationTask(self.storage)
+        return WriteConfigurationTask(self.storage, payload_type)
 
     def teardown_with_tasks(self):
         """Returns teardown tasks for this module.

--- a/pyanaconda/modules/storage/storage_interface.py
+++ b/pyanaconda/modules/storage/storage_interface.py
@@ -135,13 +135,14 @@ class StorageInterface(KickstartModuleInterface):
         """
         self.implementation.reset_partitioning()
 
-    def WriteConfigurationWithTask(self) -> ObjPath:
+    def WriteConfigurationWithTask(self, payload_type: Str) -> ObjPath:
         """Write the storage configuration with a task.
 
         FIXME: This is a temporary workaround.
 
+        :param payload_type: a string with the payload type
         :return: an installation task
         """
         return TaskContainer.to_object_path(
-            self.implementation.write_configuration_with_task()
+            self.implementation.write_configuration_with_task(payload_type)
         )

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -36,6 +36,8 @@ from pyanaconda.core.constants import (
     PARTITIONING_METHOD_CUSTOM,
     PARTITIONING_METHOD_INTERACTIVE,
     PARTITIONING_METHOD_MANUAL,
+    PAYLOAD_TYPE_DNF,
+    PAYLOAD_TYPE_RPM_OSTREE,
 )
 from pyanaconda.modules.common.constants.services import STORAGE
 from pyanaconda.modules.common.containers import PartitioningContainer
@@ -394,7 +396,7 @@ class StorageInterfaceTestCase(unittest.TestCase):
     @patch_dbus_publish_object
     def test_write_configuration_with_task(self, publisher):
         """Test WriteConfigurationWithTask."""
-        task_path = self.storage_interface.WriteConfigurationWithTask()
+        task_path = self.storage_interface.WriteConfigurationWithTask(PAYLOAD_TYPE_DNF)
         check_task_creation(task_path, publisher, WriteConfigurationTask)
 
     @patch_dbus_publish_object
@@ -1599,11 +1601,11 @@ class StorageTasksTestCase(unittest.TestCase):
             patched_conf.target.physical_root = d
 
             patched_conf.target.is_directory = True
-            WriteConfigurationTask(storage).run()
+            WriteConfigurationTask(storage, PAYLOAD_TYPE_DNF).run()
             assert not os.path.exists("{}/etc".format(d))
 
             patched_conf.target.is_directory = False
-            WriteConfigurationTask(storage).run()
+            WriteConfigurationTask(storage, PAYLOAD_TYPE_DNF).run()
             assert os.path.exists("{}/etc".format(d))
 
     @patch("pyanaconda.modules.storage.installation.conf")
@@ -1653,7 +1655,7 @@ class StorageTasksTestCase(unittest.TestCase):
 
     def test_adjust_luks_options(self):
         """Test adjusting crypttab options for LUKS devices."""
-        task = WriteConfigurationTask(Mock())
+        task = WriteConfigurationTask(Mock(), Mock())
 
         luks_dev = Mock()
         luks_dev.format.type = "luks"
@@ -1673,6 +1675,39 @@ class StorageTasksTestCase(unittest.TestCase):
         luks_dev.format.options = "discard,x-initrd.attach"
         task._adjust_luks_options(storage)
         assert luks_dev.format.options == "discard,x-initrd.attach"
+
+    def test_adjust_mount_options_for_rpm_ostree(self):
+        """Test adding ro to / and /boot for OSTree installations."""
+        root_dev = Mock()
+        root_dev.format.options = None
+        boot_dev = Mock()
+        boot_dev.format.options = "defaults"
+        storage = Mock(root_device=root_dev, boot_device=boot_dev)
+        task = WriteConfigurationTask(storage, PAYLOAD_TYPE_DNF)
+
+        task._adjust_mount_options_for_rpm_ostree(storage, "/mnt/sysroot")
+        assert root_dev.format.options is None
+        assert boot_dev.format.options == "defaults"
+
+        task = WriteConfigurationTask(storage, PAYLOAD_TYPE_RPM_OSTREE)
+        task._adjust_mount_options_for_rpm_ostree(storage, "/mnt/sysroot")
+        assert root_dev.format.options == "ro"
+        assert boot_dev.format.options == "ro"
+
+        root_dev.format.options = "defaults,rw"
+        boot_dev.format.options = "defaults,ro"
+        task._adjust_mount_options_for_rpm_ostree(storage, "/mnt/sysroot")
+        assert root_dev.format.options == "defaults,rw"
+        assert boot_dev.format.options == "defaults,ro"
+
+        # boot on root: root_device and boot_device are the same object
+        unified_dev = Mock()
+        unified_dev.format.options = None
+        storage = Mock(root_device=unified_dev, boot_device=unified_dev)
+        task = WriteConfigurationTask(storage, PAYLOAD_TYPE_RPM_OSTREE)
+        task._adjust_mount_options_for_rpm_ostree(storage, "/mnt/sysroot")
+        assert unified_dev.format.options == "ro"
+
 
 class StorageValidationTasksTestCase(unittest.TestCase):
     """Test the storage validation tasks."""


### PR DESCRIPTION
Fresh RPM OSTree installations write `/etc/fstab` from the storage devicetree without preserving read-only mount options. This PR sets defaults,ro on the root and boot devices in `WriteConfigurationTask` before `fsset.write()`, matching OSTree's sysroot.readonly expectation.

Only apply the change when the active payload is RPM OSTree, skip devices that already specify ro or rw, and handle boot-on-root layouts by deduplicating root_device and boot_device.

`_adjust_mount_options_for_rpm_ostree` includes an unused sysroot parameter to match the other helpers in `_write_storage_configuration. _get_active_payload_type()` has the same pattern as in bootloader/systemd.py -> this could be moved to some shared lib.

Resolves: INSTALLER-4278