### PR TITLE
infra: increase timeout of kickstat tests GH workflow

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -120,7 +120,7 @@ jobs:
     # only do this for Fedora for now; once we have RHEL 8/9 boot.iso builds working, also support these
     if: needs.pr-info.outputs.allowed_user == 'true' && needs.pr-info.outputs.comment_args != '' && ! contains(github.event.comment.body, '--waive')
     runs-on: [self-hosted, kstest]
-    timeout-minutes: 300
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.releases) }}

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -114,7 +114,7 @@ jobs:
     # only do this for Fedora for now; once we have RHEL 8/9 boot.iso builds working, also support these
     if: needs.pr-info.outputs.allowed_user == 'true' && needs.pr-info.outputs.comment_args != '' && ! contains(github.event.comment.body, '--waive')
     runs-on: [self-hosted, kstest]
-    timeout-minutes: 300
+    timeout-minutes: 360
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.define-matrix.outputs.releases) }}


### PR DESCRIPTION
Testing kstest PR migrating to UEFI default is timeouting with 239/264 finished, so let's increase the timeout by 60 minutes (20%).

Timeouting run: https://github.com/rhinstaller/anaconda/actions/runs/29324747111