### PR TITLE
fix: serialize localed convert operations to prevent race condition

### DIFF
--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -15,6 +15,7 @@
 # License and may only be used or replicated with the express permission of
 # Red Hat, Inc.
 #
+import threading
 from abc import ABC
 
 from pyanaconda.anaconda_loggers import get_module_logger
@@ -146,6 +147,10 @@ class LocaledWrapper(LocaledWrapperBase):
     It adds support for keymap and conversion methods between keymap and layouts.
     """
 
+    def __init__(self):
+        super().__init__()
+        self._convert_lock = threading.Lock()
+
     @property
     def keymap(self):
         """Get current VConsole keymap.
@@ -189,11 +194,12 @@ class LocaledWrapper(LocaledWrapperBase):
 
         # hack around systemd's lack of functionality -- no function to just
         # convert without changing keyboard configuration
-        orig_layouts_variants = self.get_layouts_variants()
-        orig_keymap = self.keymap
-        converted_layouts = self.set_and_convert_keymap(keymap)
-        self.set_layouts(orig_layouts_variants)
-        self.set_keymap(orig_keymap)
+        with self._convert_lock:
+            orig_layouts_variants = self.get_layouts_variants()
+            orig_keymap = self.keymap
+            converted_layouts = self.set_and_convert_keymap(keymap)
+            self.set_layouts(orig_layouts_variants)
+            self.set_keymap(orig_keymap)
 
         return converted_layouts
 
@@ -242,11 +248,12 @@ class LocaledWrapper(LocaledWrapperBase):
 
         # hack around systemd's lack of functionality -- no function to just
         # convert without changing keyboard configuration
-        orig_layouts_variants = self.get_layouts_variants()
-        orig_keymap = self.keymap
-        ret = self.set_and_convert_layouts(layouts_variants)
-        self.set_layouts(orig_layouts_variants)
-        self.set_keymap(orig_keymap)
+        with self._convert_lock:
+            orig_layouts_variants = self.get_layouts_variants()
+            orig_keymap = self.keymap
+            ret = self.set_and_convert_layouts(layouts_variants)
+            self.set_layouts(orig_layouts_variants)
+            self.set_keymap(orig_keymap)
 
         return ret
 


### PR DESCRIPTION
convert_layouts and convert_keymap need to convert between X keyboard layouts and VConsole keymaps. systemd-localed's SetX11Keyboard has a convert flag — when convert=True, it sets the X11 layout AND computes and sets the corresponding VConsole keymap. But there is no API to just ask "what VConsole keymap corresponds to this layout?" without changing the active configuration.

So to do a read-only conversion, the code uses a hack:

  1. Save current localed state (layouts + keymap)
  2. Call SetX11Keyboard(convert=True) to trigger the conversion
  3. Read back the VConsole keymap that localed computed
  4. Restore the original state

The Web UI triggers multiple GetMissingKeyboardConfigurationTask threads concurrently. Each task calls convert_layouts, and without serialization the concurrent threads corrupt each other's temporary localed state:

  Thread A: save(us)
  Thread A: set(gr, convert=True)  → localed now has gr + keymap=gr
  Thread B: save(gr)               → saves A's temporary state
  Thread A: read → gr              → correct
  Thread A: restore(us)            → localed back to us
  Thread B: set(us,gr, convert=True)
  Thread B: read → us              → WRONG, expected gr
  Thread B: restore(gr)            → WRONG original

Add a threading.Lock so only one thread runs the save-set-read-restore sequence at a time.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

