### PR TITLE
Show an error when unsupported password hash is used

### DIFF
--- a/pyanaconda/core/users.py
+++ b/pyanaconda/core/users.py
@@ -35,6 +35,7 @@ from pyanaconda.core.regexes import (
     PORTABLE_FS_CHARS,
 )
 from pyanaconda.core.string import strip_accents
+from pyanaconda.modules.common.errors.configuration import UnsupportedHashFunctionError
 
 try:
     # Use the standalone (not deprecated) package when available
@@ -523,7 +524,16 @@ def set_user_password(username, password, is_crypted, lock, root="/"):
         proc = util.startProgram(["chpasswd", "-e"] + rootargs, stdin=subprocess.PIPE)
         proc.communicate(("%s:%s\n" % (username, password)).encode("utf-8"))
         if proc.returncode != 0:
-            raise OSError("Unable to set password for new user: status=%s" % proc.returncode)
+            # Lets check if the password hash is using MD5
+            # - in version 4.2.0 of shadow utils all remaining support for MD5 password hashes
+            #   was removed
+            # - so if MD5 password hash is used, chpasswd will fail with return code 1
+            # - so check password hash type (based on the "$1$" prefix and raise a proper
+            #   error for the user to see & fix their password hash
+            if password.startswith("$1$"):
+                raise UnsupportedHashFunctionError()
+            else:
+                raise OSError("Unable to set password for new user: status=%s" % proc.returncode)
 
     # Reset sp_lstchg to an empty string. On systems with no rtc, this
     # field can be set to 0, which has a special meaning that the password

--- a/pyanaconda/errors.py
+++ b/pyanaconda/errors.py
@@ -18,6 +18,7 @@
 from pyanaconda.anaconda_loggers import get_module_logger
 from pyanaconda.core.i18n import C_, _
 from pyanaconda.flags import flags
+from pyanaconda.modules.common.errors.configuration import UnsupportedHashFunctionError
 from pyanaconda.modules.common.errors.installation import (
     BootloaderInstallationError,
     InsightsClientMissingError,
@@ -124,6 +125,7 @@ class ErrorHandler:
 
             # General installation errors.
             NonCriticalInstallationError.__name__: self._non_critical_error_handler,
+            UnsupportedHashFunctionError.__name__: self._unsupported_hash_function_error_handler,
         }
 
     def _storage_install_handler(self, exn):
@@ -227,6 +229,14 @@ class ErrorHandler:
             return ERROR_CONTINUE
         else:
             return ERROR_RAISE
+
+    def _unsupported_hash_function_error_handler(self, exn):
+        message = _("The password for %s is using the MD5 hash function, "
+                    "which is no longer supported. Please use a different "
+                    "hash function, such as SHA512.")
+
+        self.ui.showError(message)
+        return ERROR_RAISE
 
     def _subscriptionTokenTransferErrorHandler(self, exn):
         message = _("Failed to enable Red Hat subscription on the "

--- a/pyanaconda/modules/common/errors/configuration.py
+++ b/pyanaconda/modules/common/errors/configuration.py
@@ -49,3 +49,8 @@ class BootloaderConfigurationError(ConfigurationError):
 class KeyboardConfigurationError(ConfigurationError):
     """Exception for keyboard configuration errors."""
     pass
+
+@dbus_error("UnsupportedHashFunctionError", namespace=ANACONDA_NAMESPACE)
+class UnsupportedHashFunctionError(ConfigurationError):
+    """Exception for the case of unsupported hash function being used."""
+    pass


### PR DESCRIPTION
Instead of generic crash error & traceback, check if the password hash is using MD5 & report a specific error message. The error message tells the user what is wrong (MD5 password hash) and how to fix it (use SHA512 or other modern password hash).

I made made the naming a bit generic in case we need to add more deprecated hashes in the future.