### PR TITLE
Fix a shutdown (Quit) race condition

### DIFF
--- a/pyanaconda/modules/common/base/base.py
+++ b/pyanaconda/modules/common/base/base.py
@@ -110,10 +110,13 @@ class Service(BaseModule):
         log.debug("Start the loop.")
         self._loop.run()
 
+    def _deferred_stop(self):
+        DBus.disconnect()
+        self.loop.quit()
+
     def stop(self):
         """Stop the loop."""
-        DBus.disconnect()
-        Timer().timeout_sec(1, self.loop.quit)
+        Timer().timeout_sec(1, self._deferred_stop)
 
     def set_locale(self, locale):
         """Set the locale for the module.


### PR DESCRIPTION
During the shutdown process in the stop method of the modules, the DBus.disconnect() call was executed too early, leading to a race condition:

The DBus connection was torn down while pending method invocations were still being processed. As a result, attempts to handle errors or finalize ongoing calls (e.g., Quit) could reference invalid or cleaned-up objects, leading to crashes.

This issue became apparent after changes in pygobject's DBus handling introduced stricter cleanup of invocation objects upon disconnection. The updated behavior exposed the underlying problem in the shutdown sequence.

In this fix, suggested by Arjan Molenaar, the DBus.disconnect() call is to the same point where the loop is scheduled to quit.

Resolves rhbz#2329587

Fix suggested in https://gitlab.gnome.org/GNOME/pygobject/-/work_items/764#note_2821777
(as a fixup of https://github.com/rhinstaller/anaconda/pull/6059)