### PR TITLE
tests: Allow adding custom RPMs to the CI container

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -89,6 +89,8 @@ CONTAINER_TEST_ARGS ?= $(shell grep -q ID=ubuntu /etc/os-release && echo --secur
 CONTAINER_REGISTRY ?= quay.io
 # Add additional args to the existing ones to container engine
 CONTAINER_ADD_ARGS ?=
+# Custom RPM packages to install in CI container (space-separated list of .rpm file paths)
+EXTRA_RPMS ?=
 # Glade was removed in RHEL from RHEL-10
 CONTAINER_CONFIGURE_ARGS ?= $(shell test "$(CI_TAG)" = "fedora-eln" -o "$(CI_TAG)" = "rhel-10" && echo "--env=CONFIGURE_ARGS=--disable-glade")
 
@@ -180,6 +182,10 @@ container-release:
 anaconda-ci-build:
 	TEMP=$$(mktemp -t -d anaconda-ci-build.XXXX) && \
 	cp $(srcdir)/anaconda.spec.in $(CI_DOCKERFILE)/* $$TEMP/ && \
+	mkdir $$TEMP/rpms/ && \
+	if [ -n "$(EXTRA_RPMS)" ]; then \
+		cp $(EXTRA_RPMS) $$TEMP/rpms/; \
+	fi && \
 	echo "Build dir is $$TEMP" && \
 	$(CONTAINER_ENGINE) build \
 	$(CONTAINER_BUILD_ARGS) \

--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -28,6 +28,7 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 # The anaconda.spec.in is in the repository root. This file will be copied automatically here if
 # the build is invoked by Makefile.
 COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
+COPY rpms/ /root/rpms/
 
 # Replace standalone systemd package with systemd as these are conflicting
 RUN set -ex; \
@@ -75,6 +76,11 @@ RUN set -ex; \
 
 RUN pip install --no-cache-dir --upgrade pip; \
   pip install --no-cache-dir -r /root/requirements.txt
+
+# Install custom RPM packages if provided
+RUN if ls /root/rpms/*.rpm 1>/dev/null 2>&1; then \
+  dnf install -y /root/rpms/*.rpm; \
+fi
 
 RUN mkdir /anaconda
 

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -23,6 +23,11 @@ or you can build your own image.
 
     make -f Makefile.am anaconda-ci-build
 
+To include extra RPM packages in the container (e.g. custom builds of
+dependencies), pass them via the ``EXTRA_RPMS`` variable::
+
+    make -f Makefile.am anaconda-ci-build EXTRA_RPMS="/path/to/custom-pkg.rpm /path/to/another.rpm"
+
 Then you are free to run the tests without dependency installation by
 running::
 


### PR DESCRIPTION
Add an EXTRA_RPMS variable to the anaconda-ci-build Make target that accepts a space-separated list of .rpm file paths to install in the CI container image.

-----

Just a small change that helped me with testing my recent changes that require new build of pykickstart.