### PR TITLE
feat(webui): add authentication support for remote access

### DIFF
--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -112,6 +112,10 @@ Set password for the RDP session. To enable RDP access, also use the rdp and rdp
 
 rdp.password
 Set password for the RDP session. To enable RDP access, also use the rdp and rdp.username options.
+
+webui.remote
+Enable remote access to the Anaconda WebUI. Requires authentication by default.
+
 keymap
 Keyboard layout to use during installation and on the installed system. Valid KEYMAP values
 are those which can be used for the keyboard kickstart command.

--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -116,6 +116,16 @@ Set password for the RDP session. To enable RDP access, also use the rdp and rdp
 webui.remote
 Enable remote access to the Anaconda WebUI. Requires authentication by default.
 
+webui.remote.noauth
+Disable authentication for remote WebUI access. When set, remote connections
+to the Anaconda WebUI are allowed without a password. This option is meant
+only for testing/debugging purposes and should be avoided in real installations
+for security concerns.
+
+webui.remote.pin
+Set the PIN for remote WebUI access. Required when inst.webui.remote is set
+and inst.webui.remote.noauth is not set.
+
 keymap
 Keyboard layout to use during installation and on the installed system. Valid KEYMAP values
 are those which can be used for the keyboard kickstart command.

--- a/docs/user-guide/boot-options.rst
+++ b/docs/user-guide/boot-options.rst
@@ -554,6 +554,24 @@ inst.rdp.password
 Set password for the RDP session. To enable RDP access, also use the
 ``inst.rdp`` and ``inst.rdp.username`` boot options.
 
+.. inst.webui.remote.noauth:
+
+inst.webui.remote.noauth
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Disable authentication for remote WebUI access. When ``inst.webui.remote`` is set,
+authentication is required by default. ATTENTION: this option exists mostly for debugging
+purposes and its use is NOT ENCOURAGED for security concerns. Despite these warnings, if
+you decide to use it, make sure to only do it in a secure network.
+
+.. inst.webui.remote.pin:
+
+inst.webui.remote.pin
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Set the pin for remote access to the Anaconda WebUI. Required when
+``inst.webui.remote`` is set and ``inst.webui.remote.noauth`` is not set.
+
 .. inst.xdriver:
 
 inst.xdriver

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -216,7 +216,8 @@ class Anaconda:
             self._intf = CockpitUserInterface(
                 None,
                 self.payload,
-                self.opts.webui_remote
+                self.opts.webui_remote,
+                self.opts.webui_remote_noauth
             )
 
             # needs to be refreshed now we know if gui or tui will take place

--- a/pyanaconda/anaconda.py
+++ b/pyanaconda/anaconda.py
@@ -30,7 +30,6 @@ from pyanaconda.core.constants import (
     PAYLOAD_TYPE_RPM_OSTREE,
     DisplayModes,
 )
-from pyanaconda.core.kernel import kernel_arguments
 from pyanaconda.core.path import open_with_perm
 from pyanaconda.core.startup.dbus_launcher import AnacondaDBusLauncher
 from pyanaconda.modules.common.constants.services import PAYLOADS
@@ -217,7 +216,7 @@ class Anaconda:
             self._intf = CockpitUserInterface(
                 None,
                 self.payload,
-                "webui.remote" in kernel_arguments
+                self.opts.webui_remote
             )
 
             # needs to be refreshed now we know if gui or tui will take place

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -516,6 +516,12 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("rdp.password"))
     ap.add_argument("--webui.remote", action="store_true", default=False, dest="webui_remote",
                     help=help_parser.help_text("webui.remote"))
+    ap.add_argument("--webui.remote.noauth", action="store_true", default=False,
+                    dest="webui_remote_noauth",
+                    help=help_parser.help_text("webui.remote.noauth"))
+    ap.add_argument("--webui.remote.pin", default="", metavar="REMOTE_PIN",
+                    dest="webui_remote_pin",
+                    help=help_parser.help_text("webui.remote.pin"))
 
     # Language
     ap.add_argument("--keymap", metavar="KEYMAP", help=help_parser.help_text("keymap"))

--- a/pyanaconda/argument_parsing.py
+++ b/pyanaconda/argument_parsing.py
@@ -514,6 +514,8 @@ def getArgumentParser(version_string, boot_cmdline=None):
                     help=help_parser.help_text("rdp.username"))
     ap.add_argument("--rdp.password", default="", metavar="PASSWORD", dest="rdp_password",
                     help=help_parser.help_text("rdp.password"))
+    ap.add_argument("--webui.remote", action="store_true", default=False, dest="webui_remote",
+                    help=help_parser.help_text("webui.remote"))
 
     # Language
     ap.add_argument("--keymap", metavar="KEYMAP", help=help_parser.help_text("keymap"))

--- a/pyanaconda/core/constants.py
+++ b/pyanaconda/core/constants.py
@@ -72,6 +72,8 @@ WEBUI_VIEWER_PID_FILE = "/run/anaconda/webui_script.pid"
 # flag file for Web UI to signalize that Anaconda backend is ready to be used
 # FIXME: Web UI should monitor the initialization itself
 BACKEND_READY_FLAG_FILE = "/run/anaconda/backend_ready"
