### PR TITLE
Allow reboot from the live OS installation

### DIFF
--- a/pyanaconda/core/configuration/system.py
+++ b/pyanaconda/core/configuration/system.py
@@ -67,7 +67,7 @@ class SystemSection(Section):
     @property
     def can_reboot(self):
         """Can we reboot the system?"""
-        return self._is_boot_iso or self._is_booted_os
+        return self._is_boot_iso or self._is_live_os or self._is_booted_os
 
     @property
     def can_start_compositor(self):


### PR DESCRIPTION
The GTK GUI never offered a reboot option on live media — it only showed "Finish Installation" which quit back to the desktop. The new WebUI adds a "Reboot to installed system" button for live media, but can_reboot excluded LIVE_OS so anaconda's exitHandler skipped the actual reboot.

Add _is_live_os to the can_reboot check so the exitHandler honors the Reboot D-Bus property when set by the WebUI on live media.

Resolves: rhbz#2326672

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
