### PR TITLE
Fix deadlock between blivet_lock and logging lock in storage module

### DIFF
--- a/pyanaconda/core/storage.py
+++ b/pyanaconda/core/storage.py
@@ -231,7 +231,7 @@ def device_matches(spec, devicetree=None, disks_only=False):
             matches.append(dev_name)
 
     log.debug("%s matches %s for devicetree=%s and disks_only=%s",
-              spec, matches, devicetree, disks_only)
+              str(spec), str(matches), str(devicetree), str(disks_only))
 
     return matches
 


### PR DESCRIPTION
When installing OS via anaconda, the process `python3 -m pyanaconda.modules.storage` can hang due to a classic lock ordering violation between two threads:

Thread 1 (D-Bus service):
  Holds blivet_lock -> waits for logging lock
  (get_device_by_name holds blivet_lock, then calls log.debug() which acquires the logging handler's lock)

Thread 2 (task worker):
  Holds logging lock -> waits for blivet_lock
  (device_matches calls log.debug() which acquires the logging lock, then formats the message via msg % self.args, which triggers \_\_str\_\_ on a devicetree argument that internally calls run_with_lock to acquire blivet_lock)

The root cause is that Python's logging framework stores arguments as raw objects and defers string formatting until the handler emits the record, at which point the logging lock is already held. If any argument's \_\_str\_\_() acquires another lock, it creates a dependency from logging lock -> that lock, which can deadlock with code that holds that lock first and then logs.

Fix this by converting the arguments to strings before passing them to log.debug(), so that no lock acquisition occurs during the deferred formatting inside the logging framework.
