### PR TITLE
Add webui dependencies to the boot.iso - no Firefox

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -44,6 +44,7 @@ Source0: https://github.com/rhinstaller/%{name}/releases/download/%{name}-%{vers
 %define utillinuxver 2.15.1
 %define rpmostreever 2023.2
 %define s390utilscorever 2.31.0
+%define cockpitver 275
 
 BuildRequires: libtool
 BuildRequires: gettext-devel >= %{gettextver}
@@ -300,6 +301,22 @@ Requires: libselinux-utils
 Requires: selinux-policy-targeted
 Requires: policycoreutils
 Requires: policycoreutils-python-utils
+# Add Web UI depedencies to both make Web UI debuging easier
+# as well as to star preparing the boot.iso for the eventual
+# switch to Web UI as default.
+# NOTE: Once we can pull in the Web UI directly, then
+# we should be able to simplify this section.
+Requires: cockpit-storaged
+Requires: cockpit-networkmanager
+Requires: cockpit-bridge >= %{cockpitver}
+Requires: cockpit-ws >= %{cockpitver}
+Requires: anaconda-core  >= %{anacondacorever}
+Requires: python3-bugzilla
+%endif
+%if 0%{?fedora}
+Requires: system-logos
+%endif
+BuildRequires: desktop-file-utils
 
 %description install-img-deps
 The anaconda-install-img-deps metapackage lists all boot.iso installation


### PR DESCRIPTION
Eventually we will just add the anaconda-webui package at a dependency and that will pull in the Web UI deps.

But for now, lets just add the Web UI dependencies. This will make both debugging during development as well as testing easier as we will be able to finally drop many hack we have now in place to inject the missing Web UI packages to the boot.iso.

This will increase the size of the boot.iso slightly, but it should be worth the speedup and simplification this will bring.

**NOTE** Variant of the PR that does not pull in Firefox. Lets see how it manifests on the image size.