### PR TITLE
Fix GTK hub spoke grid overflowing at 1024x768 in French with Noto Sans

### DIFF
--- a/pyanaconda/ui/gui/hubs/__init__.py
+++ b/pyanaconda/ui/gui/hubs/__init__.py
@@ -123,8 +123,7 @@ class Hub(GUIObject, common.Hub):
 
         grid = Gtk.Grid(row_spacing=18, column_spacing=18, column_homogeneous=True,
                         margin_bottom=12, margin_left=12, margin_right=12,
-                        halign=Gtk.Align.CENTER, valign=Gtk.Align.CENTER,
-                        row_homogeneous=True)
+                        halign=Gtk.Align.CENTER, valign=Gtk.Align.CENTER)
 
         row_in_column = [-1] * self._gridColumns
 


### PR DESCRIPTION
Remove row_homogeneous from the spoke grid so rows with fewer lines are not forced to the height of the tallest row. This prevents the grid from exceeding the viewport in French at 1024x768

Resolves: INSTALLER-4865
Resolves: rhbz#2511870

Here is the fixed french version at 1024x768: (the bugged one can be found in the bugzilla)
<img width="1941" height="1461" alt="image" src="https://github.com/user-attachments/assets/b9038cae-44d4-4d10-96c4-e3bc461bee8c" />

Here is english at 1920x1080 with this fix: (showcase that it doesn't change UI that much unless there is word wrapping)
<img width="2114" height="1324" alt="image" src="https://github.com/user-attachments/assets/7d09fc7d-d335-483c-ac99-65b4df55b8ab" />

