### PR TITLE
infra: Pull pre-built iso-creator container instead of rebuilding it for kickstart-tests 

### DIFF
--- a/.github/workflows/kickstart-tests.yml
+++ b/.github/workflows/kickstart-tests.yml
@@ -309,10 +309,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build anaconda-iso-creator container image
-        working-directory: ./anaconda
+      - name: Pull anaconda-iso-creator container image
         run: |
-          sudo -E make -f ./Makefile.am anaconda-iso-creator-build
+          sudo podman pull $ISO_BUILD_CONTAINER_NAME:$CI_TAG
 
       - name: Build anaconda-rpm container (for RPM build)
         working-directory: ./anaconda

--- a/.github/workflows/kickstart-tests.yml.j2
+++ b/.github/workflows/kickstart-tests.yml.j2
@@ -303,10 +303,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build anaconda-iso-creator container image
-        working-directory: ./anaconda
+      - name: Pull anaconda-iso-creator container image
         run: |
-          sudo -E make -f ./Makefile.am anaconda-iso-creator-build
+          sudo podman pull $ISO_BUILD_CONTAINER_NAME:$CI_TAG
 
       - name: Build anaconda-rpm container (for RPM build)
         working-directory: ./anaconda


### PR DESCRIPTION
The kickstart tests workflow was rebuilding the iso-creator container from scratch on each run, which is unnecessary since the daily container-autoupdate workflow already builds and pushes it to quay.io. Rebuilding also makes the workflow vulnerable to transient rawhide repo issues like GPG signature verification failures. Pull the pre-built image instead, matching what the kickstart-tests repository already does.

Tradeoff: if a PR modifies the iso-creator Dockerfile or lorax-build scripts, those changes won't be picked up by the kickstart tests until the next daily container rebuild.

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>
