### PR TITLE
infra: disable fedora-cisco-openh264 repo

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -30,6 +30,12 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 COPY rpms/ /root/rpms/
 
+# FIXME: workaround — disable the fedora-cisco-openh264 repo so that freerdp falls back to
+# the stub openh264 in the main Fedora repo and dnf does not hit GPG key failures on it.
+# Remove this once the base image no longer ships the cisco repo enabled by default.
+RUN mkdir -p /etc/dnf/repos.override.d && \
+    printf '[fedora-cisco-openh264]\nenabled=0\n' > /etc/dnf/repos.override.d/disable-cisco-openh264.repo
+
 # Replace standalone systemd package with systemd as these are conflicting
 RUN set -ex; \
     dnf install -y systemd --allowerasing
@@ -41,10 +47,6 @@ RUN set -ex; \
   # Enable COPR repositories
   CI_TAG="${ci_tag}"; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
-    # disable fedora-cisco repository otherwise freerdp will depend on openh264 from fedora-cisco
-    # if fedora-cisco is not enabled it will fallback to stub library in main repository which is
-    # what we want
-    sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo; \
     dnf copr enable -y @storage/blivet-daily ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/udisks-daily ${CI_TAG}-x86_64; \
   fi; \

--- a/dockerfile/anaconda-release/Dockerfile
+++ b/dockerfile/anaconda-release/Dockerfile
@@ -7,18 +7,15 @@ ARG image
 FROM ${image}
 LABEL maintainer=anaconda-list@redhat.com
 
+# FIXME: workaround — disable the fedora-cisco-openh264 repo so that freerdp falls back to
+# the stub openh264 in the main Fedora repo and dnf does not hit GPG key failures on it.
+# Remove this once the base image no longer ships the cisco repo enabled by default.
+RUN mkdir -p /etc/dnf/repos.override.d && \
+    printf '[fedora-cisco-openh264]\nenabled=0\n' > /etc/dnf/repos.override.d/disable-cisco-openh264.repo
+
 # Add missing dependencies required to do the build.
 RUN set -e; \
   dnf update -y; \
-  # disable fedora-cisco repository otherwise freerdp will depend on openh264 from fedora-cisco
-  # if fedora-cisco is not enabled it will fallback to stub library in main repository which is
-  # what we want
-  if ! grep -q VARIANT.*eln /etc/os-release; then \
-    # disable fedora-cisco repository otherwise freerdp will depend on openh264 from fedora-cisco
-    # if fedora-cisco is not enabled it will fallback to stub library in main repository which is
-    # what we want
-    sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo; \
-  fi; \
   dnf install -y \
   git \
   python3-pip; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -25,6 +25,12 @@ LABEL maintainer=anaconda-devel@lists.fedoraproject.org
 # the build is invoked by Makefile.
 COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 
+# FIXME: workaround — disable the fedora-cisco-openh264 repo so that freerdp falls back to
+# the stub openh264 in the main Fedora repo and dnf does not hit GPG key failures on it.
+# Remove this once the base image no longer ships the cisco repo enabled by default.
+RUN mkdir -p /etc/dnf/repos.override.d && \
+    printf '[fedora-cisco-openh264]\nenabled=0\n' > /etc/dnf/repos.override.d/disable-cisco-openh264.repo
+
 # Replace standalone systemd package with systemd as these are conflicting
 RUN set -ex; \
     dnf install -y systemd --allowerasing
@@ -44,10 +50,6 @@ RUN set -ex; \
   rpmlint; \
   CI_TAG=${ci_tag}; \
   if ! grep -q VARIANT.*eln /etc/os-release; then \
-    # disable fedora-cisco repository otherwise freerdp will depend on openh264 from fedora-cisco
-    # if fedora-cisco is not enabled it will fallback to stub library in main repository which is
-    # what we want
-    sed -i 's/enabled=1/enabled=0/' /etc/yum.repos.d/fedora-cisco-openh264.repo; \
     dnf copr enable -y @storage/blivet-daily ${CI_TAG}-x86_64; \
     dnf copr enable -y @storage/udisks-daily ${CI_TAG}-x86_64; \
     dnf install -y python3-polib; \


### PR DESCRIPTION
The fedora-cisco-openh264 repo was disabled after dnf update -y, so dnf tried to upgrade openh264 from that repo first and hit a GPG key verification failure. Move the disable before dnf update.

Both Dockerfiles now carry a FIXME noting this is a workaround to be removed once the base image no longer ships the cisco repo enabled.