### PR TITLE
Allow reformat for partitions without a recognized filesystem

### DIFF
--- a/pyanaconda/modules/storage/partitioning/interactive/utils.py
+++ b/pyanaconda/modules/storage/partitioning/interactive/utils.py
@@ -969,7 +969,7 @@ def generate_device_factory_permissions(storage, request: DeviceFactoryRequest):
     permissions.reformat = \
         device.raw_device.exists \
         and not device.raw_device.format_immutable \
-        and is_supported_filesystem(request.format_type)
+        and (fmt.type is None or is_supported_filesystem(request.format_type))
 
     permissions.device_size = \
         device.resizable or (

--- a/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/storage/partitioning/test_module_scheduler.py
@@ -36,6 +36,7 @@ from blivet.devices import (
     StorageDevice,
 )
 from blivet.errors import StorageError
+from blivet.flags import flags as blivet_flags
 from blivet.formats import get_format
 from blivet.formats.fs import BTRFS, FS
 from blivet.size import Size
@@ -508,6 +509,42 @@ class DeviceTreeSchedulerTestCase(unittest.TestCase):
         permissions = self.interface.GenerateDeviceFactoryPermissions(request)
         for value in get_native(permissions).values():
             assert value is False
+
+    def test_generate_device_factory_permissions_no_format(self):
+        """Test GenerateDeviceFactoryPermissions for a device without a recognized format."""
+        with patch.object(blivet_flags, "testing", True):
+            dev1 = DiskDevice(
+                "dev1",
+                fmt=get_format("disklabel"),
+                size=Size("10 GiB"),
+                exists=True
+            )
+            dev2 = PartitionDevice(
+                "dev2",
+                size=Size("5 GiB"),
+                parents=[dev1],
+                fmt=get_format(None),
+                exists=True
+            )
+
+            self._add_device(dev1)
+            self._add_device(dev2)
+
+            # A partition without a recognized file system (raw/"Unknown") should
+            # still allow reformatting, so it can be assigned a supported file system.
+            request = self.module.generate_device_factory_request("dev2")
+            permissions = self.interface.GenerateDeviceFactoryPermissions(
+                DeviceFactoryRequest.to_structure(request)
+            )
+            assert get_native(permissions)['reformat'] is True
+
+            # An existing but unsupported file system (for example ntfs) should still
+            # disable reformatting.
+            request.format_type = "ntfs"
+            permissions = self.interface.GenerateDeviceFactoryPermissions(
+                DeviceFactoryRequest.to_structure(request)
+            )
+            assert get_native(permissions)['reformat'] is False
 
     def test_generate_device_factory_permissions_btrfs(self):
         """Test GenerateDeviceFactoryPermissions with btrfs."""


### PR DESCRIPTION
Partitions created without a filesystem show up as Unknown in custom partitioning, but reformat was disabled because is_supported_filesystem("") returns False. Allow reformat when the device has no format type while still blocking reformat for unsupported existing filesystems.

(cherry-picked from: ad3277c)

Assisted-by: Cursor
Resolves: RHEL-144461