### PR TITLE
Encrypted stratis support -- mount point assignment, backend

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -37,7 +37,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define nmver 1.0
 %define pykickstartver 3.73-1
 %define pypartedver 2.5-2
-%define pythonblivetver 1:3.13.0-1
+%define pythonblivetver 1:3.14.0-1
 %define rpmver 4.15.0
 %define simplelinever 1.9.0-1
 %define subscriptionmanagerver 1.29.31

--- a/pyanaconda/modules/common/structures/storage.py
+++ b/pyanaconda/modules/common/structures/storage.py
@@ -212,6 +212,10 @@ class DeviceData(DBusData):
         Attributes for partitions:
             partition-type-name
 
+        Attributes for stratis pools:
+            encrypted
+            has_key
+
         :return: a dictionary of attributes
         """
         return self._attrs

--- a/pyanaconda/modules/storage/devicetree/utils.py
+++ b/pyanaconda/modules/storage/devicetree/utils.py
@@ -220,14 +220,7 @@ def find_mountable_partitions(devicetree):
     return devices
 
 
-def unlock_device(storage, device, passphrase):
-    """Unlock a LUKS device.
-
-    :param storage: an instance of the storage
-    :param device: a device to unlock
-    :param passphrase: a passphrase to use
-    :return: True if success, otherwise False
-    """
+def _unlock_luks(storage, device, passphrase):
     # Set the passphrase.
     device.format.passphrase = passphrase
 
@@ -261,6 +254,52 @@ def unlock_device(storage, device, passphrase):
         storage.devicetree.teardown_all()
 
         return True
+
+
+def _unlock_stratis(storage, device, passphrase):
+    # Set the passphrase.
+    device.passphrase = passphrase
+
+    try:
+        # Unlock the device.
+        device.setup()
+    except StorageError as err:
+        log.error("Failed to unlock %s: %s", device.name, err)
+
+        # Teardown the device.
+        device.teardown(recursive=True)
+
+        # Forget the wrong passphrase.
+        device.passphrase = None
+
+        return False
+    else:
+        # Save the passphrase.
+        storage.save_passphrase(device)
+
+        # Wait for the device.
+        # Otherwise, we could get a message about no Linux partitions.
+        time.sleep(2)
+
+        # Update the device tree.
+        storage.devicetree.populate()
+        storage.devicetree.teardown_all()
+
+        return True
+
+
+def unlock_device(storage, device, passphrase):
+    """Unlock an encrypted device.
+
+    :param storage: an instance of the storage
+    :param device: a device to unlock
+    :param passphrase: a passphrase to use
+    :return: True if success, otherwise False
+    """
+    if device.type == "stratis pool":
+        return _unlock_stratis(storage, device, passphrase)
+    else:
+        return _unlock_luks(storage, device, passphrase)
 
 
 def find_unconfigured_luks(storage):

--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -21,7 +21,7 @@ from abc import ABC, abstractmethod
 from functools import partial
 
 from blivet.actionlist import ActionList
-from blivet.devices import PartitionDevice
+from blivet.devices import PartitionDevice, StratisPoolDevice
 from blivet.formats import get_format
 from blivet.size import Size
 
@@ -168,6 +168,10 @@ class DeviceTreeViewer(ABC):
         if isinstance(device, PartitionDevice):
             data.attrs["partition-type-name"] = self._get_attribute(device, "part_type_name")
             data.attrs["isleaf"] = self._get_attribute(device, "isleaf")
+
+        if isinstance(device, StratisPoolDevice):
+            data.attrs["encrypted"] = self._get_attribute(device, "encrypted")
+            data.attrs["has_key"] = self._get_attribute(device, "has_key")
 
     def _set_device_data_dasd(self, device, data):
         """Set data for a DASD device."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -32,6 +32,7 @@ from blivet.devices import (
     OpticalDevice,
     PartitionDevice,
     StorageDevice,
+    StratisPoolDevice,
     ZFCPDiskDevice,
     iScsiDiskDevice,
 )
