### PR TITLE
Bump petitboot firmware kernel version check to 5.19 (ppc64le) (rhel10 backport)

### DIFF
--- a/pyanaconda/modules/storage/checker/utils.py
+++ b/pyanaconda/modules/storage/checker/utils.py
@@ -246,7 +246,7 @@ def verify_opal_compatibility(storage, constraints, report_error, report_warning
     if arch.get_arch() == "ppc64le" and arch.is_powernv():
         # Check the kernel version.
         version = _get_opal_firmware_kernel_version()
-        if _check_opal_firmware_kernel_version(version, "5.10"):
+        if _check_opal_firmware_kernel_version(version, "5.19"):
             return
 
         # Is /boot on XFS?


### PR DESCRIPTION
The minimum firmware kernel version check for petitboot on ppc64le was set to 5.10, which no longer covers newer
petitboot versions. Increase the threshold to 5.19.

(cherry-picked from: #TBD)

wait for https://github.com/rhinstaller/anaconda/pull/7235 to be merged

Resolves: RHEL-43310