### PR TITLE
Improve Wayland compositor startup failure reporting

### DIFF
--- a/pyanaconda/display.py
+++ b/pyanaconda/display.py
@@ -183,6 +183,29 @@ def check_rd_can_be_started(anaconda):
     return rd_startup_possible, error_messages
 
 
+def _print_compositor_journal_excerpt(lines=15):
+    """Print the last journal messages of the compositor.
+
+    The compositor's stdout and stderr go only to the journal, so when
+    its startup fails the console shows nothing actionable.  Print a
+    short excerpt so the failure can be reported without shell access.
+
+    :param int lines: maximum number of journal lines to print
+    """
+    try:
+        excerpt = util.execWithCapture(
+            "journalctl", ["-q", "-t", "gnome-kiosk", "-n", str(lines), "--no-pager"]
+        )
+    except (OSError, RuntimeError) as e:
+        log.warning("Could not read the compositor journal: %s", e)
+        excerpt = ""
+
+    if excerpt.strip():
+        print("\nLast messages from the compositor (gnome-kiosk):")
+        print(excerpt)
+    print("Full compositor logs: journalctl -t gnome-kiosk")
+
+
 def do_startup_wl_actions(timeout, headless=False):
     """Start the Wayland compositor.
 
@@ -255,9 +278,17 @@ def do_startup_wl_actions(timeout, headless=False):
 
         time.sleep(0.1)
 
+    still_running = False
     WatchProcesses.unwatch_process(childproc)
-    childproc.terminate()
-    raise TimeoutError("Timeout trying to start gnome-kiosk")
+    if childproc.poll() is None:
+        still_running = True
+        childproc.terminate()
+    raise TimeoutError(
+        "gnome-kiosk did not create the Wayland socket '{}' within {} seconds "
+        "(the compositor process {})".format(
+            constants.WAYLAND_SOCKET_NAME, timeout,
+            "was still running" if still_running else "had already exited")
+    )
 
 
 def set_resolution(runres):
@@ -377,20 +408,27 @@ def setup_display(anaconda, options):
             do_startup_wl_actions(wayland_timeout)
         except TimeoutError as e:
             log.warning("Wayland startup failed: %s", e)
-            print("\nWayland did not start in the expected time, falling back to text mode. "
-                  "There are multiple ways to avoid this issue:")
+            print("\nWayland startup failed: {}".format(e))
+            print("Falling back to text mode. There are multiple ways to avoid this issue:")
             wrapper = textwrap.TextWrapper(initial_indent=" * ", subsequent_indent="   ",
                                            width=os.get_terminal_size().columns - 3)
             for line in WAYLAND_TIMEOUT_ADVICE.split("\n"):
                 print(wrapper.fill(line))
+            _print_compositor_journal_excerpt()
             util.vtActivate(1)
             anaconda.display_mode = constants.DisplayModes.TUI
             anaconda.gui_startup_failed = True
             time.sleep(2)
 
         except (OSError, RuntimeError) as e:
+            # This includes ExitError from the process watcher.  The launch
+            # wrapper (run-in-new-session) propagates the compositor's exit
+            # status and re-raises its fatal signals, so the reported status
+            # is the compositor's.
             log.warning("Wayland startup failed: %s", e)
-            print("\nWayland startup failed, falling back to text mode.")
+            print("\nWayland startup failed: {}".format(e))
+            print("Falling back to text mode.")
+            _print_compositor_journal_excerpt()
             util.vtActivate(1)
             anaconda.display_mode = constants.DisplayModes.TUI
             anaconda.gui_startup_failed = True

--- a/tests/unit_tests/pyanaconda_tests/test_display.py
+++ b/tests/unit_tests/pyanaconda_tests/test_display.py
@@ -1,0 +1,125 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 31 Milk Street #960789 Boston, MA
+# 02196 USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pyanaconda import display
+
+
+class StartupWLActionsTests(unittest.TestCase):
+    """Test the compositor startup failure reporting."""
+
+    def _run_startup(self, socket_exists, proc_running):
+        """Run do_startup_wl_actions with a mocked environment."""
+        childproc = Mock()
+        childproc.poll.return_value = None if proc_running else 1
+
+        with patch("pyanaconda.display.util.startProgram", return_value=childproc), \
+             patch("pyanaconda.display.WatchProcesses") as watch, \
+             patch("pyanaconda.display.journal.stream", return_value=None), \
+             patch("pyanaconda.display._gnome_kiosk_supports_vt_switch",
+                   return_value=False), \
+             patch("pyanaconda.display.os.path.exists", return_value=socket_exists), \
+             patch("pyanaconda.display.time.sleep"), \
+             patch.dict(display.os.environ, {"XDG_RUNTIME_DIR": "/run/user/0"}):
+            display.do_startup_wl_actions(1)
+            return childproc, watch
+
+    def test_socket_ready(self):
+        """Return quietly when the compositor socket appears."""
+        childproc, watch = self._run_startup(socket_exists=True, proc_running=True)
+        watch.watch_process.assert_called_once()
+        childproc.terminate.assert_not_called()
+
+    def test_timeout_process_still_running(self):
+        """A live compositor without a socket raises a timeout naming the state."""
+        with pytest.raises(TimeoutError) as excinfo:
+            self._run_startup(socket_exists=False, proc_running=True)
+
+        assert "was still running" in str(excinfo.value)
+        assert display.constants.WAYLAND_SOCKET_NAME in str(excinfo.value)
+
+    def test_timeout_process_exited(self):
+        """A dead compositor without a socket raises a timeout naming the exit."""
+        with pytest.raises(TimeoutError) as excinfo:
+            self._run_startup(socket_exists=False, proc_running=False)
+
+        assert "had already exited" in str(excinfo.value)
+
+    def test_timeout_terminates_and_unwatches(self):
+        """The timed-out compositor is unwatched and terminated."""
+        childproc = Mock()
+        childproc.poll.return_value = None
+
+        with patch("pyanaconda.display.util.startProgram", return_value=childproc), \
+             patch("pyanaconda.display.WatchProcesses") as watch, \
+             patch("pyanaconda.display.journal.stream", return_value=None), \
+             patch("pyanaconda.display._gnome_kiosk_supports_vt_switch",
+                   return_value=False), \
+             patch("pyanaconda.display.os.path.exists", return_value=False), \
+             patch("pyanaconda.display.time.sleep"), \
+             patch.dict(display.os.environ, {"XDG_RUNTIME_DIR": "/run/user/0"}):
+            with pytest.raises(TimeoutError):
+                display.do_startup_wl_actions(1)
+
+        watch.unwatch_process.assert_called_once_with(childproc)
+        childproc.terminate.assert_called_once()
+
+
+class CompositorJournalExcerptTests(unittest.TestCase):
+    """Test the compositor journal excerpt helper."""
+
+    @patch("pyanaconda.display.util.execWithCapture")
+    def test_excerpt_printed(self, exec_mock):
+        """A non-empty journal excerpt is printed with a pointer to the journal."""
+        exec_mock.return_value = "kiosk: something broke"
+
+        with patch("builtins.print") as print_mock:
+            display._print_compositor_journal_excerpt()
+
+        exec_mock.assert_called_once_with(
+            "journalctl", ["-q", "-t", "gnome-kiosk", "-n", "15", "--no-pager"]
+        )
+        printed = "\n".join(str(c.args[0]) for c in print_mock.call_args_list if c.args)
+        assert "kiosk: something broke" in printed
+        assert "journalctl -t gnome-kiosk" in printed
+
+    @patch("pyanaconda.display.util.execWithCapture")
+    def test_journalctl_failure_is_not_fatal(self, exec_mock):
+        """A failing journalctl must not raise; the pointer is still printed."""
+        exec_mock.side_effect = OSError("no journalctl")
+
+        with patch("builtins.print") as print_mock:
+            display._print_compositor_journal_excerpt()
+
+        printed = "\n".join(str(c.args[0]) for c in print_mock.call_args_list if c.args)
+        assert "journalctl -t gnome-kiosk" in printed
+
+    @patch("pyanaconda.display.util.execWithCapture")
+    def test_empty_journal(self, exec_mock):
+        """An empty journal prints only the pointer, not an empty excerpt block."""
+        exec_mock.return_value = "\n"
+
+        with patch("builtins.print") as print_mock:
+            display._print_compositor_journal_excerpt()
+
+        printed = [str(c.args[0]) for c in print_mock.call_args_list if c.args]
+        assert not any("Last messages" in line for line in printed)
+        assert any("journalctl -t gnome-kiosk" in line for line in printed)


### PR DESCRIPTION
On current main, a local GUI startup failure funnels three distinct
situations into nearly indistinguishable console output:

1. compositor exited/crashed → `ExitError` (RuntimeError subclass) raised by
   `WatchProcesses` with exit status/signal — but the console prints only the
   generic "startup failed" text; the status is visible in logs only
   (pyanaconda/display.py:391-397, core/process_watchers.py:66-81). (The
   status names the launch wrapper, run-in-new-session, which propagates the
   compositor's exit status and re-raises its fatal signals.)
2. compositor alive but never ready (readiness = polling for the existence
   of $XDG_RUNTIME_DIR/wl-sysinstall-0, display.py:251-256) → timeout after
   WAYLAND_TIMEOUT with generic advice.
3. transient early wedge that a fresh attempt would survive → same as 2.

Field case motivating this (Qubes R4.3, same X11-era logic): Raptor Lake
iGPU machine where the display server nondeterministically either became
ready in 2.1 s or hung forever — with `inst.xtimeout=300` the user burned
two weekends because the console output never distinguished hang from crash,
never surfaced the server log (tmpfs, destroyed on reboot), and the failure
path left the VT unusable. Full data: QubesOS/qubes-issues#11092.

Proposal (PR to follow):
a. On failure, print which case occurred: the wrapper/compositor exit
   status or fatal signal, vs "the compositor is still running but its
   Wayland socket did not appear within N seconds".
b. Print a bounded excerpt (last ~15 lines) of the compositor's journal
   output (it already goes to journald with a known identifier), or the
   exact journalctl command to view it.
c. (Discussion) one automatic retry of the compositor launch before
   declaring failure, given observed bimodal behavior. Separable from a/b.

This PR implements (a) and (b): the failure branches now print the exception message (the ExitError carries the wrapper-propagated compositor exit status/signal; the TimeoutError now states whether the compositor was still running when the socket never appeared) plus a bounded `journalctl -q -t gnome-kiosk -n 15` excerpt. Unit tests included (`tests/unit_tests/pyanaconda_tests/test_display.py`).

Item (c) (automatic retry) and a stronger readiness contract are deliberately out of scope; on readiness, note that gnome-kiosk already emits `sd_notify(READY=1)` after real startup completion (present since 47.0), so a follow-up could pass a private `$NOTIFY_SOCKET` and wait for `READY=1` instead of polling for the socket file mutter binds early in `meta_context_start()`. Happy to do that follow-up if there's interest.
