### PR TITLE
storage: handle race condition when device disappears.

### DIFF
--- a/pyanaconda/modules/storage/devicetree/viewer.py
+++ b/pyanaconda/modules/storage/devicetree/viewer.py
@@ -116,10 +116,18 @@ class DeviceTreeViewer(ABC):
 
         :param device_id: a device ID
         :return: an instance of DeviceData
-        :raise: UnknownDeviceError if the device is not found
         """
         # Find the device.
-        device = self._get_device(device_id)
+        device = self.storage.devicetree.get_device_by_device_id(
+            device_id, hidden=True, incomplete=True
+        )
+
+        # The device may disappear between GetDevices() and GetDeviceData() calls
+        # during active storage configuration (e.g. LVM/LUKS setup). Return empty
+        # data to avoid a dasbus traceback in the logs.
+        if not device:
+            log.debug("Device %s is no longer available.", device_id)
+            return DeviceData()
 
         # Collect the device data.
         data = DeviceData()
@@ -218,7 +226,17 @@ class DeviceTreeViewer(ABC):
         :param device_name: a name of the device
         :return: an instance of DeviceFormatData
         """
-        device = self._get_device(device_id)
+        device = self.storage.devicetree.get_device_by_device_id(
+            device_id, hidden=True, incomplete=True
+        )
+
+        # The device may disappear between GetDevices() and GetFormatData() calls
+        # during active storage configuration (e.g. LVM/LUKS setup). Return empty
+        # data to avoid a dasbus traceback in the logs.
+        if not device:
+            log.debug("Device %s is no longer available.", device_id)
+            return DeviceFormatData()
+
         return self._get_format_data(device.format)
 
     def _get_format_data(self, fmt):


### PR DESCRIPTION
During LVM/LUKS installation, the device tree changes rapidly. The webUI polls GetDevices() and then calls GetDeviceData()/GetFormatData() for each device. If a device disappears between GetDevices() and the subsequent calls (e.g. a transitional LVM VG), the Python backend raises UnknownDeviceError.

Dasbus logs every unhandled exception as a WARNING with a full traceback (exc_info=True), causing kickstart test runners that scan for "Traceback" in anaconda logs to incorrectly report the test as FAILED.

Fix get_device_data() and get_format_data() to check device existence directly instead of relying on _get_device(). When the device is no longer available, return empty default data and log at DEBUG level, preventing the traceback from appearing in the logs.