### PR TITLE
spec: Use if/else rich dep to select anaconda-gui or anaconda-webui

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -70,8 +70,7 @@ BuildRequires: s390utils-devel
 BuildRequires: gdk-pixbuf2-devel
 BuildRequires: libxml2
 
-Requires: (anaconda-gui = %{version}-%{release} if (fedora-release-identity-server or fedora-release-identity-basic))
-Requires: (anaconda-webui or anaconda-gui)
+Requires: (anaconda-gui = %{version}-%{release} if (fedora-release-identity-server or fedora-release-identity-basic) else anaconda-webui)
 Requires: anaconda-tui = %{version}-%{release}
 
 %description


### PR DESCRIPTION
The previous `(anaconda-webui or anaconda-gui)` fallback was
non-deterministic - RPM's boolean `or` does not guarantee preference
order.

Image Builder was pulling anaconda-widgets (see
https://github.com/osbuild/image-builder/pull/2597), which is a
dependency of anaconda-gui, resulting in DNF resolving the `or` in
favor of anaconda-gui since it was partially satisfied.

Replace the two Requires lines with a single `if...else` rich
dependency: install anaconda-gui on Server and Everything (basic),
anaconda-webui on everything else.
