### PR TITLE
Psirtsupt 21694 kickstart tests workflow v2

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -104,42 +104,36 @@ jobs:
       # when the pr_api step above fetched the head SHA. Use GitHub's GraphQL API
       # to check pushedDate (a server-side timestamp that cannot be forged) and
       # verify the head commit was pushed before the comment was created.
+      # Query the head (fork) repository since pushedDate is only available
+      # in the repo where the commit was actually pushed.
       - name: Verify head commit was pushed before the trigger comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_TIME: ${{ github.event.comment.created_at }}
-          PR_NUMBER: ${{ github.event.issue.number }}
           EXPECTED_SHA: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
+          HEAD_REPO_OWNER: ${{ fromJson(steps.pr_api.outputs.data).head.repo.owner.login }}
+          HEAD_REPO_NAME: ${{ fromJson(steps.pr_api.outputs.data).head.repo.name }}
         run: |
-          REPO_OWNER="${GITHUB_REPOSITORY%/*}"
-          REPO_NAME="${GITHUB_REPOSITORY#*/}"
-
-          RESULT=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!, $pr: Int!) {
+          PUSHED_DATE=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $oid: GitObjectID!) {
               repository(owner: $owner, name: $repo) {
-                pullRequest(number: $pr) {
-                  commits(last: 1) {
-                    nodes {
-                      commit {
-                        pushedDate
-                        oid
-                      }
-                    }
+                object(oid: $oid) {
+                  ... on Commit {
+                    pushedDate
                   }
                 }
               }
-            }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
-               --jq '.data.repository.pullRequest.commits.nodes[0].commit')
-
-          PUSHED_DATE=$(echo "$RESULT" | jq -r '.pushedDate')
-          COMMIT_OID=$(echo "$RESULT" | jq -r '.oid')
+            }' -f owner="$HEAD_REPO_OWNER" -f repo="$HEAD_REPO_NAME" \
+               -f oid="$EXPECTED_SHA" \
+               --jq '.data.repository.object.pushedDate')
 
           echo "Comment created at: $COMMENT_TIME"
-          echo "Head commit pushed at: $PUSHED_DATE (SHA: $COMMIT_OID)"
-          echo "Expected SHA from PR API: $EXPECTED_SHA"
+          echo "Head commit pushed at: $PUSHED_DATE (SHA: $EXPECTED_SHA)"
+          echo "Head repo: $HEAD_REPO_OWNER/$HEAD_REPO_NAME"
 
-          if [ "$COMMIT_OID" != "$EXPECTED_SHA" ]; then
-            echo "::error::PR head SHA changed between API calls!"
+          if [ "$PUSHED_DATE" = "null" ] || [ -z "$PUSHED_DATE" ]; then
+            echo "::error::Could not determine push time for commit $EXPECTED_SHA from $HEAD_REPO_OWNER/$HEAD_REPO_NAME."
+            echo "::error::This may indicate the fork was deleted or is inaccessible."
             exit 1
           fi
 

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -37,6 +37,12 @@
 # /kickstart-test --kstest-pr 1233 --testtype harddrive
 # ... run the tests of type harddrive with
 # https://github.com/rhinstaller/kickstart-tests/pull/1233 update of kickstart tests
+#
+#
+# To verify the PR head commit was not force-pushed after the trigger comment
+# (guards against TOCTOU attacks on fork PRs):
+#
+# /kickstart-test --check-head-timestamp --testtype smoke
 
 name: kickstart-tests
 on:
@@ -94,6 +100,14 @@ jobs:
           PR=${PR%"--"}
           # remove --kstest-pr option
           ARGS=$(echo "$ARGS" | sed -r -e "s#--kstest-pr( +|=)$PR ##" | sed 's/[[:space:]]*$//')
+          # parse --check-head-timestamp flag
+          CHECK_HEAD_TIMESTAMP=false
+          if echo "$ARGS" | grep -q -- '--check-head-timestamp'; then
+            CHECK_HEAD_TIMESTAMP=true
+            ARGS=$(echo "$ARGS" | sed 's/--check-head-timestamp//' | sed 's/^ *//;s/ *$//' | sed 's/  */ /g')
+          fi
+          echo "check_head_timestamp=${CHECK_HEAD_TIMESTAMP}" >> $GITHUB_OUTPUT
+
           echo "test selection arguments are: $ARGS"
           echo "comment_args=${ARGS}" >> $GITHUB_OUTPUT
           echo "kickstart-tests PR: $PR"
@@ -107,6 +121,7 @@ jobs:
       # Query the head (fork) repository since pushedDate is only available
       # in the repo where the commit was actually pushed.
       - name: Verify head commit was pushed before the trigger comment
+        if: steps.parse_comment_args.outputs.check_head_timestamp == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_TIME: ${{ github.event.comment.created_at }}

--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -99,6 +99,61 @@ jobs:
           echo "kickstart-tests PR: $PR"
           echo "kstest_pr=${PR}" >> $GITHUB_OUTPUT
 
