### PR TITLE
tests: Temporarily ignore stratis kickstart commands

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
+++ b/tests/unit_tests/pyanaconda_tests/test_kickstart_specification.py
@@ -461,6 +461,8 @@ class ModuleSpecificationsTestCase(unittest.TestCase):
 
     # Names of the kickstart commands and data that should be temporarily ignored.
     IGNORED_NAMES = {
+        "stratisfs",
+        "stratispool",
     }
 
     # Names of shared kickstart commands and data that should be temporarily ignored.


### PR DESCRIPTION
Newly added stratisfs and stratispool kickstart commands are causing tests to fail. Support for these is being added in #7215, but it will take some time to get this merged and meanwhile the failing tests are blocking CI container refresh.

