### PR TITLE
Handle timezone-not-set for GetSystemDateTime DBus method

### DIFF
--- a/pyanaconda/modules/timezone/timezone.py
+++ b/pyanaconda/modules/timezone/timezone.py
@@ -303,11 +303,18 @@ class TimezoneService(KickstartService):
     def get_system_date_time(self):
         """Get system time as a ISO 8601 formatted string.
 
-        :return: system time as ISO 8601 formatted string
+        :return: system time as ISO 8601 formatted string or ""
+                 if system time can't be determined, usually
+                 due to a valid timezone not being set
         :rtype: str
         """
-        # convert to the expected tzinfo format via get_timezone()
-        return datetime.datetime.now(get_timezone(self._timezone)).isoformat()
+        # check if timezone has been set
+        if self._timezone:
+            # convert to the expected tzinfo format via get_timezone()
+            return datetime.datetime.now(get_timezone(self._timezone)).isoformat()
+        else:
+            log.debug("can't determine system date & time - timezone not set")
+            return ""
 
     def set_system_date_time(self, date_time_spec):
         """Set system time based on a ISO 8601 formatted string.

--- a/pyanaconda/modules/timezone/timezone_interface.py
+++ b/pyanaconda/modules/timezone/timezone_interface.py
@@ -196,7 +196,9 @@ class TimezoneInterface(KickstartModuleInterface):
 
         The timezone set via the Timezone property affects the returned data.
 
-        :return: a string representing the date and time in ISO 8601 format
+        :return: system time as ISO 8601 formatted string or ""
+                 if system time can't be determined, usually
+                 due to a valid timezone not being set
         """
         return self.implementation.get_system_date_time()
 

--- a/tests/unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/timezone/test_module_timezone.py
@@ -406,6 +406,15 @@ class TimezoneInterfaceTestCase(unittest.TestCase):
         assert self.timezone_interface.GetSystemDateTime() == "2023-06-22T18:49:36.878200"
         fake_date.isoformat.assert_called_once()
 
+    @patch("pyanaconda.modules.timezone.timezone.datetime")
+    def test_get_system_date_time_timezone_not_set(self, fake_datetime):
+        """Test getting system date and time if timezone is not set."""
+        # make sure Timezone is not set
+        self.timezone_module._timezone = None
+        # check empty string is returned when no timezone is set,
+        # which indicates we can't return a valid date and time
+        assert self.timezone_interface.GetSystemDateTime() == ""
+
     @patch("pyanaconda.modules.timezone.timezone.set_system_date_time")
     def test_set_system_date_time(self, fake_set_time):
         """Test setting system date and time."""


### PR DESCRIPTION
In case GetSystemDateTime is called while a timezone has not been set, return "" instead of crashing the backend.

Related: INSTALLER-4764

TODO:

- [ ] unit test the new state