### PR TITLE
infra: add rpminspect waiver for liveinst.desktop icon check

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -13,6 +13,7 @@ downstream_package_name: anaconda
 
 files_to_sync:
   - rpmlint.toml
+  - rpminspect.yaml
   - .packit.yml
 
 srpm_build_deps:

--- a/.packit.yml.j2
+++ b/.packit.yml.j2
@@ -6,6 +6,7 @@ downstream_package_name: anaconda
 
 files_to_sync:
   - rpmlint.toml
+  - rpminspect.yaml
   - .packit.yml
 
 srpm_build_deps:

--- a/rpminspect.yaml
+++ b/rpminspect.yaml
@@ -1,0 +1,4 @@
+---
+desktop:
+    skip_icon_check:
+        - /usr/share/applications/liveinst.desktop


### PR DESCRIPTION
The liveinst.desktop file references the org.fedoraproject.AnacondaInstaller icon which is provided by fedora-logos (via system-logos), not by any anaconda subpackage. Add rpminspect.yaml with skip_icon_check to suppress this false positive, and sync it to dist-git via packit.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

See fixed; https://src.fedoraproject.org/rpms/anaconda/pull-request/331

Vs: https://src.fedoraproject.org/rpms/anaconda/pull-request/329