### PR TITLE
fix(storage): use disklabel_types parameter in _is_valid_disklabel

### DIFF
--- a/pyanaconda/modules/storage/bootloader/base.py
+++ b/pyanaconda/modules/storage/bootloader/base.py
@@ -370,10 +370,10 @@ class BootLoader:
 
     def _is_valid_disklabel(self, device, disklabel_types=None):
         ret = True
-        if self.disklabel_types:
+        if disklabel_types:
             for disk in device.disks:
                 label_type = getattr(disk.format, "label_type", None)
-                if not label_type or label_type not in self.disklabel_types:
+                if not label_type or label_type not in disklabel_types:
                     types_str = ",".join(disklabel_types)
                     self.errors.append(_("%(name)s must have one of the following "
                                          "disklabel types: %(types)s.")


### PR DESCRIPTION
_is_valid_disklabel() accepted a disklabel_types parameter but used self.disklabel_types (which includes both 'gpt' and 'msdos') for the actual validation. This made the platform constraint check added in 396d9d7a92 dead code - the X86EFI platform's GPT-only requirement was never enforced, allowing UEFI installations on MBR-labeled disks to proceed past partitioning.

Resolves: rhbz#2497003