+      # Guard against TOCTOU attack: an attacker could force-push malicious code
+      # to the PR branch between when the maintainer posted /kickstart-test and
+      # when the pr_api step above fetched the head SHA. Use GitHub's GraphQL API
+      # to check pushedDate (a server-side timestamp that cannot be forged) and
+      # verify the head commit was pushed before the comment was created.
+      - name: Verify head commit was pushed before the trigger comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_TIME: ${{ github.event.comment.created_at }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          EXPECTED_SHA: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
+        run: |
+          REPO_OWNER="${GITHUB_REPOSITORY%/*}"
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+
+          RESULT=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  commits(last: 1) {
+                    nodes {
+                      commit {
+                        pushedDate
+                        oid
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
+               --jq '.data.repository.pullRequest.commits.nodes[0].commit')
+
+          PUSHED_DATE=$(echo "$RESULT" | jq -r '.pushedDate')
+          COMMIT_OID=$(echo "$RESULT" | jq -r '.oid')
+
+          echo "Comment created at: $COMMENT_TIME"
+          echo "Head commit pushed at: $PUSHED_DATE (SHA: $COMMIT_OID)"
+          echo "Expected SHA from PR API: $EXPECTED_SHA"
+
+          if [ "$COMMIT_OID" != "$EXPECTED_SHA" ]; then
+            echo "::error::PR head SHA changed between API calls!"
+            exit 1
+          fi
+
+          # ISO 8601 timestamps - lexicographic comparison works correctly
+          if [[ "$PUSHED_DATE" > "$COMMENT_TIME" ]]; then
+            echo "::error::The head commit was pushed AFTER the /kickstart-test comment was created!"
+            echo "::error::Push time:   $PUSHED_DATE"
+            echo "::error::Comment time: $COMMENT_TIME"
+            echo "::error::This may indicate a malicious force-push. Re-review the PR and post a new /kickstart-test comment."
+            exit 1
+          fi
+
+          echo "Verification passed: head commit was pushed before the trigger comment."
+
     outputs:
       allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
       base_ref: ${{ fromJson(steps.pr_api.outputs.data).base.ref }}

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -31,6 +31,12 @@
 # /kickstart-test --kstest-pr 1233 --testtype harddrive
 # ... run the tests of type harddrive with
 # https://github.com/rhinstaller/kickstart-tests/pull/1233 update of kickstart tests
+#
+#
+# To verify the PR head commit was not force-pushed after the trigger comment
+# (guards against TOCTOU attacks on fork PRs):
+#
+# /kickstart-test --check-head-timestamp --testtype smoke
 
 name: kickstart-tests
 on:
@@ -88,6 +94,14 @@ jobs:
           PR=${PR%"--"}
           # remove --kstest-pr option
           ARGS=$(echo "$ARGS" | sed -r -e "s#--kstest-pr( +|=)$PR ##" | sed 's/[[:space:]]*$//')
+          # parse --check-head-timestamp flag
+          CHECK_HEAD_TIMESTAMP=false
+          if echo "$ARGS" | grep -q -- '--check-head-timestamp'; then
+            CHECK_HEAD_TIMESTAMP=true
+            ARGS=$(echo "$ARGS" | sed 's/--check-head-timestamp//' | sed 's/^ *//;s/ *$//' | sed 's/  */ /g')
+          fi
+          echo "check_head_timestamp=${CHECK_HEAD_TIMESTAMP}" >> $GITHUB_OUTPUT
+
           echo "test selection arguments are: $ARGS"
           echo "comment_args=${ARGS}" >> $GITHUB_OUTPUT
           echo "kickstart-tests PR: $PR"
@@ -101,6 +115,7 @@ jobs:
       # Query the head (fork) repository since pushedDate is only available
       # in the repo where the commit was actually pushed.
       - name: Verify head commit was pushed before the trigger comment
+        if: steps.parse_comment_args.outputs.check_head_timestamp == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_TIME: ${{ github.event.comment.created_at }}

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -93,6 +93,61 @@ jobs:
           echo "kickstart-tests PR: $PR"
           echo "kstest_pr=${PR}" >> $GITHUB_OUTPUT
 
+      # Guard against TOCTOU attack: an attacker could force-push malicious code
+      # to the PR branch between when the maintainer posted /kickstart-test and
+      # when the pr_api step above fetched the head SHA. Use GitHub's GraphQL API
+      # to check pushedDate (a server-side timestamp that cannot be forged) and
+      # verify the head commit was pushed before the comment was created.
+      - name: Verify head commit was pushed before the trigger comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_TIME: ${{ github.event.comment.created_at }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          EXPECTED_SHA: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
+        run: |
+          REPO_OWNER="${GITHUB_REPOSITORY%/*}"
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+
+          RESULT=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  commits(last: 1) {
+                    nodes {
+                      commit {
+                        pushedDate
+                        oid
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
+               --jq '.data.repository.pullRequest.commits.nodes[0].commit')
+
+          PUSHED_DATE=$(echo "$RESULT" | jq -r '.pushedDate')
+          COMMIT_OID=$(echo "$RESULT" | jq -r '.oid')
+
+          echo "Comment created at: $COMMENT_TIME"
+          echo "Head commit pushed at: $PUSHED_DATE (SHA: $COMMIT_OID)"
+          echo "Expected SHA from PR API: $EXPECTED_SHA"
+
+          if [ "$COMMIT_OID" != "$EXPECTED_SHA" ]; then
+            echo "::error::PR head SHA changed between API calls!"
+            exit 1
+          fi
+
+          # ISO 8601 timestamps - lexicographic comparison works correctly
+          if [[ "$PUSHED_DATE" > "$COMMENT_TIME" ]]; then
+            echo "::error::The head commit was pushed AFTER the /kickstart-test comment was created!"
+            echo "::error::Push time:   $PUSHED_DATE"
+            echo "::error::Comment time: $COMMENT_TIME"
+            echo "::error::This may indicate a malicious force-push. Re-review the PR and post a new /kickstart-test comment."
+            exit 1
+          fi
+
+          echo "Verification passed: head commit was pushed before the trigger comment."
+
     outputs:
       allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
       base_ref: ${{ fromJson(steps.pr_api.outputs.data).base.ref }}

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -98,42 +98,36 @@ jobs:
       # when the pr_api step above fetched the head SHA. Use GitHub's GraphQL API
       # to check pushedDate (a server-side timestamp that cannot be forged) and
       # verify the head commit was pushed before the comment was created.
+      # Query the head (fork) repository since pushedDate is only available
+      # in the repo where the commit was actually pushed.
       - name: Verify head commit was pushed before the trigger comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_TIME: ${{ github.event.comment.created_at }}
-          PR_NUMBER: ${{ github.event.issue.number }}
           EXPECTED_SHA: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
+          HEAD_REPO_OWNER: ${{ fromJson(steps.pr_api.outputs.data).head.repo.owner.login }}
+          HEAD_REPO_NAME: ${{ fromJson(steps.pr_api.outputs.data).head.repo.name }}
         run: |
-          REPO_OWNER="${GITHUB_REPOSITORY%/*}"
-          REPO_NAME="${GITHUB_REPOSITORY#*/}"
-
-          RESULT=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!, $pr: Int!) {
+          PUSHED_DATE=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $oid: GitObjectID!) {
               repository(owner: $owner, name: $repo) {
-                pullRequest(number: $pr) {
-                  commits(last: 1) {
-                    nodes {
-                      commit {
-                        pushedDate
-                        oid
-                      }
-                    }
+                object(oid: $oid) {
+                  ... on Commit {
+                    pushedDate
                   }
                 }
               }
-            }' -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F pr="$PR_NUMBER" \
-               --jq '.data.repository.pullRequest.commits.nodes[0].commit')
-
-          PUSHED_DATE=$(echo "$RESULT" | jq -r '.pushedDate')
-          COMMIT_OID=$(echo "$RESULT" | jq -r '.oid')
+            }' -f owner="$HEAD_REPO_OWNER" -f repo="$HEAD_REPO_NAME" \
+               -f oid="$EXPECTED_SHA" \
+               --jq '.data.repository.object.pushedDate')
 
           echo "Comment created at: $COMMENT_TIME"
-          echo "Head commit pushed at: $PUSHED_DATE (SHA: $COMMIT_OID)"
-          echo "Expected SHA from PR API: $EXPECTED_SHA"
+          echo "Head commit pushed at: $PUSHED_DATE (SHA: $EXPECTED_SHA)"
+          echo "Head repo: $HEAD_REPO_OWNER/$HEAD_REPO_NAME"
 
-          if [ "$COMMIT_OID" != "$EXPECTED_SHA" ]; then
-            echo "::error::PR head SHA changed between API calls!"
+          if [ "$PUSHED_DATE" = "null" ] || [ -z "$PUSHED_DATE" ]; then
+            echo "::error::Could not determine push time for commit $EXPECTED_SHA from $HEAD_REPO_OWNER/$HEAD_REPO_NAME."
+            echo "::error::This may indicate the fork was deleted or is inaccessible."
             exit 1
           fi
 


### PR DESCRIPTION
Follow-up of reverted https://github.com/rhinstaller/anaconda/pull/7250 (failed in https://github.com/rhinstaller/anaconda/pull/7254)
The --check-head-timestamp is temprorary so that we can test the solution in live CI without breaking it.

- [x] I think I'll first test like this: create a special workflow to test the solution in production. Basically just pr-info, but also instrumented with added sleep (maybe triggered as a comment argument) into it to be able reproduce the malicious push: https://github.com/rhinstaller/anaconda/pull/7258