### PR TITLE
webui: hide installation source screen on Fedora Workstation and KDE

### DIFF
--- a/data/profile.d/fedora-kde.conf
+++ b/data/profile.d/fedora-kde.conf
@@ -26,4 +26,5 @@ webui_web_engine = slitherer
 hidden_webui_pages =
     anaconda-screen-accounts
     anaconda-screen-date-time
+    anaconda-screen-installation-source
     anaconda-screen-network

--- a/data/profile.d/fedora-workstation.conf
+++ b/data/profile.d/fedora-workstation.conf
@@ -25,4 +25,5 @@ hidden_spokes =
 hidden_webui_pages =
     anaconda-screen-accounts
     anaconda-screen-date-time
+    anaconda-screen-installation-source
     anaconda-screen-network


### PR DESCRIPTION
Related: INSTALLER-3621

Completes: https://github.com/rhinstaller/anaconda-webui/pull/1384