### PR TITLE
boss: Emit PropertiesChanged signals for Boss properties

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -63,6 +63,8 @@ class Boss(Service):
         self._pending_error_message = initial_state.error_message
         self._pending_error_type = initial_state.error_type
         self.pending_error_changed = Signal()
+        self.installation_status_changed.connect(self.module_properties_changed.emit)
+        self.pending_error_changed.connect(self.module_properties_changed.emit)
 
         self._module_manager.module_observers_changed.connect(
             self._kickstart_manager.on_module_observers_changed

--- a/pyanaconda/modules/boss/boss_interface.py
+++ b/pyanaconda/modules/boss/boss_interface.py
@@ -48,6 +48,7 @@ class BossInterface(InterfaceTemplate):
     def connect_signals(self):
         """Connect the signals."""
         super().connect_signals()
+        self.implementation.module_properties_changed.connect(self.flush_changes)
         self.watch_property(
             "ActiveInstallationTask",
             self.implementation.active_installation_task_changed


### PR DESCRIPTION
BossInterface inherits InterfaceTemplate which, unlike ModuleInterfaceTemplate, does not wire module_properties_changed to flush_changes. This means dasbus watch_property caches changes but never emits the DBus PropertiesChanged signal, so clients cannot react to InstallationStatus or PendingError updates.

Connect module_properties_changed to flush_changes in BossInterface and connect the individual property-change signals to module_properties_changed in Boss.

Related: INSTALLER-4825

Note: this needs to merged or rhinstaller/anaconda-webui#1412 will never pass
Note2: I could have changed the inheritance, set BossInterface to inherit from ModuleInterfaceTemplate, but I don't have the time to test if the consequences of the change would be bad.