### PR TITLE
feat(boss): track installation status with enum

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -28,6 +28,10 @@ from pyanaconda.modules.boss.installation import (
 from pyanaconda.modules.boss.kickstart_manager import KickstartManager
 from pyanaconda.modules.boss.module_manager import ModuleManager
 from pyanaconda.modules.common.base import Service
+from pyanaconda.modules.common.constants.installation import (
+    InstallationErrorDialogType,
+    InstallationStatus,
+)
 from pyanaconda.modules.common.constants.services import BOSS
 from pyanaconda.modules.common.containers import TaskContainer
 
@@ -46,6 +50,8 @@ class Boss(Service):
         self._install_manager = InstallManager()
         self._installation_task = None
         self.active_installation_task_changed = Signal()
+        self._installation_status = InstallationStatus.NOT_STARTED
+        self.installation_status_changed = Signal()
 
         self._module_manager.module_observers_changed.connect(
             self._kickstart_manager.on_module_observers_changed
@@ -104,6 +110,14 @@ class Boss(Service):
         """
         return self._install_manager.collect_requirements()
 
+    @property
+    def installation_status(self):
+        """The current installation status.
+
+        :return: an InstallationStatus value
+        """
+        return self._installation_status
+
     def get_installation_task(self):
         """Get the active installation task, if any.
 
@@ -119,13 +133,18 @@ class Boss(Service):
         """Return installation tasks of this module.
 
         If an installation task is already running, return
-        the existing task to allow reconnection. Otherwise,
-        create a new one.
+        the existing task to allow reconnection. If it is
+        completed, return an empty list. Otherwise, create
+        a new one.
 
         :return: a list of installation tasks
         """
         if self._installation_task is not None:
             return [self._installation_task]
+
+        if self._installation_status in [InstallationStatus.SUCCEEDED, InstallationStatus.FAILED]:
+            log.debug("install_with_tasks was called, but the installation is already finished.")
+            return []
 
         self._installation_task = RunInstallationTask(
             install_manager=self._install_manager,
@@ -134,16 +153,65 @@ class Boss(Service):
         self._installation_task.started_signal.connect(
             self._on_installation_started
         )
+        self._installation_task.succeeded_signal.connect(
+            self._on_installation_succeeded
+        )
+        self._installation_task.failed_signal.connect(
+            self._on_installation_failed
+        )
         self._installation_task.stopped_signal.connect(
             self._on_installation_stopped
+        )
+        self._installation_task.error_raised_signal.connect(
+            self._on_error_raised
         )
 
         return [self._installation_task]
 
+    def _set_installation_status(self, status):
+        """Set the installation status if the transition is valid.
+
+        Terminal states (SUCCEEDED, FAILED) cannot be overwritten.
+        The signal is only emitted when the status actually changes.
+
+        :param status: the new InstallationStatus value
+        """
+        if self._installation_status in (InstallationStatus.SUCCEEDED, InstallationStatus.FAILED):
+            log.debug("Ignoring status change to %s — already in terminal state %s.",
+                       status, self._installation_status)
+            return
+
+        if self._installation_status == status:
+            return
+
+        self._installation_status = status
+        self.installation_status_changed.emit()
+
     def _on_installation_started(self):
         """Handle the installation task start."""
         log.info("The installation has started.")
+        self._set_installation_status(InstallationStatus.RUNNING)
         self.active_installation_task_changed.emit()
+
+    def _on_installation_succeeded(self):
+        """Handle the installation task success."""
+        log.info("The installation has succeeded.")
+        self._set_installation_status(InstallationStatus.SUCCEEDED)
+
+    def _on_installation_failed(self):
+        """Handle the installation task failure."""
+        log.error("The installation has failed.")
+        self._set_installation_status(InstallationStatus.FAILED)
+
+    def _on_error_raised(self, message, error_type):
+        """Handle errors raised during installation.
+
+        :param message: the error message
+        :param error_type: the error type string
+        """
+        log.info("Error raised: type=%s, message=%s", error_type, message[:80])
+        if error_type == InstallationErrorDialogType.FATAL_ERROR:
+            self._set_installation_status(InstallationStatus.FAILED)
 
     def _on_installation_stopped(self):
         """Handle the installation task stop."""

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -52,6 +52,10 @@ class BossInterface(InterfaceTemplate):
             "ActiveInstallationTask",
             self.implementation.active_installation_task_changed
         )
+        self.watch_property(
+            "InstallationStatus",
+            self.implementation.installation_status_changed
+        )
 
     @property
     def ActiveInstallationTask(self) -> Str:
@@ -68,6 +72,20 @@ class BossInterface(InterfaceTemplate):
             return ""
 
         return TaskContainer.to_object_path(task)
+
+    @property
+    def InstallationStatus(self) -> Int:
+        """The current installation status.
+
+        Possible values:
+        1 - NOT_STARTED
+        2 - RUNNING
+        3 - SUCCEEDED
+        4 - FAILED
+
+        :return: an integer value of InstallationStatus
+        """
+        return self.implementation.installation_status.value
 
     def GetModules(self) -> List[BusName]:
         """Get service names of running modules.

--- a/pyanaconda/modules/common/constants/installation.py
+++ b/pyanaconda/modules/common/constants/installation.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from enum import Enum
+from enum import StrEnum
 
 
-class InstallationErrorDialogType(Enum):
+class InstallationErrorDialogType(StrEnum):
     """Dialog types for installation errors forwarded from Boss to the UI."""
 
     YES_NO = "yesno"

--- a/pyanaconda/modules/common/constants/installation.py
+++ b/pyanaconda/modules/common/constants/installation.py
@@ -16,7 +16,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from enum import StrEnum
+from enum import IntEnum, StrEnum
+
+
+class InstallationStatus(IntEnum):
+    """Status of the installation process tracked by the Boss module."""
+
+    # Values start at 1 so that all valid states are truthy — syntactic
+    # sugar for UI clients to distinguish "status loaded" from "not yet
+    # fetched" (null/undefined), e.g. ``if (status) { /* ready */ }``.
+    NOT_STARTED = 1
+    RUNNING = 2
+    SUCCEEDED = 3
+    FAILED = 4
 
 
 class InstallationErrorDialogType(StrEnum):

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -45,6 +45,7 @@ class AnacondaLintConfig(CensorshipConfig):
         ]
 
         self.false_positives = [
+            FalsePositive(r"W0201.*tests/.*\.setup_method: Attribute .* defined outside __init__"),
             FalsePositive(r"^E1101.*: Instance of 'KickstartSpecificationHandler' has no '.*' member$"),
 
             # TODO: BlockDev introspection needs to be added to pylint to handle these

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -16,9 +16,9 @@
 # Red Hat, Inc.
 #
 import tempfile
-import unittest
 from unittest.mock import Mock, patch
 
+import pytest
 from dasbus.typing import *  # pylint: disable=wildcard-import
 
 from pyanaconda.core.constants import DEFAULT_LANG
@@ -26,6 +26,10 @@ from pyanaconda.modules.boss.boss import Boss
 from pyanaconda.modules.boss.boss_interface import BossInterface
 from pyanaconda.modules.boss.installation import RunInstallationTask
 from pyanaconda.modules.boss.module_manager.start_modules import StartModulesTask
+from pyanaconda.modules.common.constants.installation import (
+    InstallationErrorDialogType,
+    InstallationStatus,
+)
 from pyanaconda.modules.common.structures.requirement import Requirement
 from tests.unit_tests.pyanaconda_tests import (
     check_task_creation,
@@ -35,10 +39,10 @@ from tests.unit_tests.pyanaconda_tests import (
 )
 
 
-class BossInterfaceTestCase(unittest.TestCase):
+class BossInterfaceTestCase:
     """Test DBus interface for the Boss module."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up the module."""
         self.module = Boss()
         self.interface = BossInterface(self.module)
@@ -244,12 +248,21 @@ class BossInterfaceTestCase(unittest.TestCase):
             task_paths_2 = self.interface.InstallWithTasks()
             assert task_paths_1 == task_paths_2
 
-    def test_install_with_tasks_creates_new_when_previous_finished(self):
-        """Test that InstallWithTasks creates a new task when previous finished."""
-        tasks_1 = self.module.install_with_tasks()
+    def test_install_with_tasks_returns_empty_after_succeeded(self):
+        """Test that InstallWithTasks returns [] after a successful installation."""
+        self.module.install_with_tasks()
+        self.module._on_installation_started()
+        self.module._on_installation_succeeded()
         self.module._on_installation_stopped()
-        tasks_2 = self.module.install_with_tasks()
-        assert tasks_1[0] is not tasks_2[0]
+        assert self.module.install_with_tasks() == []
+
+    def test_install_with_tasks_returns_empty_after_failed(self):
+        """Test that InstallWithTasks returns [] after a failed installation."""
+        self.module.install_with_tasks()
+        self.module._on_installation_started()
+        self.module._on_installation_failed()
+        self.module._on_installation_stopped()
+        assert self.module.install_with_tasks() == []
 
     @patch_dbus_publish_object
     def test_active_installation_task_none(self, publisher):
@@ -281,6 +294,120 @@ class BossInterfaceTestCase(unittest.TestCase):
 
         self.module._on_installation_stopped()
         callback.assert_called()
+
+    def test_installation_status_default(self):
+        """Test that InstallationStatus defaults to NOT_STARTED."""
+        assert self.interface.InstallationStatus == InstallationStatus.NOT_STARTED
+        assert self.module.installation_status == InstallationStatus.NOT_STARTED
+
+    @patch_dbus_publish_object
+    def test_installation_status_running(self, publisher):
+        """Test that InstallationStatus changes to RUNNING when started."""
+        callback = Mock()
+        self.module.installation_status_changed.connect(callback)
+
+        task_paths = self.interface.InstallWithTasks()
+        check_task_creation(task_paths[0], publisher, RunInstallationTask)
+
+        self.module._on_installation_started()
+
+        assert self.interface.InstallationStatus == InstallationStatus.RUNNING
+        assert self.module.installation_status == InstallationStatus.RUNNING
+        callback.assert_called()
+
+    @patch_dbus_publish_object
+    def test_installation_status_succeeded(self, publisher):
+        """Test that InstallationStatus changes to SUCCEEDED on success."""
+        callback = Mock()
+        self.module.installation_status_changed.connect(callback)
+
+        task_paths = self.interface.InstallWithTasks()
+        check_task_creation(task_paths[0], publisher, RunInstallationTask)
+
+        self.module._on_installation_started()
+        callback.reset_mock()
+
+        self.module._on_installation_succeeded()
+
+        assert self.interface.InstallationStatus == InstallationStatus.SUCCEEDED
+        assert self.module.installation_status == InstallationStatus.SUCCEEDED
+        callback.assert_called()
+
+    @pytest.mark.parametrize("error_type", [
+        InstallationErrorDialogType.FATAL_ERROR,
+        InstallationErrorDialogType.FATAL_ERROR.value,
+    ])
+    @patch_dbus_publish_object
+    def test_installation_status_failed(self, publisher, error_type):
+        """Test that InstallationStatus changes to FAILED on fatal error."""
+        status_callback = Mock()
+        self.module.installation_status_changed.connect(status_callback)
+
+        task_paths = self.interface.InstallWithTasks()
+        task_proxy = check_task_creation(task_paths[0], publisher, RunInstallationTask)
+        task = task_proxy.implementation
+
+        self.module._on_installation_started()
+        status_callback.reset_mock()
+
+        task.error_raised_signal.emit("Something went wrong", error_type)
+
+        assert self.interface.InstallationStatus == InstallationStatus.FAILED
+        assert self.module.installation_status == InstallationStatus.FAILED
+        status_callback.assert_called()
+
+    @patch_dbus_publish_object
+    def test_yesno_error_does_not_set_failed(self, publisher):
+        """Test that a YES_NO error does not change status to FAILED."""
+        task_paths = self.interface.InstallWithTasks()
+        task_proxy = check_task_creation(task_paths[0], publisher, RunInstallationTask)
+        task = task_proxy.implementation
+
+        self.module._on_installation_started()
+        task.error_raised_signal.emit("Non-fatal error", InstallationErrorDialogType.YES_NO)
+
+        assert self.module.installation_status == InstallationStatus.RUNNING
+
+    @patch_dbus_publish_object
+    def test_installation_failed_via_signal(self, publisher):
+        """Test that failed_signal sets status to FAILED."""
+        task_paths = self.interface.InstallWithTasks()
+        check_task_creation(task_paths[0], publisher, RunInstallationTask)
+
+        self.module._on_installation_started()
+        self.module._on_installation_failed()
+
+        assert self.module.installation_status == InstallationStatus.FAILED
+
+    @pytest.mark.parametrize("terminal_status", [
+        InstallationStatus.SUCCEEDED,
+        InstallationStatus.FAILED,
+    ])
+    def test_terminal_status_cannot_be_overwritten(self, terminal_status):
+        """Test that terminal states (SUCCEEDED, FAILED) cannot be changed."""
+        callback = Mock()
+        self.module.installation_status_changed.connect(callback)
+
+        self.module._set_installation_status(terminal_status)
+        callback.reset_mock()
+
+        self.module._set_installation_status(InstallationStatus.RUNNING)
+
+        assert self.module.installation_status == terminal_status
+        callback.assert_not_called()
+
+    @pytest.mark.parametrize("terminal_handler,expected_status", [
+        ("_on_installation_succeeded", InstallationStatus.SUCCEEDED),
+        ("_on_installation_failed", InstallationStatus.FAILED),
+    ])
+    def test_stopped_preserves_terminal_status(self, terminal_handler, expected_status):
+        """Test that _on_installation_stopped does not change terminal status."""
+        self.module._on_installation_started()
+        getattr(self.module, terminal_handler)()
+        self.module._on_installation_stopped()
+
+        assert self.module.installation_status == expected_status
+        assert self.module._installation_task is None
 
     def test_quit(self):
         """Test Quit."""

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_install_category.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_install_category.py
@@ -87,8 +87,8 @@ class InstallManagerTestCase(unittest.TestCase):
         # pylint: disable=no-member
         interface.ErrorRaised.connect(callback)
 
-        task.error_raised_signal.emit("queue error", InstallationErrorDialogType.YES_NO.value)
-        callback.assert_called_once_with("queue error", InstallationErrorDialogType.YES_NO.value)
+        task.error_raised_signal.emit("queue error", InstallationErrorDialogType.YES_NO)
+        callback.assert_called_once_with("queue error", InstallationErrorDialogType.YES_NO)
 
         interface.RespondToError(True)
         assert task._error_should_continue is True

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_installation_error.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_installation_error.py
@@ -75,7 +75,7 @@ class InstallationErrorHandlerTestCase(unittest.TestCase):
         task.run()
 
         assert len(received) == 1
-        assert received[0][1] == InstallationErrorDialogType.YES_NO.value
+        assert received[0][1] == InstallationErrorDialogType.YES_NO
         assert "queue error" in received[0][0]
 
     def test_script_error_uses_fatal_dialog(self):
@@ -94,6 +94,6 @@ class InstallationErrorHandlerTestCase(unittest.TestCase):
 
         assert result == ERROR_RAISE
         assert len(received) == 1
-        assert received[0][1] == InstallationErrorDialogType.FATAL_ERROR.value
+        assert received[0][1] == InstallationErrorDialogType.FATAL_ERROR
         assert "42" in received[0][0]
         assert "script failed" in received[0][0]

--- a/tests/unit_tests/pyanaconda_tests/ui/test_installation_progress_error.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_installation_progress_error.py
@@ -41,14 +41,14 @@ class InstallationProgressErrorMixinTestCase(unittest.TestCase):
         mocked_error_handler.ui = mock_ui
         mock_ui.showYesNoQuestion.return_value = True
 
-        spoke._on_error_raised("Installation failed", InstallationErrorDialogType.FATAL_ERROR.value)
+        spoke._on_error_raised("Installation failed", InstallationErrorDialogType.FATAL_ERROR)
         mock_ui.showError.assert_called_once_with("Installation failed")
         spoke._task_proxy.RespondToError.assert_called_with(False)
 
         mock_ui.reset_mock()
         spoke._task_proxy.reset_mock()
 
-        spoke._on_error_raised("Ignore this error?", InstallationErrorDialogType.YES_NO.value)
+        spoke._on_error_raised("Ignore this error?", InstallationErrorDialogType.YES_NO)
         mock_ui.showYesNoQuestion.assert_called_once_with("Ignore this error?")
         spoke._task_proxy.RespondToError.assert_called_once_with(True)
 


### PR DESCRIPTION
Add InstallationStatus enum (NOT_STARTED, RUNNING, SUCCEEDED,
FAILED) to replace ad-hoc status tracking. The Boss module now
updates the status on task lifecycle signals and exposes it as
a D-Bus property.

Resolves: INSTALLER-4824
Assisted-by: Claude Opus 4.6