### PR TITLE
Bump petitboot firmware kernel version check to 5.19 (ppc64le)

### DIFF
--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -248,7 +248,7 @@ def verify_opal_compatibility(storage, constraints, report_error, report_warning
     if arch.get_arch() == "ppc64le" and arch.is_powernv():
         # Check the kernel version.
         version = _get_opal_firmware_kernel_version()
-        if _check_opal_firmware_kernel_version(version, "5.10"):
+        if _check_opal_firmware_kernel_version(version, "5.19"):
             return
 
         # Is /boot on XFS?

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage_checker.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/test_module_storage_checker.py
@@ -176,7 +176,7 @@ class StorageCheckerVerificationTestCase(unittest.TestCase):
         """Check verify_opal_compatibility with a newer firmware."""
         mocked_arch.get_arch.return_value = "ppc64le"
         mocked_arch.is_powernv.return_value = True
-        version_getter.return_value = "5.10.50-openpower1-p59fd803"
+        version_getter.return_value = "5.19.50-openpower1-p59fd803"
         self._verify_opal_compatibility(message=None)
 
     @patch.object(XFS, "mountable", new_callable=PropertyMock)


### PR DESCRIPTION
The minimum firmware kernel version check for petitboot on ppc64le
was set to 5.10, which no longer covers newer
petitboot versions. Increase the threshold to 5.19

Resolves: RHEL-155390