### PR TITLE
infra: create /etc/yum.repos.d before dnf copr enable on ELN

### DIFF
--- a/dockerfile/anaconda-ci/Dockerfile
+++ b/dockerfile/anaconda-ci/Dockerfile
@@ -34,7 +34,8 @@ COPY rpms/ /root/rpms/
 # the stub openh264 in the main Fedora repo and dnf does not hit GPG key failures on it.
 # Remove this once the base image no longer ships the cisco repo enabled by default.
 RUN mkdir -p /etc/dnf/repos.override.d && \
-    printf '[fedora-cisco-openh264]\nenabled=0\n' > /etc/dnf/repos.override.d/disable-cisco-openh264.repo
+    printf '[fedora-cisco-openh264]\nenabled=0\n' > /etc/dnf/repos.override.d/disable-cisco-openh264.repo && \
+    mkdir -p /etc/yum.repos.d
 
 # Replace standalone systemd package with systemd as these are conflicting
 RUN set -ex; \

--- a/dockerfile/anaconda-rpm/Dockerfile
+++ b/dockerfile/anaconda-rpm/Dockerfile
@@ -29,7 +29,8 @@ COPY ["anaconda.spec.in", "requirements.txt", "/root/"]
 # the stub openh264 in the main Fedora repo and dnf does not hit GPG key failures on it.
 # Remove this once the base image no longer ships the cisco repo enabled by default.
 RUN mkdir -p /etc/dnf/repos.override.d && \
-    printf '[fedora-cisco-openh264]\nenabled=0\n' > /etc/dnf/repos.override.d/disable-cisco-openh264.repo
+    printf '[fedora-cisco-openh264]\nenabled=0\n' > /etc/dnf/repos.override.d/disable-cisco-openh264.repo && \
+    mkdir -p /etc/yum.repos.d
 
 # Replace standalone systemd package with systemd as these are conflicting
 RUN set -ex; \


### PR DESCRIPTION
The ELN base image does not ship /etc/yum.repos.d at all. The dnf copr
plugin assumes the directory exists and fails with:
  filesystem error: cannot set permissions: No such file or directory

Create the directory in the same RUN step that already sets up
/etc/dnf/repos.override.d, before any dnf copr enable call.