### PR TITLE
Psirtsupt 21694 kickstart tests workflow issue reproducer

### DIFF
--- a/.github/workflows/test-check-head-timestamp.yml
+++ b/.github/workflows/test-check-head-timestamp.yml
@@ -1,0 +1,127 @@
+# Test workflow for the --check-head-timestamp feature of kickstart-tests.yml.
+# Contains only the pr-info job to verify the pushedDate check works correctly.
+#
+# Trigger with a comment on a PR:
+#
+#   /test-check-head-timestamp
+#
+# This will run the pr-info job with --check-head-timestamp enabled and report
+# whether the head commit timestamp verification passes or fails.
+
+name: test-check-head-timestamp
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  pr-info:
+    if: startsWith(github.event.comment.body, '/test-check-head-timestamp')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Query comment author repository permissions
+        uses: octokit/request-action@v2.x
+        id: user_permission
+        with:
+          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}/permission
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # restrict running of tests to users with admin or write permission for the repository
+      # see https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#get-repository-permissions-for-a-user
+      # store output if user is allowed in allowed_user job output so it has to be checked in downstream job
+      - name: Check if user does have correct permissions
+        if: contains('admin write', fromJson(steps.user_permission.outputs.data).permission)
+        id: check_user_perm
+        run: |
+          echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
+          echo "allowed_user=true" >> $GITHUB_OUTPUT
+
+      - name: Get information for pull request
+        uses: octokit/request-action@v2.x
+        id: pr_api
+        with:
+          route: GET /repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse comment arguments
+        id: parse_comment_args
+        # Do not use comment body directly in the shell command to avoid possible code injection.
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # extract first line and cut out the "/test-check-head-timestamp" first word
+          ARGS=$(echo "$BODY" | sed -n '1 s/^[^ ]* *//p' | sed 's/[[:space:]]*$//')
+          # parse --kstest-pr option
+          OPTS="$(getopt -q -o "" --long kstest-pr: -- $ARGS)" || true
+          PR=${OPTS#" --kstest-pr '"}
+          PR=$(echo $PR | cut -d " " -f1)
+          PR=${PR%"'"}
+          PR=${PR%"--"}
+          # remove --kstest-pr option
+          ARGS=$(echo "$ARGS" | sed -r -e "s#--kstest-pr( +|=)$PR ##" | sed 's/[[:space:]]*$//')
+          echo "test selection arguments are: $ARGS"
+          echo "comment_args=${ARGS}" >> $GITHUB_OUTPUT
+          echo "kickstart-tests PR: $PR"
+          echo "kstest_pr=${PR}" >> $GITHUB_OUTPUT
+
+      # Guard against TOCTOU attack: an attacker could force-push malicious code
+      # to the PR branch between when the maintainer posted the trigger comment and
+      # when the pr_api step above fetched the head SHA. Use GitHub's GraphQL API
+      # to check pushedDate (a server-side timestamp that cannot be forged) and
+      # verify the head commit was pushed before the comment was created.
+      # Query the head (fork) repository since pushedDate is only available
+      # in the repo where the commit was actually pushed.
+      - name: Verify head commit was pushed before the trigger comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_TIME: ${{ github.event.comment.created_at }}
+          EXPECTED_SHA: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
+          HEAD_REPO_OWNER: ${{ fromJson(steps.pr_api.outputs.data).head.repo.owner.login }}
+          HEAD_REPO_NAME: ${{ fromJson(steps.pr_api.outputs.data).head.repo.name }}
+        run: |
+          PUSHED_DATE=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $oid: GitObjectID!) {
+              repository(owner: $owner, name: $repo) {
+                object(oid: $oid) {
+                  ... on Commit {
+                    pushedDate
+                  }
+                }
+              }
+            }' -f owner="$HEAD_REPO_OWNER" -f repo="$HEAD_REPO_NAME" \
+               -f oid="$EXPECTED_SHA" \
+               --jq '.data.repository.object.pushedDate')
+
+          echo "Comment created at: $COMMENT_TIME"
+          echo "Head commit pushed at: $PUSHED_DATE (SHA: $EXPECTED_SHA)"
+          echo "Head repo: $HEAD_REPO_OWNER/$HEAD_REPO_NAME"
+
+          if [ "$PUSHED_DATE" = "null" ] || [ -z "$PUSHED_DATE" ]; then
+            echo "::error::Could not determine push time for commit $EXPECTED_SHA from $HEAD_REPO_OWNER/$HEAD_REPO_NAME."
+            echo "::error::This may indicate the fork was deleted or is inaccessible."
+            exit 1
+          fi
+
+          # ISO 8601 timestamps - lexicographic comparison works correctly
+          if [[ "$PUSHED_DATE" > "$COMMENT_TIME" ]]; then
+            echo "::error::The head commit was pushed AFTER the trigger comment was created!"
+            echo "::error::Push time:   $PUSHED_DATE"
+            echo "::error::Comment time: $COMMENT_TIME"
+            echo "::error::This may indicate a malicious force-push. Re-review the PR and post a new trigger comment."
+            exit 1
+          fi
+
+          echo "Verification passed: head commit was pushed before the trigger comment."
+
+    outputs:
+      allowed_user: ${{ steps.check_user_perm.outputs.allowed_user }}
+      base_ref: ${{ fromJson(steps.pr_api.outputs.data).base.ref }}
+      sha: ${{ fromJson(steps.pr_api.outputs.data).head.sha }}
+      comment_args: ${{ steps.parse_comment_args.outputs.comment_args }}
+      target_branch: ${{ fromJson(steps.pr_api.outputs.data).base.ref }}
+      kstest_pr: ${{ steps.parse_comment_args.outputs.kstest_pr }}

