### PR TITLE
boss: emit ActiveInstallationTask changes over DBus

### DIFF
--- a/pyanaconda/modules/boss/boss.py
+++ b/pyanaconda/modules/boss/boss.py
@@ -65,6 +65,7 @@ class Boss(Service):
         self.pending_error_changed = Signal()
         self.installation_status_changed.connect(self.module_properties_changed.emit)
         self.pending_error_changed.connect(self.module_properties_changed.emit)
+        self.active_installation_task_changed.connect(self.module_properties_changed.emit)
 
         self._module_manager.module_observers_changed.connect(
             self._kickstart_manager.on_module_observers_changed


### PR DESCRIPTION
The active_installation_task_changed signal was not connected to module_properties_changed, so the ActiveInstallationTask property change was never emitted as a PropertiesChanged DBus signal.

Related: rhbz#2521241

This is needed by https://github.com/rhinstaller/anaconda-webui/pull/1434
