### PR TITLE
storage: Run do_partitioning for reqpart in custom partitioning

### DIFF
--- a/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
+++ b/pyanaconda/modules/storage/partitioning/custom/custom_partitioning.py
@@ -97,6 +97,11 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
         # Start the partitioning.
         self._execute_reqpart(storage, data)
         self._execute_partition(storage, data)
+
+        # Allocated the partitions created by either reqpart or partition.
+        if data.reqpart.reqpart or data.partition.partitions:
+            do_partitioning(storage, boot_disk=storage.bootloader.stage1_disk)
+
         self._execute_raid(storage, data)
         self._execute_volgroup(storage, data)
         self._execute_logvol(storage, data)
@@ -143,9 +148,6 @@ class CustomPartitioningTask(NonInteractivePartitioningTask):
         """
         for partition_data in data.partition.partitions:
             self._execute_partition_data(storage, data, partition_data)
-
-        if data.partition.partitions:
-            do_partitioning(storage, boot_disk=storage.bootloader.stage1_disk)
 
     def _execute_partition_data(self, storage, data, partition_data):
         """Execute the partition data.


### PR DESCRIPTION
With the do_partitioning call the partitions are actually not allocated.
For most use cases this call is usually done by for the partition command in _execute_partition but when only reqpart is used and rest of the storage is reused with useexisting the bootloader partitions are not created.