--- a/.github/workflows/test-check-head-timestamp.yml
+++ b/.github/workflows/test-check-head-timestamp.yml
@@ -5,6 +5,11 @@
 #
 #   /test-check-head-timestamp
 #
+# Use --delay-seconds N to sleep before fetching the PR head SHA, giving
+# time to simulate a malicious force-push:
+#
+#   /test-check-head-timestamp --delay-seconds 120
+#
 # This will run the pr-info job with --check-head-timestamp enabled and report
 # whether the head commit timestamp verification passes or fails.
 
@@ -40,6 +45,27 @@ jobs:
           echo "User '${{ github.event.sender.login }}' has permission '${{ fromJson(steps.user_permission.outputs.data).permission }}' allowed values: 'admin', 'write'"
           echo "allowed_user=true" >> $GITHUB_OUTPUT
 
+      # Parse --delay-seconds early, before the PR API call, so we can
+      # sleep before fetching the head SHA.
+      - name: Parse delay option
+        id: parse_delay
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          DELAY_SECONDS=0
+          DELAY_VALUE=$(echo "$BODY" | grep -oP '(?<=--delay-seconds[ =])\d+' || true)
+          if [ -n "$DELAY_VALUE" ]; then
+            DELAY_SECONDS="$DELAY_VALUE"
+          fi
+          echo "Delay before fetching PR info: ${DELAY_SECONDS}s"
+          echo "delay_seconds=${DELAY_SECONDS}" >> $GITHUB_OUTPUT
+
+      - name: Delay before fetching PR info
+        if: steps.parse_delay.outputs.delay_seconds != '0'
+        run: |
+          echo "Sleeping ${{ steps.parse_delay.outputs.delay_seconds }} seconds to allow simulating a force-push..."
+          sleep ${{ steps.parse_delay.outputs.delay_seconds }}
+
       - name: Get information for pull request
         uses: octokit/request-action@v2.x
         id: pr_api
@@ -64,6 +90,9 @@ jobs:
           PR=${PR%"--"}
           # remove --kstest-pr option
           ARGS=$(echo "$ARGS" | sed -r -e "s#--kstest-pr( +|=)$PR ##" | sed 's/[[:space:]]*$//')
+          # remove --delay-seconds option from ARGS (already parsed earlier)
+          ARGS=$(echo "$ARGS" | sed -r 's/--delay-seconds[= ][0-9]+//' | sed 's/^ *//;s/ *$//' | sed 's/  */ /g')
+
           echo "test selection arguments are: $ARGS"
           echo "comment_args=${ARGS}" >> $GITHUB_OUTPUT
           echo "kickstart-tests PR: $PR"


### PR DESCRIPTION
A GH workflow reproducer / testing workflow for https://github.com/rhinstaller/anaconda/pull/7257.
Test and reproduce in isolation from the kickstart-tests.yml (effectively running just its pr-info part) workflow so CI is not broken by it.