### PR TITLE
gui: switch default font from Cantarell to Noto Sans

### DIFF
--- a/pyanaconda/ui/gui/__init__.py
+++ b/pyanaconda/ui/gui/__init__.py
@@ -720,7 +720,7 @@ class GraphicalUserInterface(UserInterface):
 
             # Set some program-wide settings.
             settings = Gtk.Settings.get_default()
-            settings.set_property("gtk-font-name", "Cantarell")
+            settings.set_property("gtk-font-name", "Noto Sans")
             settings.set_property("gtk-icon-theme-name", "Adwaita")
 
             # Get the path to the application data

--- a/pyanaconda/ui/gui/hubs/summary.glade
+++ b/pyanaconda/ui/gui/hubs/summary.glade
@@ -128,7 +128,7 @@
             <property name="label" translatable="yes">We won't touch your disks until you click 'Begin Installation'.</property>
             <property name="xalign">1</property>
             <attributes>
-              <attribute name="font-desc" value="Cantarell Italic"/>
+              <attribute name="font-desc" value="Noto Sans Italic"/>
               <attribute name="foreground" value="#808080808080"/>
             </attributes>
           </object>

--- a/pyanaconda/ui/gui/spokes/custom_storage.glade
+++ b/pyanaconda/ui/gui/spokes/custom_storage.glade
@@ -965,7 +965,7 @@
                                             <property name="width_chars">39</property>
                                             <property name="max_width_chars">39</property>
                                             <attributes>
-                                              <attribute name="font-desc" value="Cantarell Italic 10"/>
+                                              <attribute name="font-desc" value="Noto Sans Italic 10"/>
                                             </attributes>
                                           </object>
                                           <packing>
@@ -1006,7 +1006,7 @@
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Selected Device</property>
                                             <attributes>
-                                              <attribute name="font-desc" value="Cantarell Bold 10"/>
+                                              <attribute name="font-desc" value="Noto Sans Bold 10"/>
                                               <attribute name="weight" value="bold"/>
                                               <attribute name="scale" value="1.2"/>
                                             </attributes>
@@ -1024,7 +1024,7 @@
                                             <property name="halign">end</property>
                                             <property name="label" translatable="yes">Device description</property>
                                             <attributes>
-                                              <attribute name="font-desc" value="Cantarell Italic 10"/>
+                                              <attribute name="font-desc" value="Noto Sans Italic 10"/>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
                                           </object>
@@ -1059,7 +1059,7 @@
                                         <property name="label" translatable="yes">This device is encrypted and cannot be read without a valid passphrase. You may unlock it below.</property>
                                         <property name="wrap">True</property>
                                         <attributes>
-                                          <attribute name="font-desc" value="Cantarell 11"/>
+                                          <attribute name="font-desc" value="Noto Sans 11"/>
                                         </attributes>
                                       </object>
                                       <packing>
@@ -1081,7 +1081,7 @@
                                             <property name="use_underline">True</property>
                                             <property name="mnemonic_widget">passphraseEntry</property>
                                             <attributes>
-                                              <attribute name="font-desc" value="Cantarell 11"/>
+                                              <attribute name="font-desc" value="Noto Sans 11"/>
                                             </attributes>
                                           </object>
                                           <packing>
@@ -1153,7 +1153,7 @@
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Selected Device</property>
                                             <attributes>
-                                              <attribute name="font-desc" value="Cantarell Bold 10"/>
+                                              <attribute name="font-desc" value="Noto Sans Bold 10"/>
                                               <attribute name="weight" value="bold"/>
                                               <attribute name="scale" value="1.2"/>
                                             </attributes>
@@ -1171,7 +1171,7 @@
                                             <property name="halign">end</property>
                                             <property name="label" translatable="yes">Device description</property>
                                             <attributes>
-                                              <attribute name="font-desc" value="Cantarell Italic 10"/>
+                                              <attribute name="font-desc" value="Noto Sans Italic 10"/>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
                                           </object>
@@ -1206,7 +1206,7 @@
                                         <property name="label" translatable="yes">This device cannot be edited directly. You can remove it or select a different device.</property>
                                         <property name="wrap">True</property>
                                         <attributes>
-                                          <attribute name="font-desc" value="Cantarell 11"/>
+                                          <attribute name="font-desc" value="Noto Sans 11"/>
                                         </attributes>
                                       </object>
                                       <packing>
