### PR TITLE
keyboard: filter out the custom XKB placeholder from the layout list

### DIFF
--- a/pyanaconda/ui/gui/spokes/keyboard.py
+++ b/pyanaconda/ui/gui/spokes/keyboard.py
@@ -154,6 +154,11 @@ class AddLayoutDialog(GUIObject):
         arranged_layouts = [DEFAULT_KEYBOARD] + sorted(common_layouts, key=self._sort_layout) + \
             sorted(list(set(available_layouts) - set(common_layouts)), key=self._sort_layout)
 
+        # 'custom' is an XKB placeholder with no keymap; skip it to avoid a
+        # crash when localed later tries to compile the layout.
+        arranged_layouts = [name for name in arranged_layouts
+            if keyboard.parse_layout_variant(name)[0] != "custom"]
+
         # we add arranged layouts in the treeview store
         gtk_batch_map(self._addLayout, arranged_layouts, args=(self._store,), batch_size=20)
 


### PR DESCRIPTION
The XKB custom layout (shown as "Undetermined (A user-defined custom Layout)") is only a runtime placeholder for user-defined keymaps and has no real symbols file. Selecting it crashes anaconda (XklWrapperError on activate, and later "Specified keymap cannot be compiled" from localed). Skip it in AddLayoutDialog so it is never offered as a selectable layout.

Fedora 42
After selecting 'Undefined (A user-defined custom layout)' in 'KEYBOARD LAYOUT', anaconda crashes.
<img width="1064" height="795" alt="image" src="https://github.com/user-attachments/assets/9e108be4-38ef-43e8-9e5b-17e930e57fe7" />
<img width="1090" height="780" alt="image" src="https://github.com/user-attachments/assets/0fa41e15-1ea4-459a-aa73-a56d2cafabb8" />

/usr/share/X11/xkb/rules/base.xml
<img width="1080" height="465" alt="image" src="https://github.com/user-attachments/assets/c9bab36e-9dab-450a-9173-44fff01eb730" />
