### PR TITLE
fix(flatpak): do not explicitly install runtimes to avoid pinning

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_manager.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/flatpak_manager.py
@@ -183,6 +183,8 @@ class FlatpakManager:
 
     def _stuff_refs_to_transaction(self):
         for ref in self._remote_refs_list.get_refs_full_format():
+            if ref.startswith("runtime/"):
+                continue
             self._transaction.add_install(self.LOCAL_REMOTE_NAME, ref, None)
 
     def replace_installed_refs_remote(self, new_remote):

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_flatpak_manager.py
@@ -197,16 +197,6 @@ class FlatpakTest(unittest.TestCase):
                 "app/com.prop.notcoolapp/i386/f36",
                 None
             ),
-            call.add_install(
-                FlatpakManager.LOCAL_REMOTE_NAME,
-                "runtime/org.space.coolruntime/x86_64/stable",
-                None
-            ),
-            call.add_install(
-                FlatpakManager.LOCAL_REMOTE_NAME,
-                "runtime/com.prop.notcoolruntime/i386/f36",
-                None
-            ),
             call.run()
         ]
 


### PR DESCRIPTION
During Silverblue installation, Anaconda calls add_install() for every ref in the local flatpak repo, including runtimes. Flatpak automatically pins runtimes that are explicitly installed (as opposed to pulled in as dependencies of apps). Pinned runtimes are never auto-removed, so after upgrading to a new Fedora release, users see persistent EOL warnings:

  (pinned) runtime org.fedoraproject.Platform branch f40 is end-of-life

Skip runtime refs so only app refs are explicitly added to the transaction. The runtimes are still installed as dependencies when flatpak resolves the app requirements — but without the pinned flag.

Resolves: rhbz#2344161

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>


Before:
<img width="1146" height="716" alt="Screenshot 2026-07-27 at 15-03-35 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/5d5879bc-de60-49ae-9a9d-9ebdefa5da1f" />

After:
<img width="1146" height="716" alt="Screenshot 2026-07-27 at 15-26-58 Virtual machines - kkoukiou@fedora" src="https://github.com/user-attachments/assets/d83a3c94-f707-445c-81ef-2f0f746d945c" />