@@ -1240,7 +1240,7 @@
                                             <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Selected Device</property>
                                             <attributes>
-                                              <attribute name="font-desc" value="Cantarell Bold 10"/>
+                                              <attribute name="font-desc" value="Noto Sans Bold 10"/>
                                               <attribute name="weight" value="bold"/>
                                               <attribute name="scale" value="1.2"/>
                                             </attributes>
@@ -1258,7 +1258,7 @@
                                             <property name="halign">end</property>
                                             <property name="label" translatable="yes">Device description</property>
                                             <attributes>
-                                              <attribute name="font-desc" value="Cantarell Italic 10"/>
+                                              <attribute name="font-desc" value="Noto Sans Italic 10"/>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
                                           </object>
@@ -1293,7 +1293,7 @@
                                         <property name="yalign">0.43000000715255737</property>
                                         <property name="wrap">True</property>
                                         <attributes>
-                                          <attribute name="font-desc" value="Cantarell 11"/>
+                                          <attribute name="font-desc" value="Noto Sans 11"/>
                                         </attributes>
                                       </object>
                                       <packing>

--- a/pyanaconda/ui/gui/spokes/installation_source.glade
+++ b/pyanaconda/ui/gui/spokes/installation_source.glade
@@ -73,7 +73,7 @@
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Which installation source would you like to use?</property>
                                 <attributes>
-                                  <attribute name="font-desc" value="Cantarell 10"/>
+                                  <attribute name="font-desc" value="Noto Sans 10"/>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
                               </object>
@@ -487,7 +487,7 @@
                                     <property name="margin-top">12</property>
                                     <property name="label" translatable="yes">Updates</property>
                                     <attributes>
-                                      <attribute name="font-desc" value="Cantarell 10"/>
+                                      <attribute name="font-desc" value="Noto Sans 10"/>
                                       <attribute name="weight" value="bold"/>
                                     </attributes>
                                   </object>

--- a/pyanaconda/ui/gui/spokes/keyboard.glade
+++ b/pyanaconda/ui/gui/spokes/keyboard.glade
@@ -57,7 +57,7 @@
                     <property name="wrap">True</property>
                     <property name="xalign">0</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 12"/>
+                      <attribute name="font-desc" value="Noto Sans 12"/>
                       <attribute name="weight" value="normal"/>
                       <attribute name="scale" value="1"/>
                     </attributes>
@@ -96,7 +96,7 @@
                         <property name="label" translatable="yes">Changes here will only apply to the installed system. Use the desktop's tool to configure the keyboard for the installation process.</property>
                         <property name="wrap">True</property>
                         <attributes>
-                          <attribute name="font-desc" value="Cantarell 12"/>
+                          <attribute name="font-desc" value="Noto Sans 12"/>
                           <attribute name="weight" value="normal"/>
                           <attribute name="scale" value="1"/>
                         </attributes>
@@ -292,7 +292,7 @@
                             <property name="use_underline">True</property>
                             <property name="mnemonic_widget">layoutTextView</property>
                             <attributes>
-                              <attribute name="font-desc" value="Cantarell 10"/>
+                              <attribute name="font-desc" value="Noto Sans 10"/>
                             </attributes>
                           </object>
                           <packing>
@@ -331,7 +331,7 @@
                             <property name="label" translatable="yes">Alt + Shift to switch layouts.</property>
                             <property name="wrap">True</property>
                             <attributes>
-                              <attribute name="font-desc" value="Cantarell Italic 10"/>
+                              <attribute name="font-desc" value="Noto Sans Italic 10"/>
                               <attribute name="style" value="italic"/>
                             </attributes>
                           </object>
@@ -468,7 +468,7 @@
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">ADD A KEYBOARD LAYOUT</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell Bold 10"/>
+                  <attribute name="font-desc" value="Noto Sans Bold 10"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
@@ -485,7 +485,7 @@
                 <property name="label" translatable="yes">You may add a keyboard layout by selecting it below:</property>
                 <property name="xalign">0</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 12"/>
+                  <attribute name="font-desc" value="Noto Sans 12"/>
                 </attributes>
               </object>
               <packing>
@@ -658,7 +658,7 @@
                 <property name="valign">start</property>
                 <property name="label" translatable="yes">LAYOUT SWITCHING OPTIONS</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell Bold 10"/>
