### PR TITLE
spec: add IOT to anaconda-gui variants in rich dep

### DIFF
--- a/anaconda.spec.in
+++ b/anaconda.spec.in
@@ -70,7 +70,7 @@ BuildRequires: s390utils-devel
 BuildRequires: gdk-pixbuf2-devel
 BuildRequires: libxml2
 
-Requires: (anaconda-gui = %{version}-%{release} if (fedora-release-identity-server or fedora-release-identity-basic) else anaconda-webui)
+Requires: (anaconda-gui = %{version}-%{release} if (fedora-release-identity-server or fedora-release-identity-basic or fedora-release-identity-iot) else anaconda-webui)
 Requires: anaconda-tui = %{version}-%{release}
 
 %description


### PR DESCRIPTION
WebUI is not yet ready for the transition in IOT. Add fedora-release-identity-iot alongside server and basic so that IOT images continue to pull in anaconda-gui.
