### PR TITLE
anaconda-shell: set alias to autovt, handle reservevt

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -431,6 +431,7 @@ rm -rf \
 %define _empty_manifest_terminate_build 0
 
 %files install-img-deps
+%{_unitdir}/anaconda-shell@.service
 
 # Allow the lang file to be empty here too
 %define _empty_manifest_terminate_build 0
@@ -438,6 +439,7 @@ rm -rf \
 %files core -f %{name}.lang
 %license COPYING
 %{_unitdir}/*
+%exclude %{_unitdir}/anaconda-shell@.service
 %{_prefix}/lib/systemd/system-generators/*
 %{_bindir}/instperf
 %{_bindir}/anaconda-disable-nm-ibft-plugin

--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -432,6 +432,7 @@ rm -rf \
 
 %files install-img-deps
 %{_unitdir}/anaconda-shell@.service
+%{_prefix}/lib/systemd/logind.conf.d/*
 
 # Allow the lang file to be empty here too
 %define _empty_manifest_terminate_build 0

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -17,6 +17,7 @@
 
 systemddir = $(prefix)/lib/systemd/system
 generatordir = $(prefix)/lib/systemd/system-generators
+logindconfdir = $(prefix)/lib/systemd/logind.conf.d
 
 dist_systemd_DATA = anaconda.service \
                     anaconda-noshell.service \
@@ -33,6 +34,8 @@ dist_systemd_DATA = anaconda.service \
                     anaconda-pre.service \
                     anaconda-s390-device-config-import.service \
                     anaconda-fips.service
+
+dist_logindconf_DATA = anaconda-logind.conf
 
 dist_generator_SCRIPTS = anaconda-generator
 

--- a/data/systemd/anaconda-logind.conf
+++ b/data/systemd/anaconda-logind.conf
@@ -1,0 +1,2 @@
+[Login]
+ReserveVT=2

--- a/data/systemd/anaconda-shell@.service
+++ b/data/systemd/anaconda-shell@.service
@@ -18,3 +18,8 @@ TTYVTDisallocate=yes
 KillMode=process
 KillSignal=SIGHUP
 IgnoreSIGPIPE=no
+
+[Install]
+Alias=autovt@.service
+WantedBy=anaconda.target
+DefaultInstance=tty2

--- a/tests/rpm_tests/test_create_rpm.py
+++ b/tests/rpm_tests/test_create_rpm.py
@@ -37,6 +37,7 @@ class InstalledFilesTestCase(RPMTestCase):
 
     ANACONDA_BUS_CONF = "anaconda-bus.conf"
     ANACONDA_GENERATOR = "anaconda-generator"
+    ANACONDA_SHELL_SERVICE = "anaconda-shell@.service"
 
     def test_pyanaconda_installed_files(self):
         rpms = self._apply_filters([RPMFilters.debug_exclude,
@@ -191,7 +192,8 @@ class InstalledFilesTestCase(RPMTestCase):
             [
                 FileFilters.src_systemd_only,
                 FileFilters.makefiles_exclude,
-                lambda f: FileFilters.specific_file_exclude(self.ANACONDA_GENERATOR, f)
+                lambda f: FileFilters.specific_file_exclude(self.ANACONDA_GENERATOR, f),
+                lambda f: FileFilters.specific_file_exclude(self.ANACONDA_SHELL_SERVICE, f)
             ], self._get_source_files()
         )
 

--- a/tests/rpm_tests/test_create_rpm.py
+++ b/tests/rpm_tests/test_create_rpm.py
@@ -38,6 +38,7 @@ class InstalledFilesTestCase(RPMTestCase):
     ANACONDA_BUS_CONF = "anaconda-bus.conf"
     ANACONDA_GENERATOR = "anaconda-generator"
     ANACONDA_SHELL_SERVICE = "anaconda-shell@.service"
+    ANACONDA_LOGIND_CONF = "anaconda-logind.conf"
 
     def test_pyanaconda_installed_files(self):
         rpms = self._apply_filters([RPMFilters.debug_exclude,
@@ -193,7 +194,8 @@ class InstalledFilesTestCase(RPMTestCase):
                 FileFilters.src_systemd_only,
                 FileFilters.makefiles_exclude,
                 lambda f: FileFilters.specific_file_exclude(self.ANACONDA_GENERATOR, f),
-                lambda f: FileFilters.specific_file_exclude(self.ANACONDA_SHELL_SERVICE, f)
+                lambda f: FileFilters.specific_file_exclude(self.ANACONDA_SHELL_SERVICE, f),
+                lambda f: FileFilters.specific_file_exclude(self.ANACONDA_LOGIND_CONF, f)
             ], self._get_source_files()
         )
 
@@ -223,6 +225,29 @@ class InstalledFilesTestCase(RPMTestCase):
             [
                 ModifyingFilters.remove_data_systemd_prefix,
                 lambda x: ModifyingFilters.apply_rpm_prefix("/usr/lib/systemd/system-generators",
+                                                            x)
+            ], src_files
+        )
+
+        self._check_files_in_rpm(src_files, rpm_files)
+
+    def test_anaconda_logind_conf_file(self):
+        rpm_files = self._get_install_img_deps_rpm_content()
+
+        rpm_files = filter(FileFilters.rpm_logind_only, rpm_files)
+
+        src_files = self._apply_filters(
+            [
+                FileFilters.src_systemd_only,
+                FileFilters.makefiles_exclude,
+                lambda f: FileFilters.specific_file_only(self.ANACONDA_LOGIND_CONF, f)
+            ], self._get_source_files()
+        )
+
+        src_files = self._apply_maps(
+            [
+                ModifyingFilters.remove_data_systemd_prefix,
+                lambda x: ModifyingFilters.apply_rpm_prefix("/usr/lib/systemd/logind.conf.d",
                                                             x)
             ], src_files
         )
@@ -263,6 +288,11 @@ class InstalledFilesTestCase(RPMTestCase):
     def _get_core_rpm_content(self):
         rpms = filter(RPMFilters.debug_exclude, self.rpm_paths)
         rpms = filter(RPMFilters.anaconda_core_only, rpms)
+        return self._get_rpms_content(rpms)
+
+    def _get_install_img_deps_rpm_content(self):
+        rpms = filter(RPMFilters.debug_exclude, self.rpm_paths)
+        rpms = filter(RPMFilters.anaconda_install_img_deps_only, rpms)
         return self._get_rpms_content(rpms)
 
     def _get_rpms_content(self, rpms):
@@ -365,6 +395,10 @@ class FileFilters:
         return "/systemd/system" in path
 
     @staticmethod
+    def rpm_logind_only(path):
+        return "/systemd/logind.conf.d" in path
+
+    @staticmethod
     def src_systemd_only(path):
         return "systemd/" in path
 
@@ -398,6 +432,10 @@ class RPMFilters:
     def anaconda_core_only(rpm):
         # includes debug package
         return "anaconda-core" in rpm
+
+    @staticmethod
+    def anaconda_install_img_deps_only(rpm):
+        return "anaconda-install-img-deps" in rpm
 
 
 class ModifyingFilters:


### PR DESCRIPTION
Things have changed in Fedora and autovt@ is no longer a static symlink. To prevent image build tooling from having to manually symlink the service to `autovt@.service` instead give it an alias; this is similar to [1].

Then we also require this service for the `anaconda.target` so it actually gets started automatically.

Additionally we set the reserved VT to 2 instead of 6 so that the reserved VT doesn't clash with the VT that Anaconda wants to start its graphical interface on (tty6).

[1]: https://github.com/systemd/systemd/commit/072e72424b