### PR TITLE
feat(boss): persist pending errors for client reconnection

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -17,6 +17,10 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import os
+from collections import namedtuple
+from pathlib import Path
+
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.dbus import DBus
 from pyanaconda.core.signal import Signal
@@ -40,6 +44,9 @@ log = get_module_logger(__name__)
 __all__ = ["Boss"]
 
 
+InitialState = namedtuple("InitialState", ["status", "error_message", "error_type"])
+
+
 class Boss(Service):
     """The Boss service."""
 
@@ -50,8 +57,12 @@ class Boss(Service):
         self._install_manager = InstallManager()
         self._installation_task = None
         self.active_installation_task_changed = Signal()
-        self._installation_status = InstallationStatus.NOT_STARTED
+        initial_state = self._load_initial_state()
+        self._installation_status = initial_state.status
         self.installation_status_changed = Signal()
+        self._pending_error_message = initial_state.error_message
+        self._pending_error_type = initial_state.error_type
+        self.pending_error_changed = Signal()
 
         self._module_manager.module_observers_changed.connect(
             self._kickstart_manager.on_module_observers_changed
@@ -59,6 +70,21 @@ class Boss(Service):
 
         self._module_manager.module_observers_changed.connect(
             self._install_manager.on_module_observers_changed
+        )
+
+    ERROR_FILE_NAME = "installation-error-msg"
+
+    @property
+    def _error_file(self) -> Path:
+        rundir = Path(os.environ.get("ANACONDA_RUN_DIR", "/run/anaconda"))
+        return rundir / self.ERROR_FILE_NAME
+
+    def _load_initial_state(self):
+        err = self._error_file.read_text() if self._error_file.exists() else ""
+        return InitialState(
+            status=InstallationStatus.FAILED if err else InstallationStatus.NOT_STARTED,
+            error_message=err,
+            error_type=InstallationErrorDialogType.FATAL_ERROR if err else "",
         )
 
     def publish(self):
@@ -118,6 +144,26 @@ class Boss(Service):
         """
         return self._installation_status
 
+    @property
+    def pending_error_message(self):
+        """The error message awaiting a UI response or describing a fatal error.
+
+        Non-empty when a non-critical error dialog is waiting for the user,
+        or when a fatal error has occurred. A reconnecting client should
+        read this to discover unhandled errors.
+
+        :return: an error message string or empty string
+        """
+        return self._pending_error_message
+
+    @property
+    def pending_error_type(self):
+        """The type of the pending error (e.g. YES_NO or FATAL_ERROR).
+
+        :return: an InstallationErrorDialogType value or empty string
+        """
+        return self._pending_error_type
+
     def get_installation_task(self):
         """Get the active installation task, if any.
 
@@ -165,6 +211,9 @@ class Boss(Service):
         self._installation_task.error_raised_signal.connect(
             self._on_error_raised
         )
+        self._installation_task.error_response_signal.connect(
+            self._on_error_response
+        )
 
         return [self._installation_task]
 
@@ -186,6 +235,37 @@ class Boss(Service):
 
         self._installation_status = status
         self.installation_status_changed.emit()
+
+    def _set_pending_error(self, error_message, error_type):
+        """Store an error and notify listeners.
+
+        For fatal errors, also persist the message to disk (so it
+        survives a Boss restart) and transition to FAILED.
+        Non-critical errors are stored but do not change the status.
+        """
+        self._pending_error_message = error_message
+        self._pending_error_type = error_type
+        if error_type == InstallationErrorDialogType.FATAL_ERROR:
+            self._persist_error_message(error_message)
+            self._set_installation_status(InstallationStatus.FAILED)
+        self.pending_error_changed.emit()
+
+    def _persist_error_message(self, error_message):
+        self._error_file.write_text(error_message)
+
+    def _on_error_response(self, should_continue):
+        """Handle the user's response to a non-critical error.
+
+        On continue: clear the pending error so the UI returns to normal.
+        On abort: do nothing here — the task thread will fail and
+        _thread_failed_callback will emit the actual fatal error
+        with the proper exception message (not the non-critical dialog text).
+        """
+        if should_continue:
+            log.info("User chose to continue past the error.")
+            self._set_pending_error(error_message="", error_type="")
+        else:
+            log.info("User chose to abort.")
 
     def _on_installation_started(self):
         """Handle the installation task start."""
@@ -210,8 +290,7 @@ class Boss(Service):
         :param error_type: the error type string
         """
         log.info("Error raised: type=%s, message=%s", error_type, message[:80])
-        if error_type == InstallationErrorDialogType.FATAL_ERROR:
-            self._set_installation_status(InstallationStatus.FAILED)
+        self._set_pending_error(error_message=message, error_type=error_type)
 
     def _on_installation_stopped(self):
         """Handle the installation task stop."""

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -56,6 +56,14 @@ class BossInterface(InterfaceTemplate):
             "InstallationStatus",
             self.implementation.installation_status_changed
         )
+        self.watch_property(
+            "PendingErrorMessage",
+            self.implementation.pending_error_changed
+        )
+        self.watch_property(
+            "PendingErrorType",
+            self.implementation.pending_error_changed
+        )
 
     @property
     def ActiveInstallationTask(self) -> Str:
@@ -86,6 +94,29 @@ class BossInterface(InterfaceTemplate):
         :return: an integer value of InstallationStatus
         """
         return self.implementation.installation_status.value
+
+    @property
+    def PendingErrorMessage(self) -> Str:
+        """The pending error message awaiting a response.
+
+        Non-empty when an error dialog is waiting for the user
+        to respond, or when a fatal error has occurred. A
+        reconnecting client should read this to discover unhandled errors.
+
+        :return: an error message string or empty string
+        """
+        return self.implementation.pending_error_message
+
+    @property
+    def PendingErrorType(self) -> Str:
+        """The type of the pending error.
+
+        Possible values: "yesno" (non-critical, awaiting user decision),
+        "error" (fatal), or "" (no pending error).
+
+        :return: an error type string or empty string
+        """
+        return self.implementation.pending_error_type
 
     def GetModules(self) -> List[BusName]:
         """Get service names of running modules.

--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -332,7 +332,9 @@ class RunInstallationTask(InstallationTask):
         self._install_manager = install_manager
         self._error_raised_signal = Signal()
         self._error_response_event = Event()
+        self._error_response_signal = Signal()
         self._error_should_continue = False
+        self._fatal_error_already_emitted = False
 
     @property
     def error_raised_signal(self):
@@ -342,12 +344,22 @@ class RunInstallationTask(InstallationTask):
         """
         return self._error_raised_signal
 
+    @property
+    def error_response_signal(self):
+        """Signal emitted when the user responds to a pending error.
+
+        Carries a boolean: True to continue, False to abort.
+        """
+        return self._error_response_signal
+
     def _show_dialog(self, message, dialog_type):
         """Emit error signal and block until UI responds.
 
         :param message: the error message to display
         :param dialog_type: the type of dialog to show
         """
+        if dialog_type == InstallationErrorDialogType.FATAL_ERROR:
+            self._fatal_error_already_emitted = True
         self._error_response_event.clear()
         self._error_raised_signal.emit(message, dialog_type.value)
         self._error_response_event.wait()
@@ -360,6 +372,21 @@ class RunInstallationTask(InstallationTask):
         """
         self._error_should_continue = should_continue
         self._error_response_event.set()
+        self._error_response_signal.emit(should_continue)
+
+    def _thread_failed_callback(self, *exc_info):
+        """Emit the fatal error before reporting the failure.
+
+        Skips emission if a fatal error was already emitted by _show_dialog
+        to avoid overwriting the original error message (e.g. ScriptError
+        emits via _show_dialog, then sys.exit triggers this callback with
+        a less informative SystemExit message).
+        """
+        if not self._fatal_error_already_emitted:
+            self._error_raised_signal.emit(
+                str(exc_info[1]), InstallationErrorDialogType.FATAL_ERROR
+            )
+        super()._thread_failed_callback(*exc_info)
 
     @property
     def name(self):

--- a/pyanaconda/modules/boss/installation.py
+++ b/pyanaconda/modules/boss/installation.py
@@ -361,7 +361,7 @@ class RunInstallationTask(InstallationTask):
         if dialog_type == InstallationErrorDialogType.FATAL_ERROR:
             self._fatal_error_already_emitted = True
         self._error_response_event.clear()
-        self._error_raised_signal.emit(message, dialog_type.value)
+        self._error_raised_signal.emit(message, dialog_type)
         self._error_response_event.wait()
         return self._error_should_continue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,3 +13,12 @@ def change_working_directory():
     # this fixture allows calling pytest from project root
     tests_dir = Path(__file__).resolve().parent
     os.chdir(tests_dir)
+
+
+@pytest.fixture
+def anaconda_run_dir(tmp_path, monkeypatch):
+    """Set up an isolated /run/anaconda directory for tests."""
+    rundir = tmp_path / "rundir"
+    rundir.mkdir()
+    monkeypatch.setenv("ANACONDA_RUN_DIR", str(rundir))
+    return rundir

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -45,7 +45,7 @@ class AnacondaLintConfig(CensorshipConfig):
         ]
 
         self.false_positives = [
-            FalsePositive(r"W0201.*tests/.*\.setup_method: Attribute .* defined outside __init__"),
+            FalsePositive(r"W0201.*tests/.*\._?setup(?:_method)?: Attribute .* defined outside __init__"),
             FalsePositive(r"^E1101.*: Instance of 'KickstartSpecificationHandler' has no '.*' member$"),
 
             # TODO: BlockDev introspection needs to be added to pylint to handle these

--- a/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/boss/test_boss.py
@@ -42,10 +42,11 @@ from tests.unit_tests.pyanaconda_tests import (
 class BossInterfaceTestCase:
     """Test DBus interface for the Boss module."""
 
-    def setup_method(self):
-        """Set up the module."""
+    @pytest.fixture(autouse=True)
+    def _setup(self, anaconda_run_dir):
         self.module = Boss()
         self.interface = BossInterface(self.module)
+        self._error_file = self.module._error_file
 
     def _add_module(self, service_name, available=True, proxy=None):
         """Add a DBus module."""
@@ -333,12 +334,18 @@ class BossInterfaceTestCase:
         assert self.module.installation_status == InstallationStatus.SUCCEEDED
         callback.assert_called()
 
-    @pytest.mark.parametrize("error_type", [
-        InstallationErrorDialogType.FATAL_ERROR,
-        InstallationErrorDialogType.FATAL_ERROR.value,
-    ])
+    @pytest.mark.parametrize(
+        "error_type,expected_status,expected_status_callback_count",
+        [
+            (InstallationErrorDialogType.FATAL_ERROR, InstallationStatus.FAILED, 1),
+            (InstallationErrorDialogType.FATAL_ERROR.value, InstallationStatus.FAILED, 1),
+            (InstallationErrorDialogType.YES_NO, InstallationStatus.RUNNING, 0),
+        ],
+    )
     @patch_dbus_publish_object
-    def test_installation_status_failed(self, publisher, error_type):
+    def test_installation_status_on_error(
+        self, publisher, error_type, expected_status, expected_status_callback_count
+    ):
         """Test that InstallationStatus changes to FAILED on fatal error."""
         status_callback = Mock()
         self.module.installation_status_changed.connect(status_callback)
@@ -352,9 +359,12 @@ class BossInterfaceTestCase:
 
         task.error_raised_signal.emit("Something went wrong", error_type)
 
-        assert self.interface.InstallationStatus == InstallationStatus.FAILED
-        assert self.module.installation_status == InstallationStatus.FAILED
-        status_callback.assert_called()
+        assert self.interface.InstallationStatus == expected_status
+        assert self.module.installation_status == expected_status
+        assert status_callback.call_count == expected_status_callback_count
+
+        assert self.interface.PendingErrorMessage == "Something went wrong"
+        assert self.interface.PendingErrorType == error_type
 
     @patch_dbus_publish_object
     def test_yesno_error_does_not_set_failed(self, publisher):
@@ -366,6 +376,8 @@ class BossInterfaceTestCase:
         self.module._on_installation_started()
         task.error_raised_signal.emit("Non-fatal error", InstallationErrorDialogType.YES_NO)
 
+        assert self.interface.PendingErrorMessage == "Non-fatal error"
+        assert self.interface.PendingErrorType == InstallationErrorDialogType.YES_NO
         assert self.module.installation_status == InstallationStatus.RUNNING
 
     @patch_dbus_publish_object
@@ -409,6 +421,114 @@ class BossInterfaceTestCase:
         assert self.module.installation_status == expected_status
         assert self.module._installation_task is None
 
+    def test_persist_error_message_writes_file(self):
+        """Test that a fatal error is persisted to disk."""
+        self.module._on_installation_started()
+        self.module._set_pending_error("disk full", InstallationErrorDialogType.FATAL_ERROR)
+
+        assert self._error_file.exists()
+        assert self._error_file.read_text() == "disk full"
+
+    def test_non_fatal_error_does_not_persist(self):
+        """Test that a YES_NO error is not persisted to disk."""
+        self.module._on_installation_started()
+        self.module._set_pending_error("ignore this?", InstallationErrorDialogType.YES_NO)
+
+        assert not self._error_file.exists()
+
+    def test_on_error_response_continue_clears_pending(self):
+        """Test that continuing past an error clears the pending error."""
+        self.module._on_installation_started()
+        self.module._set_pending_error("ignore this?", InstallationErrorDialogType.YES_NO)
+
+        callback = Mock()
+        self.module.pending_error_changed.connect(callback)
+
+        self.module._on_error_response(True)
+
+        assert self.interface.PendingErrorMessage == ""
+        assert self.interface.PendingErrorType == ""
+        callback.assert_called()
+
+    def test_on_error_response_abort_preserves_pending(self):
+        """Test that aborting does not overwrite the pending error."""
+        self.module._on_installation_started()
+        self.module._set_pending_error("ignore this?", InstallationErrorDialogType.YES_NO)
+
+        self.module._on_error_response(False)
+
+        assert self.interface.PendingErrorMessage == "ignore this?"
+
+    @patch_dbus_publish_object
+    def test_error_response_signal_wired_to_boss(self, publisher):
+        """Test that the task's error_response_signal is connected to Boss."""
+        task_paths = self.interface.InstallWithTasks()
+        task_proxy = check_task_creation(task_paths[0], publisher, RunInstallationTask)
+        task = task_proxy.implementation
+
+        self.module._on_installation_started()
+        self.module._set_pending_error("ignore?", InstallationErrorDialogType.YES_NO)
+
+        task.error_response_signal.emit(True)
+
+        assert self.interface.PendingErrorMessage == ""
+
+    def test_pending_error_changed_signal_emitted(self):
+        """Test that pending_error_changed fires on error."""
+        callback = Mock()
+        self.module.pending_error_changed.connect(callback)
+
+        self.module._on_installation_started()
+        self.module._set_pending_error("boom", InstallationErrorDialogType.FATAL_ERROR)
+
+        callback.assert_called()
+
+    @patch_dbus_publish_object
+    def test_thread_failed_callback_emits_when_no_prior_fatal(self, publisher):
+        """Test that _thread_failed_callback emits error when no prior fatal."""
+        task_paths = self.interface.InstallWithTasks()
+        task_proxy = check_task_creation(task_paths[0], publisher, RunInstallationTask)
+        task = task_proxy.implementation
+
+        callback = Mock()
+        task.error_raised_signal.connect(callback)
+
+        task._thread_failed_callback(None, RuntimeError("unexpected crash"), None)
+
+        callback.assert_called_once()
+        msg, error_type = callback.call_args[0]
+        assert "unexpected crash" in msg
+        assert error_type == InstallationErrorDialogType.FATAL_ERROR
+
+    @patch_dbus_publish_object
+    def test_thread_failed_callback_suppressed_after_fatal(self, publisher):
+        """Test that _thread_failed_callback skips emit if fatal already emitted."""
+        task_paths = self.interface.InstallWithTasks()
+        task_proxy = check_task_creation(task_paths[0], publisher, RunInstallationTask)
+        task = task_proxy.implementation
+
+        task._fatal_error_already_emitted = True
+
+        callback = Mock()
+        task.error_raised_signal.connect(callback)
+
+        task._thread_failed_callback(None, SystemExit(0), None)
+
+        callback.assert_not_called()
+
     def test_quit(self):
         """Test Quit."""
         assert self.interface.Quit() is None
+
+
+def test_load_initial_state_with_error_file(anaconda_run_dir):
+    """Test that Boss restores FAILED state from a persisted error file."""
+    (anaconda_run_dir / Boss.ERROR_FILE_NAME).write_text("disk full")
+
+    boss = Boss()
+    interface = BossInterface(boss)
+
+    assert boss.installation_status == InstallationStatus.FAILED
+    assert interface.InstallationStatus == InstallationStatus.FAILED
+    assert interface.PendingErrorMessage == "disk full"
+    assert interface.PendingErrorType == InstallationErrorDialogType.FATAL_ERROR


### PR DESCRIPTION
Expose PendingErrorMessage and PendingErrorType on BossInterface
so a reconnecting client can discover unhandled errors.

Resolves: INSTALLER-4815
Assisted-by: Claude Opus 4.6