+# Remote authentication PIN for WebUI
+WEBUI_REMOTE_PIN_FILE = "/run/anaconda/remote-pin"
 
 # NOTE: this should be LANG_TERRITORY.CODESET, e.g. en_US.UTF-8
 DEFAULT_LANG = "en_US.UTF-8"

--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -37,6 +37,7 @@ from pyanaconda.anaconda_loggers import get_module_logger, get_stdout_logger
 from pyanaconda.core import constants, hw, util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.i18n import _
+from pyanaconda.core.path import open_with_perm
 from pyanaconda.core.process_watchers import WatchProcesses
 from pyanaconda.flags import flags
 from pyanaconda.gnome_remote_desktop import GRDServer
@@ -423,6 +424,8 @@ def setup_display(anaconda, options):
         grd_server.rdp_password = rdp_creds.password
         grd_server.start_grd_rdp()
 
+    _setup_webui_remote_auth(options)
+
     # with Wayland running we can initialize the UI interface
     anaconda.initialize_interface()
 
@@ -442,3 +445,31 @@ def _set_gui_mode_on_rdp(anaconda, use_rdp):
         log.info("RDP requested via RDP question, switching Anaconda to GUI mode.")
     anaconda.display_mode = constants.DisplayModes.GUI
     flags.use_rd = use_rdp
+
+
+def _setup_webui_remote_auth(options):
+    """Set up authentication for remote WebUI access.
+
+    Must be called before anaconda.initialize_interface(), which triggers
+    webui-cockpit-ws.service and its ExecStartPre conf merge.
+    """
+    if not options.webui_remote:
+        return
+
+    if options.webui_remote_noauth and options.webui_remote_pin:
+        msg = "inst.webui.remote.noauth and inst.webui.remote.pin are mutually exclusive"
+        log.critical(msg)
+        raise SystemExit(msg)
+
+    if options.webui_remote_noauth:
+        log.info("WebUI remote access: authentication disabled by inst.webui.remote.noauth")
+        return
+
+    if not options.webui_remote_pin:
+        msg = "inst.webui.remote requires inst.webui.remote.pin=<PIN> to be set."
+        log.critical(msg)
+        raise SystemExit(msg)
+
+    with open_with_perm(constants.WEBUI_REMOTE_PIN_FILE, "w", 0o600) as f:
+        f.write(options.webui_remote_pin)
+    log.info("WebUI remote auth: wrote PIN file %s", constants.WEBUI_REMOTE_PIN_FILE)

--- a/pyanaconda/ui/webui/__init__.py
+++ b/pyanaconda/ui/webui/__init__.py
@@ -56,8 +56,7 @@ class CockpitUserInterface(ui.UserInterface):
         :param payload: payload (usually dnf) reference
         :type payload: instance of payload handler
 
-        :param remote: if used run a cockpit-ws process to allow
-                       passwordless remote access to the anaconda-webui for easier testing.
+        :param remote: enable remote access to the anaconda-webui.
         :type remote: bool
 
         :param productTitle: the name of the product

--- a/pyanaconda/ui/webui/__init__.py
+++ b/pyanaconda/ui/webui/__init__.py
@@ -43,7 +43,7 @@ FIREFOX_THEME_LIVE = "live"
 class CockpitUserInterface(ui.UserInterface):
     """This is the main class for Cockpit user interface."""
 
