### PR TITLE
fix(storage): ensure discard option in crypttab for all LUKS devices

### DIFF
--- a/pyanaconda/modules/storage/installation.py
+++ b/pyanaconda/modules/storage/installation.py
@@ -279,7 +279,7 @@ class WriteConfigurationTask(Task):
             os.mkdir("%s/etc" % sysroot)
 
         self._write_escrow_packets(storage, sysroot)
-        self._adjust_options_for_root_volume(storage, sysroot)
+        self._adjust_luks_options(storage)
 
         storage.fsset.write()
 
@@ -296,28 +296,42 @@ class WriteConfigurationTask(Task):
 
         self._write_s390_device_config(sysroot)
 
-    def _adjust_options_for_root_volume(self, storage, sysroot):
-        """Adjust options for the root volume.
+    def _add_luks_option(self, device, option):
+        """Add an option to a LUKS device's crypttab options if not already present.
 
-        Currently this only affects root volumes that are located on LUKS,
-        resulting in x-initrd.attach option being added for such volumes
-        into /etc/crypttab.
-
-        :type storage: an instance of InstallerStorage
-        :param sysroot: a path to the target OS installation
+        :param device: a storage device with a LUKS format
+        :param option: the option string to add
         """
+        if not device.format.options:
+            device.format.options = option
+        elif option not in device.format.options.split(","):
+            device.format.options += "," + option
 
-        # find the root device
+    def _adjust_luks_options(self, storage):
+        """Adjust crypttab options for all LUKS devices.
+
+        Ensures the discard option is set for all LUKS devices and adds
+        x-initrd.attach for LUKS devices that back the root volume.
+
+        :param storage: the storage object
+        :type storage: an instance of InstallerStorage
+        """
+        root_ancestors = set()
         if storage.root_device:
-            # check if it is on a LUKS volume
-            for m in storage.root_device.ancestors:
-                if m.format.type == "luks":
-                    log.debug("adding x-initrd.attach option for LUKS device containing / volume to /etc/crypttab")
-                    # handle options being empty
-                    if m.format.options:
-                        m.format.options += ",x-initrd.attach"
-                    else:
-                        m.format.options = "x-initrd.attach"
+            root_ancestors = {
+                m for m in storage.root_device.ancestors
+                if m.format.type == "luks"
+            }
+
+        for device in storage.devices:
+            if device.format.type != "luks":
+                continue
+
+            self._add_luks_option(device, "discard")
+
+            if device in root_ancestors:
+                log.debug("adding x-initrd.attach option for LUKS device containing / volume to /etc/crypttab")
+                self._add_luks_option(device, "x-initrd.attach")
 
     def _write_escrow_packets(self, storage, sysroot):
         """Write the escrow packets.

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage.py
@@ -1651,6 +1651,28 @@ class StorageTasksTestCase(unittest.TestCase):
                 dev4.format.lvmdevices_add.assert_not_called()
                 exists_mock.assert_called_once_with("/etc/lvm/devices/system.devices")
 
+    def test_adjust_luks_options(self):
+        """Test adjusting crypttab options for LUKS devices."""
+        task = WriteConfigurationTask(Mock())
+
+        luks_dev = Mock()
+        luks_dev.format.type = "luks"
+        luks_dev.format.options = None
+        storage = Mock(devices=[luks_dev], root_device=None)
+
+        # no options
+        task._adjust_luks_options(storage)
+        assert luks_dev.format.options == "discard"
+
+        # existing options
+        luks_dev.format.options = "x-initrd.attach"
+        task._adjust_luks_options(storage)
+        assert luks_dev.format.options == "x-initrd.attach,discard"
+
+        # already has discard
+        luks_dev.format.options = "discard,x-initrd.attach"
+        task._adjust_luks_options(storage)
+        assert luks_dev.format.options == "discard,x-initrd.attach"
 
 class StorageValidationTasksTestCase(unittest.TestCase):
     """Test the storage validation tasks."""


### PR DESCRIPTION
Blivet only adds the discard option to /etc/crypttab for LUKS formats it creates itself (via the discard_new flag). When LUKS devices are created externally (e.g. by cockpit-storage in the Web UI), the option is missing, which means TRIM will not work on SSDs.

Unify all LUKS crypttab option adjustments (discard, x-initrd.attach) into a single _adjust_luks_options method with a shared _add_luks_option helper, so the discard option is always present regardless of how the LUKS device was created.

Resolves: rhbz#2367388

