### PR TITLE
rescue: read fstab from sysroot for OSTree deployments

### DIFF
--- a/pyanaconda/modules/storage/devicetree/root.py
+++ b/pyanaconda/modules/storage/devicetree/root.py
@@ -54,8 +54,15 @@ def mount_existing_system(storage, root_device, read_only=None):
     # Set up the sysroot.
     set_system_root(root_path)
 
+    # For OSTree deployments, the fstab lives in the deployment directory,
+    # not at the physical root. Find it by walking the directory tree.
+    fstab_root = _find_root_from_fstab(root_path)
+    if fstab_root and fstab_root != root_path:
+        set_system_root(fstab_root)
+
     # Mount the filesystems.
-    storage.fsset.parse_fstab(chroot=root_path)
+    sysroot = conf.target.system_root
+    storage.fsset.parse_fstab(chroot=sysroot)
     storage.fsset.mount_filesystems(root_path=root_path, read_only=read_only, skip_root=True)
 
     # Turn on swap.

--- a/pyanaconda/rescue.py
+++ b/pyanaconda/rescue.py
@@ -36,7 +36,6 @@ from pyanaconda.core import util
 from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import ANACONDA_CLEANUP, IPMI_ABORTED, QUIT_MESSAGE, THREAD_STORAGE
 from pyanaconda.core.i18n import N_, _
-from pyanaconda.core.path import set_system_root
 from pyanaconda.core.threads import thread_manager
 from pyanaconda.errors import errorHandler
 from pyanaconda.flags import flags
@@ -207,25 +206,14 @@ class Rescue(object):
             task_proxy = STORAGE.get_proxy(task_path)
             sync_run_task(task_proxy)
             log.info("System has been mounted under: %s", conf.target.system_root)
-
-            # Mount /boot if it exists
-            # This is needed for OSTree deployments to be detected properly
-            boot_device = root.get_boot_device()
-            if boot_device:
-                boot_path = os.path.join(conf.target.system_root, "boot")
-                read_only = "ro" if self.ro else ""
-                self._device_tree_proxy.MountDevice(boot_device, boot_path, read_only)
         except MountFilesystemError as e:
             log.error("Mounting system under %s failed: %s", conf.target.system_root, e)
             self.status = RescueModeStatus.MOUNT_FAILED
             self.error = e
             return False
 
-        # Check if this is an OSTree/atomic system
-        deployment_path = get_ostree_deployment_path(conf.target.physical_root)
-        if deployment_path:
-            self.is_ostree = True
-            set_system_root(deployment_path)
+        # Check if this is an OSTree/immutable system
+        self.is_ostree = get_ostree_deployment_path(conf.target.physical_root) is not None
 
         # Set up for SELinux relabeling on reboot
         # Skip for ostree/bootc systems - the root filesystem is immutable


### PR DESCRIPTION
On OSTree systems fstab is nested inside the deployment directory rather than at the top level of the physical root. Use _find_root_from_fstab() to locate it by walking the directory tree, then update sysroot before parsing fstab.

This avoids the OSTree API (which needs /boot mounted) and removes the explicit /boot mount workaround which caused a double-mount failure on RPM systems.

Fixes: 3038124a49 ("rescue: detect OSTree deployments in rescue mode and show deployment path")
Resolves: RHEL-245259

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

