### PR TITLE
[rhel10 port] rescue: skip SELinux autorelabel for ostree/bootc systems

### DIFF
--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -221,8 +221,16 @@ class Rescue(object):
             self.error = e
             return False
 
-        # turn on selinux also
-        if conf.security.selinux:
+        # Check if this is an OSTree/atomic system
+        deployment_path = get_ostree_deployment_path(conf.target.physical_root)
+        if deployment_path:
+            self.is_ostree = True
+            set_system_root(deployment_path)
+
+        # Set up for SELinux relabeling on reboot
+        # Skip for ostree/bootc systems - the root filesystem is immutable
+        # and SELinux relabeling is handled differently.
+        if conf.security.selinux and not self.is_ostree:
             # we have to catch the possible exception, because we
             # support read-only mounting
             try:
@@ -253,12 +261,6 @@ class Rescue(object):
 
         # create /etc/fstab in ramdisk so it's easier to work with RO mounted fs
         makeFStab()
-
-        # Check if this is an OSTree/atomic system
-        deployment_path = get_ostree_deployment_path(conf.target.physical_root)
-        if deployment_path:
-            self.is_ostree = True
-            set_system_root(deployment_path)
 
         # run %post if we've mounted everything
         if not self.ro and self._scripts:

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -36,6 +36,7 @@ from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import ANACONDA_CLEANUP, IPMI_ABORTED, QUIT_MESSAGE, THREAD_STORAGE
 from pyanaconda.core.i18n import N_, _
+from pyanaconda.core.path import set_system_root
 from pyanaconda.core.threads import thread_manager
 from pyanaconda.errors import errorHandler
 from pyanaconda.flags import flags
@@ -253,9 +254,11 @@ class Rescue(object):
         # create /etc/fstab in ramdisk so it's easier to work with RO mounted fs
         makeFStab()
 
-        # Check if this is an OSTree/immutable system
-        if get_ostree_deployment_path(conf.target.system_root):
+        # Check if this is an OSTree/atomic system
+        deployment_path = get_ostree_deployment_path(conf.target.physical_root)
+        if deployment_path:
             self.is_ostree = True
+            set_system_root(deployment_path)
 
         # run %post if we've mounted everything
         if not self.ro and self._scripts:
@@ -467,12 +470,7 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
                                      "command line for autorelabel to work properly.\n")
                                    if self._rescue.autorelabel else "")
 
-                # For OSTree installations, find the deployment directory for chroot
-                mountpoint = conf.target.system_root
-                deployment_path = get_ostree_deployment_path(mountpoint)
-                chroot_path = deployment_path if deployment_path else mountpoint
-
-                ostree_warning = (_("Warning: An immutable system has been detected. "
+                ostree_warning = (_("Warning: An atomic system has been detected. "
                                     "It is not recommended to make manual changes to the deployment "
                                     "directories as this may break system integrity. Only modify "
                                     "/etc, /var, or boot loader configuration files as needed.\n\n")
@@ -481,8 +479,8 @@ class RescueStatusAndShellSpoke(NormalTUISpoke):
                 text = TextWidget(_("Your system has been mounted under %(mountpoint)s.\n\n"
                                     "If you would like to make the root of your system the "
                                     "root of the active system, run the command:\n\n"
-                                    "\tchroot %(chroot_path)s\n\n")
-                                  % {"mountpoint": mountpoint, "chroot_path": chroot_path}
+                                    "\tchroot %(mountpoint)s\n\n")
+                                  % {"mountpoint": conf.target.system_root}
                                   + ostree_warning + autorelabel_msg + finish_msg)
             elif status == RescueModeStatus.MOUNT_FAILED:
                 if self._rescue.reboot:


### PR DESCRIPTION
Direct port of upstream https://github.com/rhinstaller/anaconda/pull/7236
Plus port of upstream https://github.com/rhinstaller/anaconda/pull/7120 - it is not required for the patch, but is a worthy improvement and makes the upstream patch apply seamlessly.