+                  <attribute name="font-desc" value="Noto Sans Bold 10"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
@@ -676,7 +676,7 @@
                 <property name="label" translatable="yes">Which combination(s) would you prefer for switching between keyboard layouts?</property>
                 <property name="wrap">True</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 12"/>
+                  <attribute name="font-desc" value="Noto Sans 12"/>
                 </attributes>
               </object>
               <packing>

--- a/pyanaconda/ui/gui/spokes/language_support.glade
+++ b/pyanaconda/ui/gui/spokes/language_support.glade
@@ -78,7 +78,7 @@
                     <property name="label" translatable="yes">Select additional language support to be installed:</property>
                     <property name="xalign">0</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 14"/>
+                      <attribute name="font-desc" value="Noto Sans 14"/>
                       <attribute name="weight" value="normal"/>
                       <attribute name="scale" value="1"/>
                     </attributes>
@@ -142,7 +142,7 @@
                                 <child>
                                   <object class="GtkCellRendererText" id="nativeNameRenderer">
                                     <property name="xalign">0.10000000149011612</property>
-                                    <property name="font">Cantarell 12</property>
+                                    <property name="font">Noto Sans 12</property>
                                   </object>
                                   <attributes>
                                     <attribute name="markup">0</attribute>
@@ -152,7 +152,7 @@
                                   <object class="GtkCellRendererText" id="englishNameRenderer">
                                     <property name="xalign">0.89999997615814209</property>
                                     <property name="ellipsize">end</property>
-                                    <property name="font">Cantarell Italic 14</property>
+                                    <property name="font">Noto Sans Italic 14</property>
                                     <property name="foreground">gray</property>
                                   </object>
                                   <attributes>
@@ -237,7 +237,7 @@
                                 <property name="sort_column_id">0</property>
                                 <child>
                                   <object class="GtkCellRendererText" id="localeNativeNameRenderer">
-                                    <property name="font">Cantarell 12</property>
+                                    <property name="font">Noto Sans 12</property>
                                   </object>
                                   <attributes>
                                     <attribute name="markup">0</attribute>

--- a/pyanaconda/ui/gui/spokes/lib/beta_warning_dialog.glade
+++ b/pyanaconda/ui/gui/spokes/lib/beta_warning_dialog.glade
@@ -70,7 +70,7 @@
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">This is unstable, pre-release software.</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell Bold 12"/>
+                  <attribute name="font-desc" value="Noto Sans Bold 12"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
@@ -104,7 +104,7 @@ By clicking "I want to proceed", you understand and accept the risks associated 
 If you do not understand or accept the risks, then please exit this program by selecting "I want to exit" which will reboot your system.</property>
                 <property name="wrap">True</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 12"/>
+                  <attribute name="font-desc" value="Noto Sans 12"/>
                 </attributes>
               </object>
               <packing>

--- a/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
+++ b/pyanaconda/ui/gui/spokes/lib/custom_storage_helpers.glade
@@ -66,7 +66,7 @@
             <property name="xalign">0</property>
             <property name="yalign">0</property>
             <attributes>
-              <attribute name="font-desc" value="Cantarell 11"/>
+              <attribute name="font-desc" value="Noto Sans 11"/>
             </attributes>
           </object>
           <packing>
@@ -437,7 +437,7 @@
                 <property name="label" translatable="yes">More customization options are available
 after creating the mount point below.</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 11"/>
+                  <attribute name="font-desc" value="Noto Sans 11"/>
                   <attribute name="scale" value="1"/>
                 </attributes>
               </object>
@@ -472,7 +472,7 @@ after creating the mount point below.</property>
                     <property name="label" translatable="yes">That mount point is already in
 use.  Try something else?</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 10"/>
+                      <attribute name="font-desc" value="Noto Sans 10"/>
                       <attribute name="scale" value="1"/>
                       <attribute name="foreground" value="#ffff00000000"/>
                     </attributes>
@@ -946,7 +946,7 @@ use.  Try something else?</property>
                     <property name="label" translatable="yes">Please enter a valid name.</property>
                     <property name="wrap">True</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 10"/>
+                      <attribute name="font-desc" value="Noto Sans 10"/>
                       <attribute name="scale" value="1"/>
                       <attribute name="foreground" value="#ffff00000000"/>
                     </attributes>

