### PR TITLE
anaconda-pre: don't require a tty

### DIFF
--- a/data/systemd/anaconda-pre.service
+++ b/data/systemd/anaconda-pre.service
@@ -16,7 +16,7 @@ Type=oneshot
 ExecStart=/usr/libexec/anaconda/anaconda-pre-log-gen
 # RHEL-110525 (sysctl configuration/API does not work)
 ExecStart=/bin/dmesg --console-level emerg
-StandardInput=tty
+StandardInput=null
 StandardOutput=journal+console
 StandardError=journal+console
 TimeoutSec=0


### PR DESCRIPTION
Nothing in the `anaconda-pre-log-gen` executable actually requires a tty. In some cases when the active tty is already owned (for example by a window manager, or a serial console) this blocks indefinitely which prevents Anaconda from ever starting.