### PR TITLE
localization: suppress compositor signals during GetMissingKeyboardConfiguration hack

### DIFF
--- a/pyanaconda/modules/localization/localed.py
+++ b/pyanaconda/modules/localization/localed.py
@@ -16,6 +16,7 @@
 # Red Hat, Inc.
 #
 from abc import ABC
+from contextlib import contextmanager
 
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.configuration.anaconda import conf
@@ -262,6 +263,7 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
 
         self._user_layouts_variants = []
         self._last_layouts_variants = []
+        self._suppress_signals = False
 
         self.compositor_layouts_changed = Signal()
         self.compositor_selected_layout_changed = Signal()
@@ -269,8 +271,27 @@ class CompositorLocaledWrapper(LocaledWrapperBase):
         # to reflect updates from the compositor
         self._localed_proxy.PropertiesChanged.connect(self._on_properties_changed)
 
+    @contextmanager
+    def suppress_signals(self):
+        """Suppress compositor signals during temporary localed modifications.
+
+        Use this when LocaledWrapper.convert_layouts() or similar conversion
+        methods temporarily modify localed state. Without suppression, the
+        PropertiesChanged signals from these temporary modifications can
+        create a feedback loop with the compositor and WebUI.
+        """
+        self._suppress_signals = True
+        try:
+            yield
+        finally:
+            self._suppress_signals = False
+
     def _on_properties_changed(self, interface, changed_props, invalid_props):  # noqa: F841
         if "X11Layout" in changed_props or "X11Variant" in changed_props:
+            if self._suppress_signals:
+                log.debug("Suppressing localed PropertiesChanged during conversion")
+                return
+
             layouts_variants = self._from_localed_format(changed_props["X11Layout"].get_string(),
                                                          changed_props["X11Variant"].get_string())
             # This part is a bit tricky. The signal processing here means that compositor has

--- a/pyanaconda/modules/localization/localization.py
+++ b/pyanaconda/modules/localization/localization.py
@@ -354,6 +354,7 @@ class LocalizationService(KickstartService):
             localed_wrapper=self.localed_wrapper,
             x_layouts=self.x_layouts,
             vc_keymap=self.vc_keymap,
+            compositor_wrapper=self._localed_compositor_wrapper,
         )
         task.succeeded_signal.connect(lambda: self._update_settings_from_task(task.get_result()))
         return task
@@ -376,6 +377,7 @@ class LocalizationService(KickstartService):
             localed_wrapper=self.localed_wrapper,
             x_layouts=self.x_layouts,
             vc_keymap=self.vc_keymap,
+            compositor_wrapper=self._localed_compositor_wrapper,
         )
         return task
 

--- a/pyanaconda/modules/localization/runtime.py
+++ b/pyanaconda/modules/localization/runtime.py
@@ -69,7 +69,7 @@ class AssignGenericKeyboardSettingTask(Task):
 class GetMissingKeyboardConfigurationTask(Task):
     """Task for getting missing keyboard settings by conversion and default values."""
 
-    def __init__(self, localed_wrapper, x_layouts, vc_keymap):
+    def __init__(self, localed_wrapper, x_layouts, vc_keymap, compositor_wrapper=None):
         """Create a new task.
 
         :param localed_wrapper: instance of systemd-localed service wrapper
@@ -78,11 +78,15 @@ class GetMissingKeyboardConfigurationTask(Task):
         :type x_layouts: list(str)
         :param vc_keymap: virtual console keyboard mapping name
         :type vc_keymap: str
+        :param compositor_wrapper: instance of compositor localed wrapper to suppress
+                                   signals during conversion
+        :type compositor_wrapper: CompositorLocaledWrapper or None
         """
         super().__init__()
         self._localed_wrapper = localed_wrapper
         self._x_layouts = x_layouts
         self._vc_keymap = vc_keymap
+        self._compositor_wrapper = compositor_wrapper
 
     def for_publication(self):
         return KeyboardConfigurationTaskInterface(self)
@@ -99,6 +103,11 @@ class GetMissingKeyboardConfigurationTask(Task):
         :raises: KeyboardConfigurationError exception when we should use unsupported layouts
                  from Live
         """
+        if self._compositor_wrapper:
+            with self._compositor_wrapper.suppress_signals():
+                return get_missing_keyboard_configuration(self._localed_wrapper,
+                                                          self._x_layouts,
+                                                          self._vc_keymap)
         return get_missing_keyboard_configuration(self._localed_wrapper,
                                                   self._x_layouts,
                                                   self._vc_keymap)


### PR DESCRIPTION
When a second keyboard layout is added via the WebUI on KDE, the
convert_layouts() hack in GetMissingKeyboardConfigurationTask temporarily
modifies systemd-localed to convert between X layouts and VConsole
keymaps. These temporary SetX11Keyboard calls generate PropertiesChanged
signals that CompositorLocaledWrapper picks up and propagates as
CompositorLayoutsChanged to the WebUI, which in turn creates another
GetMissingKeyboardConfigurationTask — producing a feedback loop of 160+
SetX11Keyboard calls in 32 seconds. The continuous xkb keymap
recompilation in KWin breaks modifier key state (Shift, CapsLock).

Add a suppress_signals() context manager to CompositorLocaledWrapper
that prevents _on_properties_changed from emitting signals while
conversion operations are in progress. Use it in
GetMissingKeyboardConfigurationTask which is the task triggered by the
WebUI's CompositorLayoutsChanged handler and the source of the loop.

Resolves: INSTALLER-4866
https://bugzilla.redhat.com/show_bug.cgi?id=2510055

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

NOTE: https://github.com/rhinstaller/anaconda/blob/fa97e954439913557147778d4ca1b63a16551782/pyanaconda/modules/localization/localed.py#L292 should mitigate similar flood of signals (checking if the value has really changed) but it is hitting a race condition as can be seen in the log messages, more details in https://bugzilla.redhat.com/show_bug.cgi?id=2510055#c5
 
TODO:
- [ ] update the unit tests

Question: Can we lose some important signal with the fix?

Answer (by Claude, valid IMO):

`convert_layouts()` is a pure conversion hack: it temporarily sets localed to a different state, reads back the converted value, then restores the original state. By the time `suppress_signals()` releases, localed is back exactly
  where it started. Any `PropertiesChanged` signals emitted during that window are artifacts of the temporary state — they don't represent real keyboard changes.

  If a real external change happened to arrive during those few hundred milliseconds (e.g., user changing layout in KDE Settings while the task runs), it would be suppressed. But that signal would have been about the temporary
  conversion state anyway, not the external change — localed only emits `PropertiesChanged` for the SetX11Keyboard calls it processes, and the task's restore call would overwrite whatever the external change was. So even without
  suppression, the external change would be lost.