--- a/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
+++ b/pyanaconda/ui/gui/spokes/lib/dasdfmt.glade
@@ -73,7 +73,7 @@
                 <property name="label" translatable="yes">The following unformatted or LDL DASDs have been detected on your system. You can choose to format them now with dasdfmt or cancel to leave them unformatted. Unformatted DASDs cannot be used during installation.</property>
                 <property name="wrap">True</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 12"/>
+                  <attribute name="font-desc" value="Noto Sans 12"/>
                 </attributes>
               </object>
               <packing>
@@ -88,7 +88,7 @@
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">Unformatted DASDs Detected</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell Bold 12"/>
+                  <attribute name="font-desc" value="Noto Sans Bold 12"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>

--- a/pyanaconda/ui/gui/spokes/lib/storage_dialogs.glade
+++ b/pyanaconda/ui/gui/spokes/lib/storage_dialogs.glade
@@ -82,7 +82,7 @@
                 <property name="label" translatable="yes">INSTALLATION OPTIONS</property>
                 <property name="xalign">0</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell Bold 10"/>
+                  <attribute name="font-desc" value="Noto Sans Bold 10"/>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
@@ -100,7 +100,7 @@
                 <property name="wrap">True</property>
                 <property name="xalign">0</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 11"/>
+                  <attribute name="font-desc" value="Noto Sans 11"/>
                 </attributes>
               </object>
               <packing>
@@ -125,7 +125,7 @@
                     <property name="label" translatable="yes">disk free</property>
                     <property name="xalign">1</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell Bold 11"/>
+                      <attribute name="font-desc" value="Noto Sans Bold 11"/>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
@@ -142,7 +142,7 @@
                     <property name="wrap">True</property>
                     <property name="xalign">0</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 11"/>
+                      <attribute name="font-desc" value="Noto Sans 11"/>
                     </attributes>
                   </object>
                   <packing>
@@ -157,7 +157,7 @@
                     <property name="label" translatable="yes">fs free</property>
                     <property name="xalign">1</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell Bold 11"/>
+                      <attribute name="font-desc" value="Noto Sans Bold 11"/>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
@@ -174,7 +174,7 @@
                     <property name="wrap">True</property>
                     <property name="xalign">0</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 11"/>
+                      <attribute name="font-desc" value="Noto Sans 11"/>
                     </attributes>
                   </object>
                   <packing>
@@ -197,7 +197,7 @@
                 <property name="wrap">True</property>
                 <property name="xalign">0</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 11"/>
+                  <attribute name="font-desc" value="Noto Sans 11"/>
                 </attributes>
               </object>
               <packing>
@@ -320,7 +320,7 @@
                 <property name="wrap">True</property>
                 <property name="xalign">0</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 11"/>
+                  <attribute name="font-desc" value="Noto Sans 11"/>
                 </attributes>
               </object>
               <packing>
@@ -361,7 +361,7 @@
                     <property name="wrap">True</property>
                     <property name="xalign">0</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 11"/>
+                      <attribute name="font-desc" value="Noto Sans 11"/>
                     </attributes>
                   </object>
                   <packing>
@@ -376,7 +376,7 @@
                     <property name="label" translatable="yes">fs free</property>
                     <property name="xalign">1</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 11"/>
+                      <attribute name="font-desc" value="Noto Sans 11"/>
                       <attribute name="weight" value="bold"/>
                     </attributes>
                   </object>
@@ -393,7 +393,7 @@
                     <property name="wrap">True</property>
                     <property name="xalign">0</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 11"/>
+                      <attribute name="font-desc" value="Noto Sans 11"/>
                     </attributes>
                   </object>
                   <packing>
@@ -416,7 +416,7 @@
                 <property name="wrap">True</property>
                 <property name="xalign">0</property>
                 <attributes>
-                  <attribute name="font-desc" value="Cantarell 11"/>
+                  <attribute name="font-desc" value="Noto Sans 11"/>
                 </attributes>
               </object>
               <packing>

--- a/pyanaconda/ui/gui/spokes/network.glade
+++ b/pyanaconda/ui/gui/spokes/network.glade
@@ -420,7 +420,7 @@
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">We'll need network access to fetch information about your location and to make software updates available for you.</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 12"/>
+                      <attribute name="font-desc" value="Noto Sans 12"/>
                     </attributes>
                   </object>
                   <packing>

