### PR TITLE
fix(ostree): set bootprefix to true

### DIFF
--- a/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
+++ b/pyanaconda/modules/payloads/payload/rpm_ostree/installation.py
@@ -929,6 +929,13 @@ class DeployOSTreeTask(Task):
 
         safe_exec_program(
             "ostree",
+            ["config",
+             "--repo=" + self._physroot + "/ostree/repo",
+             "set", "sysroot.bootprefix", "true"]
+        )
+
+        safe_exec_program(
+            "ostree",
             ["admin",
              "--sysroot=" + self._physroot,
              "os-init",


### PR DESCRIPTION
~OSTree may generate kernel/initrd paths without the /boot prefix when /boot is a directory on the root filesystem instead of a separate partition, causing GRUB to fail with "file not found".~

Check conversations for updates with this PR

Assisted-by: Opus 4.6
Resolves: INSTALLER-4829