### PR TITLE
Support LUKS encryption in interactive text mode automatic partitioning

### DIFF
--- a/pyanaconda/ui/tui/spokes/storage.py
+++ b/pyanaconda/ui/tui/spokes/storage.py
@@ -334,6 +334,9 @@ class StorageSpoke(NormalTUISpoke):
                     ScreenHandler.push_screen_modal(new_spoke)
                     self._partitioning = new_spoke.partitioning
                     self.apply()
+                    # Ask for a passphrase if the partitioning requests
+                    # encryption without one (a no-op otherwise).
+                    self.run_passphrase_dialog()
                     self.execute()
 
                 return InputState.PROCESSED_AND_CLOSE
@@ -627,6 +630,9 @@ class PartitionSchemeSpoke(NormalTUISpoke):
             box = CheckboxWidget(title=_(scheme), completed=(value == self._selected_scheme_value))
             self._container.add(box, self._set_part_scheme_callback, value)
 
+        box = CheckboxWidget(title=_("Encrypt my data"), completed=self._request.encrypted)
+        self._container.add(box, self._set_encryption_callback, None)
+
         self.window.add_with_separator(self._container)
 
         message = _("Select a partition scheme configuration.")
@@ -635,6 +641,9 @@ class PartitionSchemeSpoke(NormalTUISpoke):
     def _set_part_scheme_callback(self, data):
         self._selected_scheme_value = data
         self._request.partitioning_scheme = data
+
+    def _set_encryption_callback(self, data):
+        self._request.encrypted = not self._request.encrypted
 
     def input(self, args, key):
         """ Grab the choice and update things. """

--- a/tests/unit_tests/pyanaconda_tests/test_tui_storage.py
+++ b/tests/unit_tests/pyanaconda_tests/test_tui_storage.py
@@ -1,0 +1,84 @@
+#
+# Copyright (C) 2026  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 31 Milk Street #960789 Boston, MA
+# 02196 USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+import unittest
+from unittest.mock import Mock, patch
+
+from pyanaconda.modules.common.structures.partitioning import PartitioningRequest
+from pyanaconda.ui.tui.spokes import storage as tui_storage
+
+
+class PartitionSchemeSpokeTests(unittest.TestCase):
+    """Test the encryption selection in the partition scheme spoke."""
+
+    def _make_spoke(self, encrypted=False):
+        request = PartitioningRequest()
+        request.encrypted = encrypted
+
+        partitioning = Mock()
+        partitioning.Request = PartitioningRequest.to_structure(request)
+
+        with patch.object(tui_storage, "get_supported_autopart_choices",
+                          return_value=[("LVM", 1)]):
+            spoke = tui_storage.PartitionSchemeSpoke(
+                data=Mock(), storage=Mock(), payload=Mock(),
+                partitioning=partitioning,
+            )
+
+        return spoke, partitioning
+
+    def test_encryption_toggle(self):
+        """The encryption callback toggles the request's encrypted flag."""
+        spoke, _partitioning = self._make_spoke(encrypted=False)
+
+        spoke._set_encryption_callback(None)
+        assert spoke._request.encrypted is True
+
+        spoke._set_encryption_callback(None)
+        assert spoke._request.encrypted is False
+
+    def test_encryption_preserved_from_request(self):
+        """A pre-set encrypted flag (kickstart or configuration default)
+        is reflected without toggling."""
+        spoke, _partitioning = self._make_spoke(encrypted=True)
+        assert spoke._request.encrypted is True
+
+    def test_apply_publishes_encryption(self):
+        """apply() writes the toggled encryption back to the module."""
+        spoke, partitioning = self._make_spoke(encrypted=False)
+
+        spoke._set_encryption_callback(None)
+        spoke.apply()
+
+        request = PartitioningRequest.from_structure(partitioning.Request)
+        assert request.encrypted is True
+
+    def test_refresh_shows_encryption_checkbox(self):
+        """refresh() offers the encryption choice in the option list."""
+        spoke, _partitioning = self._make_spoke(encrypted=False)
+        spoke.window = Mock()
+
+        with patch.object(tui_storage.NormalTUISpoke, "refresh"), \
+             patch.object(tui_storage, "ListColumnContainer") as container_cls, \
+             patch.object(tui_storage, "CheckboxWidget") as checkbox_cls:
+            spoke.refresh()
+
+        titles = [call.kwargs.get("title") for call in checkbox_cls.call_args_list]
+        assert "Encrypt my data" in titles
+
+        # one entry per partition scheme plus the encryption checkbox
+        assert container_cls.return_value.add.call_count == 2


### PR DESCRIPTION
**Opening as a draft to double as the proposal (issues are disabled on this repo) — please treat the first section as the RFC.**


Text mode has never offered disk encryption for interactive installs —
the TODO ("Add encryption option to text mode partitioning") is old
enough to live in pyanaconda/ui/gui/TODO. The pieces all exist: the
backend PartitioningRequest models `encrypted` + passphrase, and the TUI
ships a LUKS-policy PasswordDialog (`run_passphrase_dialog()` in the
storage spoke) — it is just gated to kickstart flows
(`flags.automatedInstall and flags.ksprompt`).

Real-world cost of the gap: when graphical startup fails on some
hardware, text mode is the fallback — and it cannot produce an encrypted
system. Qubes OS considered this bad enough that they patched the
GUI-failure fallback into a hard installation abort rather than let
users end up unencrypted (their patch queue, 0011-Abort-installation-
on-X-startup-fail). With this ~30-line change they could drop that
downstream divergence and restore your stock fallback behavior.

Scope (deliberately minimal): an "Encrypt my data" checkbox on the
automatic partitioning scheme screen writing `PartitioningRequest.
encrypted`, and a `run_passphrase_dialog()` call in the interactive
flow before the partitioning executes (no-op unless a passphrase is
required). No new dialogs, no backend changes, no manual-partitioning
encryption (that is a much larger project and not needed here). Unit
tests included. Is TUI still an accepted surface for this through the
WebUI transition? If yes, PR follows.


---


See the commit message in the patch — it is self-contained. Additional
notes for review:

- The checkbox also *surfaces* a configuration-default encryption
  (profiles with `encrypted = True`): today such a profile in
  interactive TUI fails at commit time with "encryption requested …
  but no encryption key specified" because nothing ever asks.
- Empty-passphrase semantics are identical to the existing kickstart
  path (PasswordDialog policy handling); no new policy code.
- Tests: toggle behavior, request round-trip, screen rendering.
  tests/unit_tests/pyanaconda_tests/test_tui_storage.py is new (no
  prior TUI-storage unit tests existed).