--- a/pyanaconda/ui/gui/spokes/software_selection.glade
+++ b/pyanaconda/ui/gui/spokes/software_selection.glade
@@ -69,7 +69,7 @@
                         <property name="wrap">True</property>
                         <property name="xalign">0</property>
                         <attributes>
-                          <attribute name="font-desc" value="Cantarell 12"/>
+                          <attribute name="font-desc" value="Noto Sans 12"/>
                           <attribute name="weight" value="normal"/>
                         </attributes>
                       </object>
@@ -118,7 +118,7 @@
                         <property name="wrap">True</property>
                         <property name="xalign">0</property>
                         <attributes>
-                          <attribute name="font-desc" value="Cantarell 12"/>
+                          <attribute name="font-desc" value="Noto Sans 12"/>
                           <attribute name="weight" value="normal"/>
                         </attributes>
                       </object>
@@ -180,7 +180,7 @@
                                 <property name="wrap">True</property>
                                 <property name="xalign">0</property>
                                 <attributes>
-                                  <attribute name="font-desc" value="Cantarell 12"/>
+                                  <attribute name="font-desc" value="Noto Sans 12"/>
                                   <attribute name="weight" value="normal"/>
                                 </attributes>
                               </object>

--- a/pyanaconda/ui/gui/spokes/storage.glade
+++ b/pyanaconda/ui/gui/spokes/storage.glade
@@ -77,7 +77,7 @@
                                 <property name="label" translatable="yes">Device Selection</property>
                                 <property name="xalign">0</property>
                                 <attributes>
-                                  <attribute name="font-desc" value="Cantarell Bold 12"/>
+                                  <attribute name="font-desc" value="Noto Sans Bold 12"/>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
                               </object>
@@ -97,7 +97,7 @@
                                 <property name="wrap">True</property>
                                 <property name="xalign">0</property>
                                 <attributes>
-                                  <attribute name="font-desc" value="Cantarell 12"/>
+                                  <attribute name="font-desc" value="Noto Sans 12"/>
                                 </attributes>
                               </object>
                               <packing>
@@ -116,7 +116,7 @@
                                 <property name="track-visited-links">False</property>
                                 <property name="xalign">0</property>
                                 <attributes>
-                                  <attribute name="font-desc" value="Cantarell Bold 10"/>
+                                  <attribute name="font-desc" value="Noto Sans Bold 10"/>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
                               </object>
@@ -181,7 +181,7 @@
                                     <property name="label" translatable="yes">Disks left unselected here will not be touched.</property>
                                     <property name="xalign">1</property>
                                     <attributes>
-                                      <attribute name="font-desc" value="Cantarell Italic 10"/>
+                                      <attribute name="font-desc" value="Noto Sans Italic 10"/>
                                     </attributes>
                                   </object>
                                 </child>
@@ -201,7 +201,7 @@
                                 <property name="track-visited-links">False</property>
                                 <property name="xalign">0</property>
                                 <attributes>
-                                  <attribute name="font-desc" value="Cantarell Bold 10"/>
+                                  <attribute name="font-desc" value="Noto Sans Bold 10"/>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
                               </object>
@@ -323,7 +323,7 @@
                                     <property name="label" translatable="yes">Disks left unselected here will not be touched.</property>
                                     <property name="xalign">1</property>
                                     <attributes>
-                                      <attribute name="font-desc" value="Cantarell Italic 10"/>
+                                      <attribute name="font-desc" value="Noto Sans Italic 10"/>
                                     </attributes>
                                   </object>
                                 </child>
@@ -351,7 +351,7 @@
                                     <property name="label" translatable="yes">Storage Configuration</property>
                                     <property name="xalign">0</property>
                                     <attributes>
-                                      <attribute name="font-desc" value="Cantarell Bold 12"/>
+                                      <attribute name="font-desc" value="Noto Sans Bold 12"/>
                                       <attribute name="weight" value="bold"/>
                                     </attributes>
                                   </object>
@@ -605,7 +605,7 @@
                         <property name="hexpand">True</property>
                         <property name="label" translatable="yes">summary</property>
                         <attributes>
-                          <attribute name="font-desc" value="Cantarell 10"/>
+                          <attribute name="font-desc" value="Noto Sans 10"/>
                         </attributes>
                       </object>
                       <packing>

--- a/pyanaconda/ui/gui/spokes/welcome.glade
+++ b/pyanaconda/ui/gui/spokes/welcome.glade
@@ -80,7 +80,7 @@
                     <property name="wrap">True</property>
                     <property name="xalign">0</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell Bold 16"/>
