### PR TITLE
Handle relocation of packaged repo configs to /usr/share/dnf5

### DIFF
--- a/data/anaconda_options.txt
+++ b/data/anaconda_options.txt
@@ -79,7 +79,7 @@ it takes precedence over all other methods of finding the install.img. Otherwise
 to find the install.img first on any existing CD, and then from the location given by repo.
 If only the stage2 option is given without repo, Anaconda will use whatever repos the installed
 system would have enabled by default for installation. For instance, an install of a Fedora release
-will attempt to use the Fedora mirrorlist given by /etc/yum.repos.d/fedora.repo from that release.
+will attempt to use the Fedora mirrorlist given by fedora.repo from that release.
 
 addrepo
 This option adds additional repositories to the installation. These repositories are used during

--- a/docs/user-guide/troubleshooting/common-bugs.rst
+++ b/docs/user-guide/troubleshooting/common-bugs.rst
@@ -493,7 +493,7 @@ Missing options of the ``repo`` command
 
         %pre
         # Generate the custom repo file.
-        cat >> /etc/anaconda.repos.d/custom.repo << EOF
+        cat >> /etc/yum.repos.d/custom.repo << EOF
 
         [my-custom-repo]
         name=My Custom Repository

--- a/pyanaconda/modules/payloads/constants.py
+++ b/pyanaconda/modules/payloads/constants.py
@@ -44,8 +44,8 @@ from pyanaconda.core.constants import (
 
 # Locations of repo files.
 DNF_REPO_DIRS = [
+    '/usr/share/dnf5/repos.d',
     '/etc/yum.repos.d',
-    '/etc/anaconda.repos.d'
 ]
 
 

--- a/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/payloads/payload/test_module_payload_dnf_manager.py
@@ -160,8 +160,8 @@ class DNFManagerTestCase(unittest.TestCase):
         assert config.installroot == "/mnt/sysroot"
         assert config.persistdir == "/mnt/sysroot/var/lib/dnf"
         assert config.reposdir == (
-            "/etc/yum.repos.d",
-            "/etc/anaconda.repos.d"
+            "/usr/share/dnf5/repos.d",
+            "/etc/yum.repos.d"
         )
         self._check_variables(releasever="rawhide")
 


### PR DESCRIPTION
In Fedora 45+, packaged repo configs are moved to /usr/share/dnf5:
https://fedoraproject.org/wiki/Changes/RelocateRpmRepoConfigsToUsr
This adjusts anaconda appropriately. We drop the use of /etc/anaconda.repos.d because it is no longer needed. It was originally introduced in c51389518415d9182f01757314c7cfa272534557 to solve a problem involving upgrades. anaconda has not handled upgrades since 2012. Other than that, we add the new directory to the DNF_REPO_DIRS constant and make a few minor tweaks in docs etc.