@@ -394,6 +395,23 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
             data = self.interface.GetDeviceData("dev1")
             assert data['attrs']['partition-type-name'] == "Microsoft reserved partition"
             assert data['attrs']['isleaf'] == "True"
+
+    def test_get_stratis_pool_device_data(self):
+        dev1 = StorageDevice("dev1", size=Size("50 GiB"))
+        self._add_device(dev1)
+
+        pool = StratisPoolDevice(
+            "pool1",
+            size=Size("50 GiB"),
+            parents=[dev1],
+            exists=True,
+            encrypted=True,
+        )
+        self._add_device(pool)
+
+        data = self.interface.GetDeviceData("STRATIS-pool1")
+        assert data['attrs']['encrypted'] == "True"
+        assert data['attrs']['has_key'] == "False"
 
     def test_get_format_data(self):
         """Test GetFormatData."""

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_device_tree.py
@@ -871,8 +871,8 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
     @patch.object(LUKS, "setup")
     @patch.object(StorageDevice, "teardown")
     @patch.object(StorageDevice, "setup")
-    def test_unlock_device(self, device_setup, device_teardown, format_setup):
-        """Test UnlockDevice."""
+    def test_unlock_device_luks(self, device_setup, device_teardown, format_setup):
+        """Test UnlockDevice with a LUKS device."""
         self.storage.devicetree.populate = Mock()
         self.storage.devicetree.teardown_all = Mock()
 
@@ -900,6 +900,49 @@ class DeviceTreeInterfaceTestCase(unittest.TestCase):
 
         device_teardown.assert_called_once()
         assert not dev1.format.has_key
+
+    @patch.object(StratisPoolDevice, "teardown")
+    @patch.object(StratisPoolDevice, "setup")
+    def test_unlock_device_stratis(self, device_setup, device_teardown):
+        """Test UnlockDevice with a Stratis pool."""
+        self.storage.devicetree.populate = Mock()
+        self.storage.devicetree.teardown_all = Mock()
+
+        dev1 = StorageDevice("dev1", fmt=get_format("stratis"), size=Size("10 GiB"), exists=True)
+        self._add_device(dev1)
+
+        pool = StratisPoolDevice("pool", parents=[dev1], size=Size("10 GiB"),
+                                 encrypted=True, exists=True)
+        self._add_device(pool)
+
+        assert self.interface.UnlockDevice(pool.device_id, "passphrase") is True
+
+        device_setup.assert_called_once()
+        device_teardown.assert_not_called()
+        self.storage.devicetree.populate.assert_called_once()
+        self.storage.devicetree.teardown_all.assert_called_once()
+        assert pool.has_key
+        assert self.interface.GetDeviceData(pool.device_id) == {
+            'attrs': get_variant(Dict[Str, Str], { "encrypted": "True", "has_key": "True" }),
+            'children': get_variant(List[Str], []),
+            'description': get_variant(Str, ''),
+            'device-id': get_variant(Str, 'STRATIS-pool'),
+            'is-disk':get_variant(Bool, False),
+            'links': get_variant(List[Str], []),
+            'name': get_variant(Str, 'pool'),
+            'parents': get_variant(List[Str], ['dev1']),
+            'path': get_variant(Str, '/dev/stratis/pool'),
+            'protected':get_variant(Bool, False),
+            'removable':get_variant(Bool, False),
+            'size': get_variant(UInt64, Size("10 GiB").get_bytes()),
+            'type': get_variant(Str, 'stratis pool'),
+        }
+
+        device_setup.side_effect = StorageError("Fake error")
+        assert self.interface.UnlockDevice(pool.device_id, "passphrase") is False
+
+        device_teardown.assert_called_once()
+        assert not pool.has_key
 
     def test_find_unconfigured_luks(self):
         """Test FindUnconfiguredLUKS."""


### PR DESCRIPTION
Changes needed for mountpoint assignment in WebUI to work with encrypted stratis pools (based on LUKS/dm-crypt but on the pool level with LUKS header being private so there is no LUKS format visible for Anaconda).

These changes are needed for the WebUI PR but are self-contained and shouldn't break anything anywhere else.