### PR TITLE
Replace usage of MD5 password hash in tests

### DIFF
--- a/tests/unit_tests/pyanaconda_tests/core/test_user_create.py
+++ b/tests/unit_tests/pyanaconda_tests/core/test_user_create.py
@@ -316,7 +316,7 @@ class UserCreateTest(unittest.TestCase):
         assert crypt_r.crypt(password, shadow_fields[1][1:]) == shadow_fields[1][1:]
 
         # Try an encrypted password
-        password = crypt_r.crypt("testpass", crypt_r.METHOD_MD5)
+        password = crypt_r.crypt("testpass", crypt_r.METHOD_SHA512)
         users.set_root_password(password, is_crypted=True, root=self.tmpdir)
         shadow_fields = self._readFields("/etc/shadow", "root")
         assert password == shadow_fields[1]


### PR DESCRIPTION
Shadow utils 4.20 drops any remaining support for MD5 password hashes, so attempts to use MD5 for password hashing in Anaconda tests will fail.

Switch to SHA512 instead.