### PR TITLE
boss: Change InstallationStatus from IntEnum to StrEnum

### DIFF
--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -82,16 +82,16 @@ class BossInterface(InterfaceTemplate):
         return TaskContainer.to_object_path(task)
 
     @property
-    def InstallationStatus(self) -> Int:
+    def InstallationStatus(self) -> Str:
         """The current installation status.
 
         Possible values:
-        1 - NOT_STARTED
-        2 - RUNNING
-        3 - SUCCEEDED
-        4 - FAILED
+        "not_started" - NOT_STARTED
+        "running"     - RUNNING
+        "succeeded"   - SUCCEEDED
+        "failed"      - FAILED
 
-        :return: an integer value of InstallationStatus
+        :return: a string value of InstallationStatus
         """
         return self.implementation.installation_status.value
 

--- a/pyanaconda/modules/common/constants/installation.py
+++ b/pyanaconda/modules/common/constants/installation.py
@@ -16,19 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from enum import IntEnum, StrEnum
+from enum import StrEnum
 
 
-class InstallationStatus(IntEnum):
+class InstallationStatus(StrEnum):
     """Status of the installation process tracked by the Boss module."""
 
-    # Values start at 1 so that all valid states are truthy — syntactic
-    # sugar for UI clients to distinguish "status loaded" from "not yet
-    # fetched" (null/undefined), e.g. ``if (status) { /* ready */ }``.
-    NOT_STARTED = 1
-    RUNNING = 2
-    SUCCEEDED = 3
-    FAILED = 4
+    NOT_STARTED = "not_started"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
 
 
 class InstallationErrorDialogType(StrEnum):


### PR DESCRIPTION
Replace integer values with descriptive string values for the InstallationStatus enum. Update the D-Bus property return type from Int to Str and its docstring accordingly.

Assisted-by: Claude Opus 4.6