### PR TITLE
fix(storage): avoid mutating the action list in get_actions()

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -20,6 +20,7 @@
 from abc import ABC, abstractmethod
 from functools import partial
 
+from blivet.actionlist import ActionList
 from blivet.devices import PartitionDevice
 from blivet.formats import get_format
 from blivet.size import Size
@@ -347,19 +348,17 @@ class DeviceTreeViewer(ABC):
     def get_actions(self):
         """Get the device actions.
 
-        The actions are pruned and sorted.
+        The returned actions are pruned and sorted for display
+        without mutating the live action list.
 
         :return: a list of DeviceActionData
         """
-        actions = []
+        actions_copy = ActionList()
+        actions_copy._actions = self.storage.devicetree.actions.find()
+        actions_copy.prune()
+        actions_copy.sort()
 
-        self.storage.devicetree.actions.prune()
-        self.storage.devicetree.actions.sort()
-
-        for action in self.storage.devicetree.actions.find():
-            actions.append(self._get_action_data(action))
-
-        return actions
+        return [self._get_action_data(a) for a in actions_copy.find()]
 
     def _get_action_data(self, action):
         """Get the action data.


### PR DESCRIPTION
get_actions() called prune() and sort() on the live blivet action list for display purposes. This mutated it before installation, so the topological sort in process() ran on already-sorted input.

Blivet's tsort uses LIFO to pick among independent nodes (like LVs in the same VG), so re-sorting produces a different order. In the [lvm-cache-2](https://github.com/rhinstaller/kickstart-tests/blob/main/lvm-cache-2.ks.in) test this flipped root before home, filling pv.1 and leaving no space for home's cache on pv.2.

Prune and sort a copy instead.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

Note: WIthout this LVM-cache-2 Kickstart tests [FAILS](https://github.com/rhinstaller/kickstart-tests/actions/runs/29294561115/job/86965157825) for WebUI.
