### PR TITLE
subscription: wait for connectivity when fetching Satellite script

### DIFF
--- a/pyanaconda/modules/subscription/satellite.py
+++ b/pyanaconda/modules/subscription/satellite.py
@@ -20,6 +20,7 @@
 
 import os
 import tempfile
+import time
 
 from requests import RequestException
 
@@ -85,30 +86,35 @@ def download_satellite_provisioning_script(satellite_url, proxy_url=None):
                      " provisioning script %s: %s",
                      proxy_url, e)
 
+    deadline = time.monotonic() + 90
     with util.requests_session() as session:
-        try:
-            # NOTE: we explicitly don't verify SSL certificates while
-            #       downloading the provisioning script as the Satellite
-            #       instance will most likely have it's own self signed certs that
-            #       will only be trusted once the provisioning script runs
-            result = session.get(script_url, headers=headers,
-                                 proxies=proxies, verify=False,
-                                 timeout=constants.NETWORK_CONNECTION_TIMEOUT)
-            if result.ok:
-                provisioning_script = result.text
-                result.close()
-                log.debug("subscription: Satellite provisioning script downloaded (%d characters)",
-                          len(provisioning_script))
-                return provisioning_script
-            else:
+        while True:
+            try:
+                # NOTE: we explicitly don't verify SSL certificates while
+                #       downloading the provisioning script as the Satellite
+                #       instance will most likely have it's own self signed certs that
+                #       will only be trusted once the provisioning script runs
+                result = session.get(script_url, headers=headers,
+                                     proxies=proxies, verify=False,
+                                     timeout=constants.NETWORK_CONNECTION_TIMEOUT)
+                if result.ok:
+                    provisioning_script = result.text
+                    result.close()
+                    log.debug("subscription: Satellite provisioning script downloaded (%d characters)",
+                              len(provisioning_script))
+                    return provisioning_script
+
                 log.debug("subscription: server returned %i code when downloading"
                           " Satellite provisioning script", result.status_code)
                 result.close()
                 return None
-        except RequestException as e:
-            log.debug("subscription: can't download Satellite provisioning script"
-                      " from %s with proxy: %s. Error: %s", script_url, proxies, e)
-            return None
+            except RequestException as e:
+                if time.monotonic() >= deadline:
+                    log.debug("subscription: can't download Satellite provisioning script"
+                              " from %s with proxy: %s. Error: %s", script_url, proxies, e)
+                    return None
+                log.debug("subscription: retrying Satellite provisioning script download: %s", e)
+                time.sleep(2)
 
 
 def run_satellite_provisioning_script(provisioning_script=None, run_on_target_system=False):

--- a/pyanaconda/modules/subscription/satellite.py
+++ b/pyanaconda/modules/subscription/satellite.py
@@ -86,9 +86,19 @@ def download_satellite_provisioning_script(satellite_url, proxy_url=None):
                      " provisioning script %s: %s",
                      proxy_url, e)
 
-    deadline = time.monotonic() + 90
+    # Retry with a progressively longer pause so NetworkManager has a chance
+    # to restore connectivity (for example after LACP renegotiation).
+    xdelay = util.xprogressive_delay()
+    start_time = time.monotonic()
+    retry_count = 0
+
     with util.requests_session() as session:
         while True:
+            if retry_count > 0:
+                log.debug("subscription: retrying Satellite provisioning script download (%d)",
+                          retry_count)
+                time.sleep(next(xdelay))
+
             try:
                 # NOTE: we explicitly don't verify SSL certificates while
                 #       downloading the provisioning script as the Satellite
@@ -103,18 +113,17 @@ def download_satellite_provisioning_script(satellite_url, proxy_url=None):
                     log.debug("subscription: Satellite provisioning script downloaded (%d characters)",
                               len(provisioning_script))
                     return provisioning_script
-
-                log.debug("subscription: server returned %i code when downloading"
-                          " Satellite provisioning script", result.status_code)
-                result.close()
-                return None
-            except RequestException as e:
-                if time.monotonic() >= deadline:
-                    log.debug("subscription: can't download Satellite provisioning script"
-                              " from %s with proxy: %s. Error: %s", script_url, proxies, e)
+                else:
+                    log.debug("subscription: server returned %i code when downloading"
+                              " Satellite provisioning script", result.status_code)
+                    result.close()
                     return None
-                log.debug("subscription: retrying Satellite provisioning script download: %s", e)
-                time.sleep(2)
+            except RequestException as e:
+                log.debug("subscription: can't download Satellite provisioning script"
+                          " from %s with proxy: %s. Error: %s", script_url, proxies, e)
+                if time.monotonic() - start_time >= constants.RHSM_SERVICE_TIMEOUT:
+                    return None
+                retry_count += 1
 
 
 def run_satellite_provisioning_script(provisioning_script=None, run_on_target_system=False):


### PR DESCRIPTION
## Summary
- Retry Satellite provisioning script download on transient DNS/connection errors (e.g. Name or service not known) so Kickstart rhsm can wait out LACP bond renegotiation.
- Does not change default Kickstart network activation (not equivalent to --no-activate).
- Does not revive inst.waitfornet.global (PR #5507).
## Related
- https://issues.redhat.com/browse/RHEL-4750
- https://redhat.atlassian.net/browse/RHELPLAN-140012
## Test plan
- [ ] Kickstart rhsm + Satellite hostname: download succeeds if DNS fails for a few seconds then works
- [ ] HTTP error from Satellite is not retried in a loop
- [ ] Normal registration still works