-    def __init__(self, storage, payload, remote,
+    def __init__(self, storage, payload, remote, noauth=False,
                  productTitle="Anaconda",
                  quitMessage=QUIT_MESSAGE):
         """
@@ -59,6 +59,9 @@ class CockpitUserInterface(ui.UserInterface):
         :param remote: enable remote access to the anaconda-webui.
         :type remote: bool
 
+        :param noauth: disable authentication for remote access.
+        :type noauth: bool
+
         :param productTitle: the name of the product
         :type productTitle: str
 
@@ -72,6 +75,7 @@ class CockpitUserInterface(ui.UserInterface):
         super().__init__(storage, payload)
         self.productTitle = productTitle
         self.remote = remote
+        self.noauth = noauth
         self.quitMessage = quitMessage
         self._meh_interface = meh.ui.text.TextIntf()
         self._main_loop = None
@@ -131,11 +135,10 @@ class CockpitUserInterface(ui.UserInterface):
         profile_name = FIREFOX_THEME_DEFAULT
 
         try:
-            proc = startProgram(
-                ["/usr/libexec/anaconda/webui-desktop",
-                 "-t", profile_name, "-r", str(int(self.remote))],
-                reset_lang=False
-            )
+            cmd = ["/usr/libexec/anaconda/webui-desktop",
+                   "-t", profile_name, "-r", str(int(self.remote)),
+                   "-n", str(int(self.noauth))]
+            proc = startProgram(cmd, reset_lang=False)
 
             log.debug("cockpit web view has been started")
             with open(self._viewer_pid_file, "w") as f:

--- a/tests/unit_tests/pyanaconda_tests/test_argparse.py
+++ b/tests/unit_tests/pyanaconda_tests/test_argparse.py
@@ -310,6 +310,38 @@ class ArgparseTest(unittest.TestCase):
             ("r3", "http://url/3"),
         ]
 
+    def test_webui_remote_auth_options(self):
+        """Test webui.remote auth boot options defaults and CLI."""
+        opts = self._parseCmdline([])
+        assert opts.webui_remote_noauth is False
+        assert opts.webui_remote_pin == ""
+
+        opts = self._parseCmdline(['--webui.remote.noauth'])
+        assert opts.webui_remote_noauth is True
+
+        opts = self._parseCmdline(['--webui.remote.pin', 'mypin123'])
+        assert opts.webui_remote_pin == 'mypin123'
+
+    def test_webui_remote_auth_boot_cmdline(self):
+        """Test webui.remote auth via boot command line."""
+        boot_cmdline = KernelArguments.from_string("inst.webui.remote.noauth")
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        assert opts.webui_remote_noauth is True
+
+        boot_cmdline = KernelArguments.from_string("inst.webui.remote.pin=secret123")
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        assert opts.webui_remote_pin == "secret123"
+
+    def test_webui_remote_auth_requires_inst_prefix(self):
+        """Test webui.remote auth options are ignored without inst. prefix."""
+        boot_cmdline = KernelArguments.from_string("webui.remote.noauth")
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        assert opts.webui_remote_noauth is False
+
+        boot_cmdline = KernelArguments.from_string("webui.remote.pin=secret123")
+        opts = self._parseCmdline([], boot_cmdline=boot_cmdline)
+        assert opts.webui_remote_pin == ""
+
 
 # Pytest-style tests for remote-debugger argument parsing
 class RemoteDebuggerArgumentTest:

--- a/tests/unit_tests/pyanaconda_tests/ui/test_webui.py
+++ b/tests/unit_tests/pyanaconda_tests/ui/test_webui.py
@@ -39,9 +39,10 @@ class SimpleWebUITestCase(unittest.TestCase):
                                   pid_file,
                                   backend_file,
                                   pid_content="",
-                                  remote=0):
+                                  remote=0,
+                                  noauth=False):
         # prepare UI interface class
-        self.intf = CockpitUserInterface(None, None, remote)
+        self.intf = CockpitUserInterface(None, None, remote, noauth)
         self.intf._backend_ready_flag_file = backend_file
 
         open(backend_file, "wt").close()
@@ -165,7 +166,8 @@ class SimpleWebUITestCase(unittest.TestCase):
 
             mocked_startProgram.assert_called_once_with(
                 ["/usr/libexec/anaconda/webui-desktop",
-                 "-t", FIREFOX_THEME_DEFAULT, "-r", "1"],
+                 "-t", FIREFOX_THEME_DEFAULT, "-r", "1",
+                 "-n", "0"],
                 reset_lang=False
             )
             # Check if backend flag file was removed after finish of run method
@@ -181,6 +183,22 @@ class SimpleWebUITestCase(unittest.TestCase):
             mocked_log.error.assert_any_call("Test error")
 
 
+        # test with remote + noauth
+        mocked_startProgram.reset_mock()
+        mocked_process.reset_mock()
+        mocked_process.communicate.return_value = ("Noauth output", "")
+        mocked_startProgram.return_value = mocked_process
+        with tempfile.TemporaryDirectory() as fd:
+            pid_file = os.path.join(fd, "anaconda.pid")
+            backend_file = os.path.join(fd, "backend_ready")
+            self._prepare_for_live_testing(pid_file, backend_file, remote=1, noauth=True)
+            self.intf.run()
+
+            mocked_startProgram.assert_called_once_with(["/usr/libexec/anaconda/webui-desktop",
+                                                         "-t", FIREFOX_THEME_DEFAULT, "-r", "1",
+                                                         "-n", "1"],
+                                                        reset_lang=False)
+
         # test with disabled remote
         mocked_startProgram.reset_mock()
         mocked_process.reset_mock()
@@ -193,7 +211,8 @@ class SimpleWebUITestCase(unittest.TestCase):
             self.intf.run()
 
             mocked_startProgram.assert_called_once_with(["/usr/libexec/anaconda/webui-desktop",
-                                                         "-t", FIREFOX_THEME_DEFAULT, "-r", "0"],
+                                                         "-t", FIREFOX_THEME_DEFAULT, "-r", "0",
+                                                         "-n", "0"],
                                                         reset_lang=False)
             # check if backend flag file was removed after finish of run method
             assert os.path.exists(backend_file) is False


### PR DESCRIPTION
When inst.webui.remote is set, require either inst.webui.remote.password
or inst.webui.remote.noauth. Without one of these, anaconda exits with
an error.

When a password is provided, write it to /run/anaconda/remote-password
(mode 0600) so the cockpit-pin-auth script on the webui side can
validate remote connections against it.

Pass the noauth flag through CockpitUserInterface to webui-desktop (-n)
so the webui side can decide whether to generate the cockpit auth
drop-in configuration.

Resolves: INSTALLER-3373