### PR TITLE
fix: default to grp:alt_shift_toggle when installing multiple layouts

### DIFF
--- a/pyanaconda/keyboard.py
+++ b/pyanaconda/keyboard.py
@@ -36,6 +36,8 @@ LAYOUT_VARIANT_RE = re.compile(r'^\s*([/\w]+)\s*'  # layout plus
                                r'(?:(?:\(\s*([-\w]+)\s*\))'  # variant in parentheses
                                r'|(?:$))\s*')  # or nothing
 
+DEFAULT_LAYOUT_SWITCH_OPTIONS = ["grp:alt_shift_toggle"]
+
 
 class KeyboardConfigError(Exception):
     """Exception class for keyboard configuration related problems"""

--- a/pyanaconda/modules/localization/installation.py
+++ b/pyanaconda/modules/localization/installation.py
@@ -22,6 +22,7 @@ from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.constants import DEFAULT_VC_FONT
 from pyanaconda.core.path import join_paths
 from pyanaconda.core.util import execWithCapture
+from pyanaconda.keyboard import DEFAULT_LAYOUT_SWITCH_OPTIONS
 from pyanaconda.localization import find_best_locale_match, get_locale_console_fonts
 from pyanaconda.modules.common.errors.installation import (
     KeyboardInstallationError,
@@ -150,11 +151,15 @@ class KeyboardInstallationTask(Task):
                 self._vc_keymap
             )
 
+        switch_options = self._switch_options
+        if len(x_layouts) >= 2 and not switch_options:
+            switch_options = DEFAULT_LAYOUT_SWITCH_OPTIONS
+
         if x_layouts:
             write_x_configuration(
                 self._localed_wrapper,
                 x_layouts,
-                self._switch_options,
+                switch_options,
                 X_CONF_DIR,
                 self._sysroot
             )

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -24,7 +24,11 @@ from pyanaconda.core.configuration.anaconda import conf
 from pyanaconda.core.constants import DEFAULT_KEYBOARD
 from pyanaconda.core.dbus import DBus
 from pyanaconda.core.signal import Signal
-from pyanaconda.keyboard import can_configure_keyboard, normalize_layout_variant
+from pyanaconda.keyboard import (
+    DEFAULT_LAYOUT_SWITCH_OPTIONS,
+    can_configure_keyboard,
+    normalize_layout_variant,
+)
 from pyanaconda.localization import (
     _build_layout_infos,
     _get_layout_variant_description,
@@ -468,11 +472,10 @@ class LocalizationService(KickstartService):
             self.set_compositor_layouts(new_layouts, self.switch_options or [])
 
         if len(new_layouts) >= 2 and not self.switch_options:
-            # initialize layout switching if needed
-            self.set_switch_options(["grp:alt_shift_toggle"])
+            self.set_switch_options(DEFAULT_LAYOUT_SWITCH_OPTIONS)
 
             if can_configure_keyboard():
-                self.set_compositor_layouts(new_layouts, ["grp:alt_shift_toggle"])
+                self.set_compositor_layouts(new_layouts, DEFAULT_LAYOUT_SWITCH_OPTIONS)
                 # activate the language-default layout instead of the additional
                 # one
                 self.set_compositor_selected_layout(new_layouts[0])

--- a/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization_tasks.py
+++ b/tests/unit_tests/pyanaconda_tests/modules/localization/test_module_localization_tasks.py
@@ -25,6 +25,7 @@ from unittest.mock import Mock, call, create_autospec, patch
 import pytest
 
 from pyanaconda.core.constants import DEFAULT_KEYBOARD, DEFAULT_VC_FONT
+from pyanaconda.keyboard import DEFAULT_LAYOUT_SWITCH_OPTIONS
 from pyanaconda.modules.common.errors.configuration import KeyboardConfigurationError
 from pyanaconda.modules.common.errors.installation import KeyboardInstallationError
 from pyanaconda.modules.localization.installation import (
@@ -692,5 +693,33 @@ class LocalizationTasksTestCase(unittest.TestCase):
         )
         write_vc_mock.assert_called_once_with(
             vc_keymap_default,
+            sysroot
+        )
+
+    @patch("pyanaconda.modules.localization.installation.get_missing_keyboard_configuration")
+    @patch("pyanaconda.modules.localization.installation.write_x_configuration")
+    @patch("pyanaconda.modules.localization.installation.write_vc_configuration")
+    def test_keyboard_installation_task_default_switch_options(
+        self, write_vc_mock, write_x_mock, get_missing_mock
+    ):
+        """Multiple layouts with no switch options should default to alt_shift_toggle."""
+        localed = Mock()
+        sysroot = "/mnt/sysimage"
+        x_layouts = ["us", "cz (qwerty)"]
+        vc_keymap = "us"
+
+        task = KeyboardInstallationTask(
+            localed_wrapper=localed,
+            sysroot=sysroot,
+            x_layouts=x_layouts,
+            switch_options=[],
+            vc_keymap=vc_keymap
+        )
+        task.run()
+        write_x_mock.assert_called_once_with(
+            localed,
+            x_layouts,
+            DEFAULT_LAYOUT_SWITCH_OPTIONS,
+            X_CONF_DIR,
             sysroot
         )


### PR DESCRIPTION
On GNOME Workstation live, anaconda WebUI delegates keyboard configuration to GNOME Settings. GNOME handles layout switching through its own keybinding system and never sets an XKB grp: option, so anaconda's switch_options stays empty even with multiple layouts configured.

At install time, 00-keyboard.conf is written via systemd-localed without XkbOptions. This means VT consoles and GDM on the installed system have no way to switch between layouts.

Fix this by defaulting to grp:alt_shift_toggle in
KeyboardInstallationTask when installing 2+ layouts with no switch options configured.

Resolves: rhbz#2508253

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