+                      <attribute name="font-desc" value="Noto Sans Bold 16"/>
                     </attributes>
                   </object>
                   <packing>
@@ -101,7 +101,7 @@
                     <property name="label" translatable="yes">What language would you like to use during the installation process?</property>
                     <property name="xalign">0</property>
                     <attributes>
-                      <attribute name="font-desc" value="Cantarell 12"/>
+                      <attribute name="font-desc" value="Noto Sans 12"/>
                     </attributes>
                   </object>
                   <packing>
@@ -154,7 +154,7 @@
                                 <child>
                                   <object class="GtkCellRendererText" id="nativeNameRenderer">
                                     <property name="xalign">0.10000000149011612</property>
-                                    <property name="font">Cantarell 12</property>
+                                    <property name="font">Noto Sans 12</property>
                                   </object>
                                   <attributes>
                                     <attribute name="markup">0</attribute>
@@ -164,7 +164,7 @@
                                   <object class="GtkCellRendererText" id="englishNameRenderer">
                                     <property name="xalign">0.8999999761581421</property>
                                     <property name="ellipsize">end</property>
-                                    <property name="font">Cantarell Italic 14</property>
+                                    <property name="font">Noto Sans Italic 14</property>
                                     <property name="foreground">gray</property>
                                   </object>
                                   <attributes>
@@ -245,7 +245,7 @@
                                 <property name="sort_column_id">0</property>
                                 <child>
                                   <object class="GtkCellRendererText" id="nativeNameRenderer1">
-                                    <property name="font">Cantarell 12</property>
+                                    <property name="font">Noto Sans 12</property>
                                   </object>
                                   <attributes>
                                     <attribute name="markup">0</attribute>


### PR DESCRIPTION
Resolves: https://redhat.atlassian.net/browse/INSTALLER-4826

<img width="2009" height="1266" alt="Screenshot From 2026-07-29 17-18-03" src="https://github.com/user-attachments/assets/e287379d-0993-4463-9b0a-47db50543b80" />
<img width="1926" height="1256" alt="Screenshot From 2026-07-29 17-18-23" src="https://github.com/user-attachments/assets/6f711d68-0543-495e-9510-525125232f0c" />
<img width="1926" height="1256" alt="Screenshot From 2026-07-29 17-18-36" src="https://github.com/user-attachments/assets/1a864c28-5613-459d-bba8-4a1b94e262c2" />
<img width="1923" height="1214" alt="Screenshot From 2026-07-29 17-18-54" src="https://github.com/user-attachments/assets/16c60a10-c94d-44c2-912f-2ee838de122a" />
<img width="1916" height="1209" alt="Screenshot From 2026-07-29 17-27-51" src="https://github.com/user-attachments/assets/da5993c7-75e5-43b1-ad92-6644a2e58bf4" />
<img width="1916" height="1209" alt="Screenshot From 2026-07-29 17-27-58" src="https://github.com/user-attachments/assets/5c3648f1-3d5a-45e9-ac1b-e4f3411a2235" />
<img width="1916" height="1209" alt="Screenshot From 2026-07-29 17-28-12" src="https://github.com/user-attachments/assets/6fc3f506-55a9-484e-9821-56ae54a633ec" />
<img width="1916" height="1209" alt="Screenshot From 2026-07-29 17-28-18" src="https://github.com/user-attachments/assets/cf92685f-4b6a-478a-a6fe-77db885a9544" />
<img width="1916" height="1209" alt="Screenshot From 2026-07-29 17-28-27" src="https://github.com/user-attachments/assets/06aeb0de-b498-458e-a626-7efb15558c3e" />
<img width="1916" height="1209" alt="Screenshot From 2026-07-29 17-28-42" src="https://github.com/user-attachments/assets/725c7fd2-1ba6-41a2-9e17-7942f73706df" />
<img width="1933" height="1194" alt="Screenshot From 2026-07-29 17-30-54" src="https://github.com/user-attachments/assets/df2409b9-d52c-4392-a0f1-cfe88121aff4" />
<img width="1933" height="1194" alt="Screenshot From 2026-07-29 17-36-33" src="https://github.com/user-attachments/assets/7586d337-4892-45e5-9dd6-1f88bd417a52" />
